### PR TITLE
Implement Prometheus metrics

### DIFF
--- a/octavia_f5/common/config.py
+++ b/octavia_f5/common/config.py
@@ -71,6 +71,8 @@ f5_agent_opts = [
                       "this request deploys any changes."
                       "When empty (default) this request will not affect "
                       "config-sync at all.")),
+    cfg.BoolOpt('prometheus', default=True,
+                help=_("Enable prometheus metrics exporter")),
 
 ]
 

--- a/octavia_f5/controller/statusmanager/status_manager.py
+++ b/octavia_f5/controller/statusmanager/status_manager.py
@@ -30,6 +30,8 @@ from octavia_f5.restclient.as3restclient import BigipAS3RestClient, authorized
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
 
+PROMETHEUS_PORT = 8000
+
 
 class StatusManager(BigipAS3RestClient):
     def __init__(self, exit_event):
@@ -44,6 +46,9 @@ class StatusManager(BigipAS3RestClient):
         self.amp_repo = repo.AmphoraRepository()
         self.amp_health_repo = repo.AmphoraHealthRepository()
         self.lb_repo = repo.LoadBalancerRepository()
+
+        LOG.info('Starting Prometheus HTTP server on port {}'.format(PROMETHEUS_PORT))
+        prometheus.start_http_server(PROMETHEUS_PORT)
 
     _metric_heartbeat = prometheus.metrics.Counter(
         'status_heartbeat', 'The amount of heartbeats sent')

--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -79,7 +79,7 @@ class ControllerWorker(object):
         t.start()
 
         if cfg.CONF.f5_agent.prometheus:
-            LOG.debug('Starting Prometheus HTTP server on port {}'.format(PROMETHEUS_PORT))
+            LOG.info('Starting Prometheus HTTP server on port {}'.format(PROMETHEUS_PORT))
             prometheus.start_http_server(PROMETHEUS_PORT)
 
         super(ControllerWorker, self).__init__()

--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -15,6 +15,7 @@
 
 import threading
 
+import prometheus_client as prometheus
 import tenacity
 from futurist import periodics
 from oslo_concurrency import lockutils
@@ -41,6 +42,8 @@ RETRY_ATTEMPTS = 15
 RETRY_INITIAL_DELAY = 1
 RETRY_BACKOFF = 1
 RETRY_MAX = 5
+
+PROMETHEUS_PORT = 8000
 
 
 class ControllerWorker(object):
@@ -74,6 +77,9 @@ class ControllerWorker(object):
         t = threading.Thread(target=worker.start)
         t.daemon = True
         t.start()
+
+        LOG.debug('Starting Prometheus HTTP server on port {}'.format(PROMETHEUS_PORT))
+        prometheus.start_http_server(PROMETHEUS_PORT)
 
         super(ControllerWorker, self).__init__()
 

--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -78,8 +78,9 @@ class ControllerWorker(object):
         t.daemon = True
         t.start()
 
-        LOG.debug('Starting Prometheus HTTP server on port {}'.format(PROMETHEUS_PORT))
-        prometheus.start_http_server(PROMETHEUS_PORT)
+        if cfg.CONF.f5_agent.prometheus:
+            LOG.debug('Starting Prometheus HTTP server on port {}'.format(PROMETHEUS_PORT))
+            prometheus.start_http_server(PROMETHEUS_PORT)
 
         super(ControllerWorker, self).__init__()
 

--- a/octavia_f5/restclient/as3restclient.py
+++ b/octavia_f5/restclient/as3restclient.py
@@ -53,31 +53,31 @@ class BigipAS3RestClient(object):
         self.session = self._create_session()
         self.esd = esd
 
-    _metric_request_post = prometheus.metrics.Counter(
-        'as3_request_post', 'The amount of POST requests sent by F5 provider driver')
-    _metric_request_post_time = prometheus.metrics.Summary(
-        'as3_request_post_time', 'Time it needs to send a POST request')
-    _metric_request_post_exceptions = prometheus.metrics.Counter(
-        'as3_request_post_exceptions', 'Number of exceptions at POST request')
-    _metric_request_patch = prometheus.metrics.Counter(
-        'as3_request_patch', 'The amount of PATCH requests sent by F5 provider driver')
-    _metric_request_patch_time = prometheus.metrics.Summary(
-        'as3_request_patch_time', 'Time it needs to send a PATCH request')
-    _metric_request_patch_exceptions = prometheus.metrics.Counter(
-        'as3_request_patch_exceptions', 'Number of exceptions at PATCH request')
-    _metric_request_delete = prometheus.metrics.Counter(
-        'as3_request_delete', 'The amount of DELETE requests sent by F5 provider driver')
-    _metric_request_delete_time = prometheus.metrics.Summary(
-        'as3_request_delete_time', 'Time it needs to send a DELETE request.')
-    _metric_request_delete_exceptions = prometheus.metrics.Counter(
-        'as3_request_delete_exceptions', 'Number of exceptions at DELETE request')
-    _metric_request_authorization = prometheus.metrics.Counter(
-        'as3_request_authorization',
+    _metric_post = prometheus.metrics.Counter(
+        'as3_post', 'The amount of POST requests sent by F5 provider driver')
+    _metric_post_time = prometheus.metrics.Summary(
+        'as3_post_time', 'Time it needs to send a POST request')
+    _metric_post_exceptions = prometheus.metrics.Counter(
+        'as3_post_exceptions', 'Number of exceptions at POST request')
+    _metric_patch = prometheus.metrics.Counter(
+        'as3_patch', 'The amount of PATCH requests sent by F5 provider driver')
+    _metric_patch_time = prometheus.metrics.Summary(
+        'as3_patch_time', 'Time it needs to send a PATCH request')
+    _metric_patch_exceptions = prometheus.metrics.Counter(
+        'as3_patch_exceptions', 'Number of exceptions at PATCH request')
+    _metric_delete = prometheus.metrics.Counter(
+        'as3_delete', 'The amount of DELETE requests sent by F5 provider driver')
+    _metric_delete_time = prometheus.metrics.Summary(
+        'as3_delete_time', 'Time it needs to send a DELETE request.')
+    _metric_delete_exceptions = prometheus.metrics.Counter(
+        'as3_delete_exceptions', 'Number of exceptions at DELETE request')
+    _metric_authorization = prometheus.metrics.Counter(
+        'as3_authorization',
         'How often the F5 provider driver had to (re)authorize before performing a request')
-    _metric_request_authorization_time = prometheus.metrics.Summary(
-        'as3_request_authorization_time', 'Time it needs to (re)authorize')
-    _metric_request_authorization_exceptions = prometheus.metrics.Counter(
-        'as3_request_authorization_exceptions', 'Number of exceptions at (re)authorization')
+    _metric_authorization_time = prometheus.metrics.Summary(
+        'as3_authorization_time', 'Time it needs to (re)authorize')
+    _metric_authorization_exceptions = prometheus.metrics.Counter(
+        'as3_authorization_exceptions', 'Number of exceptions at (re)authorization')
 
     def _url(self, path):
         return parse.urlunsplit(
@@ -99,10 +99,10 @@ class BigipAS3RestClient(object):
         session.verify = self.enable_verify
         return session
 
-    @_metric_request_authorization_exceptions.count_exceptions()
-    @_metric_request_authorization_time.time()
+    @_metric_authorization_exceptions.count_exceptions()
+    @_metric_authorization_time.time()
     def reauthorize(self):
-        self._metric_request_authorization.inc()
+        self._metric_authorization.inc()
         # Login
         credentials = {
             "username": self.bigip.username,
@@ -123,10 +123,10 @@ class BigipAS3RestClient(object):
         LOG.debug("Reauthorized!")
 
     @authorized
-    @_metric_request_post_exceptions.count_exceptions()
-    @_metric_request_post_time.time()
+    @_metric_post_exceptions.count_exceptions()
+    @_metric_post_time.time()
     def post(self, **kwargs):
-        self._metric_request_post.inc()
+        self._metric_post.inc()
         LOG.debug("Calling POST with JSON %s", kwargs.get('json'))
         response = self.session.post(self._url(AS3_DECLARE_PATH), **kwargs)
         LOG.debug("POST finished with %d", response.status_code)
@@ -137,10 +137,10 @@ class BigipAS3RestClient(object):
         return response
 
     @authorized
-    @_metric_request_patch_exceptions.count_exceptions()
-    @_metric_request_patch_time.time()
+    @_metric_patch_exceptions.count_exceptions()
+    @_metric_patch_time.time()
     def patch(self, operation, path, **kwargs):
-        self._metric_request_patch.inc()
+        self._metric_patch.inc()
         LOG.debug("Calling PATCH %s with path %s", operation, path)
         if 'value' in kwargs:
             LOG.debug(json.dumps(kwargs['value'], indent=4, sort_keys=True))
@@ -154,10 +154,10 @@ class BigipAS3RestClient(object):
         return response
 
     @authorized
-    @_metric_request_delete_exceptions.count_exceptions()
-    @_metric_request_delete_time.time()
+    @_metric_delete_exceptions.count_exceptions()
+    @_metric_delete_time.time()
     def delete(self, **kwargs):
-        self._metric_request_delete.inc()
+        self._metric_delete.inc()
         tenants = kwargs.get('tenants', None)
         if not tenants:
             LOG.error("Delete called without tenant, would wipe all AS3 Declaration, ignoring!")

--- a/octavia_f5/restclient/as3restclient.py
+++ b/octavia_f5/restclient/as3restclient.py
@@ -55,19 +55,27 @@ class BigipAS3RestClient(object):
 
     _metric_request_post = prometheus.metrics.Counter(
         'as3_request_post', 'The amount of POST requests sent by F5 provider driver')
+    _metric_request_post_time = prometheus.metrics.Summary(
+        'as3_request_post_time', 'Time it needs to send a POST request')
     _metric_request_post_exceptions = prometheus.metrics.Counter(
         'as3_request_post_exceptions', 'Number of exceptions at POST request')
     _metric_request_patch = prometheus.metrics.Counter(
         'as3_request_patch', 'The amount of PATCH requests sent by F5 provider driver')
+    _metric_request_patch_time = prometheus.metrics.Summary(
+        'as3_request_patch_time', 'Time it needs to send a PATCH request')
     _metric_request_patch_exceptions = prometheus.metrics.Counter(
         'as3_request_patch_exceptions', 'Number of exceptions at PATCH request')
     _metric_request_delete = prometheus.metrics.Counter(
         'as3_request_delete', 'The amount of DELETE requests sent by F5 provider driver')
+    _metric_request_delete_time = prometheus.metrics.Summary(
+        'as3_request_delete_time', 'Time it needs to send a DELETE request.')
     _metric_request_delete_exceptions = prometheus.metrics.Counter(
         'as3_request_delete_exceptions', 'Number of exceptions at DELETE request')
     _metric_request_authorization = prometheus.metrics.Counter(
         'as3_request_authorization',
         'How often the F5 provider driver had to (re)authorize before performing a request')
+    _metric_request_authorization_time = prometheus.metrics.Summary(
+        'as3_request_authorization_time', 'Time it needs to (re)authorize')
     _metric_request_authorization_exceptions = prometheus.metrics.Counter(
         'as3_request_authorization_exceptions', 'Number of exceptions at (re)authorization')
 
@@ -92,6 +100,7 @@ class BigipAS3RestClient(object):
         return session
 
     @_metric_request_authorization_exceptions.count_exceptions()
+    @_metric_request_authorization_time.time()
     def reauthorize(self):
         self._metric_request_authorization.inc()
         # Login
@@ -115,6 +124,7 @@ class BigipAS3RestClient(object):
 
     @authorized
     @_metric_request_post_exceptions.count_exceptions()
+    @_metric_request_post_time.time()
     def post(self, **kwargs):
         self._metric_request_post.inc()
         LOG.debug("Calling POST with JSON %s", kwargs.get('json'))
@@ -128,6 +138,7 @@ class BigipAS3RestClient(object):
 
     @authorized
     @_metric_request_patch_exceptions.count_exceptions()
+    @_metric_request_patch_time.time()
     def patch(self, operation, path, **kwargs):
         self._metric_request_patch.inc()
         LOG.debug("Calling PATCH %s with path %s", operation, path)
@@ -144,6 +155,7 @@ class BigipAS3RestClient(object):
 
     @authorized
     @_metric_request_delete_exceptions.count_exceptions()
+    @_metric_request_delete_time.time()
     def delete(self, **kwargs):
         self._metric_request_delete.inc()
         tenants = kwargs.get('tenants', None)

--- a/octavia_f5/restclient/as3restclient.py
+++ b/octavia_f5/restclient/as3restclient.py
@@ -55,27 +55,27 @@ class BigipAS3RestClient(object):
 
     _metric_post = prometheus.metrics.Counter(
         'as3_post', 'Amount of POST requests sent to AS3')
-    _metric_post_time = prometheus.metrics.Summary(
-        'as3_post_time', 'Time it needs to send a POST request to AS3')
+    _metric_post_duration = prometheus.metrics.Summary(
+        'as3_post_duration', 'Time it needs to send a POST request to AS3')
     _metric_post_exceptions = prometheus.metrics.Counter(
         'as3_post_exceptions', 'Number of exceptions at POST requests sent to AS3')
     _metric_patch = prometheus.metrics.Counter(
         'as3_patch', 'Amount of PATCH requests sent to AS3')
-    _metric_patch_time = prometheus.metrics.Summary(
-        'as3_patch_time', 'Time it needs to send a PATCH request to AS3')
+    _metric_patch_duration = prometheus.metrics.Summary(
+        'as3_patch_duration', 'Time it needs to send a PATCH request to AS3')
     _metric_patch_exceptions = prometheus.metrics.Counter(
         'as3_patch_exceptions', 'Number of exceptions at PATCH request sent to AS3')
     _metric_delete = prometheus.metrics.Counter(
         'as3_delete', 'Amount of DELETE requests  sent to AS3')
-    _metric_delete_time = prometheus.metrics.Summary(
-        'as3_delete_time', 'Time it needs to send a DELETE request to AS3')
+    _metric_delete_duration = prometheus.metrics.Summary(
+        'as3_delete_duration', 'Time it needs to send a DELETE request to AS3')
     _metric_delete_exceptions = prometheus.metrics.Counter(
         'as3_delete_exceptions', 'Number of exceptions at DELETE request sent to AS3')
     _metric_authorization = prometheus.metrics.Counter(
         'as3_authorization',
         'How often the F5 provider driver had to (re)authorize before performing an AS3 request')
-    _metric_authorization_time = prometheus.metrics.Summary(
-        'as3_authorization_time', 'Time it needs to (re)authorize')
+    _metric_authorization_duration = prometheus.metrics.Summary(
+        'as3_authorization_duration', 'Time it needs to (re)authorize')
     _metric_authorization_exceptions = prometheus.metrics.Counter(
         'as3_authorization_exceptions', 'Number of exceptions at (re)authorization')
 
@@ -100,7 +100,7 @@ class BigipAS3RestClient(object):
         return session
 
     @_metric_authorization_exceptions.count_exceptions()
-    @_metric_authorization_time.time()
+    @_metric_authorization_duration.time()
     def reauthorize(self):
         self._metric_authorization.inc()
         # Login
@@ -124,7 +124,7 @@ class BigipAS3RestClient(object):
 
     @authorized
     @_metric_post_exceptions.count_exceptions()
-    @_metric_post_time.time()
+    @_metric_post_duration.time()
     def post(self, **kwargs):
         self._metric_post.inc()
         LOG.debug("Calling POST with JSON %s", kwargs.get('json'))
@@ -138,7 +138,7 @@ class BigipAS3RestClient(object):
 
     @authorized
     @_metric_patch_exceptions.count_exceptions()
-    @_metric_patch_time.time()
+    @_metric_patch_duration.time()
     def patch(self, operation, path, **kwargs):
         self._metric_patch.inc()
         LOG.debug("Calling PATCH %s with path %s", operation, path)
@@ -155,7 +155,7 @@ class BigipAS3RestClient(object):
 
     @authorized
     @_metric_delete_exceptions.count_exceptions()
-    @_metric_delete_time.time()
+    @_metric_delete_duration.time()
     def delete(self, **kwargs):
         self._metric_delete.inc()
         tenants = kwargs.get('tenants', None)

--- a/octavia_f5/restclient/as3restclient.py
+++ b/octavia_f5/restclient/as3restclient.py
@@ -54,26 +54,26 @@ class BigipAS3RestClient(object):
         self.esd = esd
 
     _metric_post = prometheus.metrics.Counter(
-        'as3_post', 'The amount of POST requests sent by F5 provider driver')
+        'as3_post', 'Amount of POST requests sent to AS3')
     _metric_post_time = prometheus.metrics.Summary(
-        'as3_post_time', 'Time it needs to send a POST request')
+        'as3_post_time', 'Time it needs to send a POST request to AS3')
     _metric_post_exceptions = prometheus.metrics.Counter(
-        'as3_post_exceptions', 'Number of exceptions at POST request')
+        'as3_post_exceptions', 'Number of exceptions at POST requests sent to AS3')
     _metric_patch = prometheus.metrics.Counter(
-        'as3_patch', 'The amount of PATCH requests sent by F5 provider driver')
+        'as3_patch', 'Amount of PATCH requests sent to AS3')
     _metric_patch_time = prometheus.metrics.Summary(
-        'as3_patch_time', 'Time it needs to send a PATCH request')
+        'as3_patch_time', 'Time it needs to send a PATCH request to AS3')
     _metric_patch_exceptions = prometheus.metrics.Counter(
-        'as3_patch_exceptions', 'Number of exceptions at PATCH request')
+        'as3_patch_exceptions', 'Number of exceptions at PATCH request sent to AS3')
     _metric_delete = prometheus.metrics.Counter(
-        'as3_delete', 'The amount of DELETE requests sent by F5 provider driver')
+        'as3_delete', 'Amount of DELETE requests  sent to AS3')
     _metric_delete_time = prometheus.metrics.Summary(
-        'as3_delete_time', 'Time it needs to send a DELETE request.')
+        'as3_delete_time', 'Time it needs to send a DELETE request to AS3')
     _metric_delete_exceptions = prometheus.metrics.Counter(
-        'as3_delete_exceptions', 'Number of exceptions at DELETE request')
+        'as3_delete_exceptions', 'Number of exceptions at DELETE request sent to AS3')
     _metric_authorization = prometheus.metrics.Counter(
         'as3_authorization',
-        'How often the F5 provider driver had to (re)authorize before performing a request')
+        'How often the F5 provider driver had to (re)authorize before performing an AS3 request')
     _metric_authorization_time = prometheus.metrics.Summary(
         'as3_authorization_time', 'Time it needs to (re)authorize')
     _metric_authorization_exceptions = prometheus.metrics.Counter(

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ oslo.context>=2.19.2 # Apache-2.0
 oslo.db>=4.27.0 # Apache-2.0
 oslo.log>=3.36.0 # Apache-2.0
 requests>=2.14.2 # Apache-2.0
-prometheus_client>=0.7.0 # Apache-2.0
+prometheus_client>=0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ oslo.context>=2.19.2 # Apache-2.0
 oslo.db>=4.27.0 # Apache-2.0
 oslo.log>=3.36.0 # Apache-2.0
 requests>=2.14.2 # Apache-2.0
+prometheus_client>=0.7.0 # Apache-2.0


### PR DESCRIPTION
PR for issue #14 

- [x] Add prometheus configuration option (see [networking-f5](https://github.com/sapcc/networking-f5/), namely [here](https://github.com/sapcc/networking-f5/blob/stable/queens-m3/networking_f5/agent/f5_agent.py#L60) and [here](https://github.com/sapcc/networking-f5/blob/stable/queens-m3/networking_f5/agent/f5_agent.py#L298). Define in `octavia_f5/common/config.py`)
- [x] Add metrics for status manager
- [x] Add metric for HTTP codes

#### Metrics introduced with this PR:

| metric | module | description |
|-|-|-|
| as3_httpstatus | as3restclient | Number of HTTP statuses in responses to AS3 requests |
| as3_post | as3restclient | Amount of POST requests sent to AS3 | 
| as3_post_time | as3restclient | Time it needs to send a POST request to AS3 | 
| as3_post_exceptions | as3restclient | Number of exceptions at POST requests sent to AS3 | 
| as3_patch | as3restclient | Amount of PATCH requests sent to AS3 | 
| as3_patch_time | as3restclient | Time it needs to send a PATCH request to AS3 | 
| as3_patch_exceptions | as3restclient | Number of exceptions at PATCH request sent to AS3 | 
| as3_delete | as3restclient | Amount of DELETE requests  sent to AS3 | 
| as3_delete_time | as3restclient | Time it needs to send a DELETE request to AS3 | 
| as3_delete_exceptions | as3restclient | Number of exceptions at DELETE request sent to AS3 | 
| as3_authorization | as3restclient | How often the F5 provider driver had to (re)authorize before performing an AS3 request | 
| as3_authorization_time | as3restclient | Time it needs to (re)authorize | 
| as3_authorization_exceptions | as3restclient | Number of exceptions at (re)authorization | 
| status_heartbeat | status_manager | The amount of heartbeats sent |
| status_heartbeat_time | status_manager | Time it needs for one heartbeat |
| status_heartbeat_exceptions | status_manager | Number of exceptions at heartbeat |
