### PR TITLE
support for backup member

### DIFF
--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -289,7 +289,7 @@ class ControllerWorker(object):
 
         self.ensure_amphora_exists(member.pool.load_balancer.id)
 
-        if member_create(self.bigip, member).ok:
+        if not member.backup and member_create(self.bigip, member).ok:
             self.status.set_active(member)
         elif self._refresh(member.pool.load_balancer.vip.network_id).ok:
             self.status.set_active(member)

--- a/octavia_f5/restclient/as3classes.py
+++ b/octavia_f5/restclient/as3classes.py
@@ -269,3 +269,9 @@ class CA_Bundle(BaseDescription):
         super(CA_Bundle, self).__init__(locals())
         setattr(self, 'class', 'CA_Bundle')
         self.require('bundle')
+
+
+class HTTP_Profile(BaseDescription):
+    def __init__(self, **kwargs):
+        super(HTTP_Profile, self).__init__(locals())
+        setattr(self, 'class', 'HTTP_Profile')

--- a/octavia_f5/restclient/as3objects/pool.py
+++ b/octavia_f5/restclient/as3objects/pool.py
@@ -52,7 +52,8 @@ def get_pool(pool):
     }
 
     for member in pool.members:
-        if not utils.pending_delete(member):
+        # Ignore backup members, will be handled by service
+        if not utils.pending_delete(member) and not member.backup:
             service_args['members'].append(
                 m_member.get_member(member))
 

--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -173,7 +173,7 @@ def get_service(listener, cert_manager):
                 entities.append((name, irule))
 
             # Support of backup members (realized as fallback host via http_profile), pick the first one
-            backup_members = [member for member  in pool.members if member.backup]
+            backup_members = [member for member in pool.members if member.backup]
             if backup_members:
                 http_profile_name = m_member.get_name(backup_members[0].id)
                 http_profile = as3.HTTP_Profile(fallbackRedirect=backup_members[0].ip_address)


### PR DESCRIPTION
adds support for octavia backup member, will be realized
as custom service HTTP profile with fallback host.
Only one backup member supported.
fixes #37