### PR TITLE
# added multi-agent and scheduling capability

### DIFF
--- a/octavia_f5/api/drivers/f5_driver/driver.py
+++ b/octavia_f5/api/drivers/f5_driver/driver.py
@@ -16,6 +16,11 @@ from oslo_config import cfg
 from oslo_log import log as logging
 
 from octavia.api.drivers.amphora_driver import driver
+from octavia.common import constants as consts
+from octavia.db import api as db_apis
+from octavia_f5.common import constants as f5_consts
+from octavia_f5.utils import driver_utils
+from octavia_lib.api.drivers import data_models as driver_dm
 from octavia_lib.api.drivers import exceptions
 
 CONF = cfg.CONF
@@ -25,8 +30,182 @@ LOG = logging.getLogger(__name__)
 
 class F5ProviderDriver(driver.AmphoraProviderDriver):
     """Octavia plugin for the F5 driver."""
+
     def __init__(self):
         super(F5ProviderDriver, self).__init__()
+
+    def _get_server(self, loadbalancer_id):
+        return getattr(
+            self.repositories.amphora.get(
+                db_apis.get_session(),
+                load_balancer_id=loadbalancer_id,
+                status=f5_consts.ACTIVE),
+            'compute_flavor', None)
+
+    def loadbalancer_create(self, loadbalancer):
+        if loadbalancer.flavor == driver_dm.Unset:
+            loadbalancer.flavor = None
+
+        network_driver = driver_utils.get_network_driver()
+        host = network_driver.get_scheduled_host(loadbalancer.vip_port_id)
+
+        LOG.info("Scheduling loadbalancer %s to %s",
+                 loadbalancer.loadbalancer_id,
+                 host)
+        payload = {consts.LOAD_BALANCER_ID: loadbalancer.loadbalancer_id,
+                   consts.FLAVOR: loadbalancer.flavor}
+        client = self.client.prepare(server=host)
+        client.cast({}, 'create_load_balancer', **payload)
+
+    def loadbalancer_delete(self, loadbalancer, cascade=False):
+        loadbalancer_id = loadbalancer.loadbalancer_id
+        payload = {consts.LOAD_BALANCER_ID: loadbalancer_id,
+                   'cascade': cascade}
+        client = self.client.prepare(server=self._get_server(loadbalancer_id))
+        client.cast({}, 'delete_load_balancer', **payload)
+
+    def loadbalancer_failover(self, loadbalancer_id):
+        payload = {consts.LOAD_BALANCER_ID: loadbalancer_id}
+        client = self.client.prepare(server=self._get_server(loadbalancer_id))
+        client.cast({}, 'failover_load_balancer', **payload)
+
+    def loadbalancer_update(self, old_loadbalancer, new_loadbalancer):
+        lb_id = new_loadbalancer.loadbalancer_id
+        payload = {consts.LOAD_BALANCER_ID: lb_id,
+                   consts.LOAD_BALANCER_UPDATES: {}}
+        client = self.client.prepare(server=self._get_server(lb_id))
+        client.cast({}, 'update_load_balancer', **payload)
+
+    # Listener
+    def listener_create(self, listener):
+        payload = {consts.LISTENER_ID: listener.listener_id}
+        client = self.client.prepare(server=self._get_server(listener.loadbalancer_id))
+        client.cast({}, 'create_listener', **payload)
+
+    def listener_delete(self, listener):
+        listener_id = listener.listener_id
+        payload = {consts.LISTENER_ID: listener_id}
+        client = self.client.prepare(server=self._get_server(listener.loadbalancer_id))
+        client.cast({}, 'delete_listener', **payload)
+
+    def listener_update(self, old_listener, new_listener):
+        listener_id = old_listener.listener_id
+        payload = {consts.LISTENER_ID: listener_id,
+                   consts.LISTENER_UPDATES: {}}
+        client = self.client.prepare(server=self._get_server(old_listener.loadbalancer_id))
+        client.cast({}, 'update_listener', **payload)
+
+    # Pool
+    def pool_create(self, pool):
+        payload = {consts.POOL_ID: pool.pool_id}
+        client = self.client.prepare(server=self._get_server(pool.loadbalancer_id))
+        client.cast({}, 'create_pool', **payload)
+
+    def pool_delete(self, pool):
+        pool_id = pool.pool_id
+        payload = {consts.POOL_ID: pool_id}
+        client = self.client.prepare(server=self._get_server(pool.loadbalancer_id))
+        client.cast({}, 'delete_pool', **payload)
+
+    def pool_update(self, old_pool, new_pool):
+        pool_id = new_pool.pool_id
+        payload = {consts.POOL_ID: pool_id,
+                   consts.POOL_UPDATES: {}}
+        client = self.client.prepare(server=self._get_server(old_pool.loadbalancer_id))
+        client.cast({}, 'update_pool', **payload)
+
+    # Member
+    def member_create(self, member):
+        db_pool = self.repositories.pool.get(db_apis.get_session(),
+                                             id=member.pool_id)
+        payload = {consts.MEMBER_ID: member.member_id}
+        db_pool = self.repositories.pool.get(db_apis.get_session(), id=member.pool_id)
+        client = self.client.prepare(server=self._get_server(db_pool.load_balancer_id))
+        client.cast({}, 'create_member', **payload)
+
+    def member_delete(self, member):
+        db_pool = self.repositories.pool.get(db_apis.get_session(), id=member.pool_id)
+        payload = {consts.MEMBER_ID: member.member_id}
+        client = self.client.prepare(server=self._get_server(db_pool.load_balancer_id))
+        client.cast({}, 'delete_member', **payload)
+
+    def member_update(self, old_member, new_member):
+        db_pool = self.repositories.pool.get(db_apis.get_session(), id=old_member.pool_id)
+        payload = {consts.MEMBER_ID: new_member.member_id,
+                   consts.MEMBER_UPDATES: {}}
+        client = self.client.prepare(server=self._get_server(db_pool.load_balancer_id))
+        client.cast({}, 'update_member', **payload)
+
+    def member_batch_update(self, pool_id, members):
+        db_pool = self.repositories.pool.get(db_apis.get_session(), id=pool_id)
+        payload = {'old_member_ids': [],
+                   'new_member_ids': [],
+                   'updated_members': []}
+        client = self.client.prepare(server=self._get_server(db_pool.loadbalancer_id))
+        client.cast({}, 'batch_update_members', **payload)
+
+    # Health Monitor
+    def health_monitor_create(self, healthmonitor):
+        db_pool = self.repositories.pool.get(db_apis.get_session(), id=healthmonitor.pool_id)
+        payload = {consts.HEALTH_MONITOR_ID: healthmonitor.healthmonitor_id}
+        client = self.client.prepare(server=self._get_server(db_pool.load_balancer_id))
+        client.cast({}, 'create_health_monitor', **payload)
+
+    def health_monitor_delete(self, healthmonitor):
+        db_pool = self.repositories.pool.get(db_apis.get_session(), id=healthmonitor.pool_id)
+        payload = {consts.HEALTH_MONITOR_ID: healthmonitor.healthmonitor_id}
+        client = self.client.prepare(server=self._get_server(db_pool.load_balancer_id))
+        client.cast({}, 'delete_health_monitor', **payload)
+
+    def health_monitor_update(self, old_healthmonitor, new_healthmonitor):
+        db_pool = self.repositories.pool.get(db_apis.get_session(), id=old_healthmonitor.pool_id)
+        payload = {consts.HEALTH_MONITOR_ID: new_healthmonitor.healthmonitor_id,
+                   consts.HEALTH_MONITOR_UPDATES: {}}
+        client = self.client.prepare(server=self._get_server(db_pool.load_balancer_id))
+        client.cast({}, 'update_health_monitor', **payload)
+
+    # L7 Policy
+    def l7policy_create(self, l7policy):
+        db_listener = self.repositories.listener.get(db_apis.get_session(), id=l7policy.listener_id)
+        payload = {consts.L7POLICY_ID: l7policy.l7policy_id}
+        client = self.client.prepare(server=self._get_server(db_listener.load_balancer_id))
+        client.cast({}, 'create_l7policy', **payload)
+
+    def l7policy_delete(self, l7policy):
+        db_listener = self.repositories.listener.get(db_apis.get_session(), id=l7policy.listener_id)
+        payload = {consts.L7POLICY_ID: l7policy.l7policy_id}
+        client = self.client.prepare(server=self._get_server(db_listener.load_balancer_id))
+        client.cast({}, 'delete_l7policy', **payload)
+
+    def l7policy_update(self, old_l7policy, new_l7policy):
+        db_listener = self.repositories.listener.get(db_apis.get_session(), id=old_l7policy.listener_id)
+        payload = {consts.L7POLICY_ID: new_l7policy.l7policy_id,
+                   consts.L7POLICY_UPDATES: {}}
+        client = self.client.prepare(server=self._get_server(db_listener.load_balancer_id))
+        self.client.cast({}, 'update_l7policy', **payload)
+
+    # L7 Rule
+    def l7rule_create(self, l7rule):
+        db_l7 = self.repositories.l7policy.get(db_apis.get_session(), id=l7rule.l7policy_id)
+
+        payload = {consts.L7RULE_ID: l7rule.l7rule_id}
+        client = self.client.prepare(server=self._get_server(db_l7.listener.load_balancer_id))
+        client.cast({}, 'create_l7rule', **payload)
+
+    def l7rule_delete(self, l7rule):
+        db_l7 = self.repositories.l7policy.get(db_apis.get_session(), id=l7rule.l7policy_id)
+
+        payload = {consts.L7RULE_ID: l7rule.l7rule_id}
+        client = self.client.prepare(server=self._get_server(db_l7.listener.load_balancer_id))
+        client.cast({}, 'delete_l7rule', **payload)
+
+    def l7rule_update(self, old_l7rule, new_l7rule):
+        db_l7 = self.repositories.l7policy.get(db_apis.get_session(), id=old_l7rule.l7policy_id)
+
+        payload = {consts.L7RULE_ID: new_l7rule.l7rule_id,
+                   consts.L7RULE_UPDATES: {}}
+        client = self.client.prepare(server=self._get_server(db_l7.listener.load_balancer_id))
+        client.cast({}, 'update_l7rule', **payload)
 
     def create_vip_port(self, loadbalancer_id, project_id, vip_dictionary):
         # Let Octavia create the port

--- a/octavia_f5/api/drivers/f5_driver/driver.py
+++ b/octavia_f5/api/drivers/f5_driver/driver.py
@@ -29,7 +29,12 @@ LOG = logging.getLogger(__name__)
 
 
 class F5ProviderDriver(driver.AmphoraProviderDriver):
-    """Octavia plugin for the F5 driver."""
+    """Octavia plugin for the F5 driver.
+
+    Callbacks need to be overwritten for setting the _server_ attribute
+    in RPC calls to specify the target rpc receiver (e.g. the scheduled
+    host)
+    """
 
     def __init__(self):
         super(F5ProviderDriver, self).__init__()

--- a/octavia_f5/api/drivers/f5_driver/driver.py
+++ b/octavia_f5/api/drivers/f5_driver/driver.py
@@ -40,6 +40,11 @@ class F5ProviderDriver(driver.AmphoraProviderDriver):
         super(F5ProviderDriver, self).__init__()
 
     def _get_server(self, loadbalancer_id):
+        """ Get scheduled host of the loadbalancer.
+
+        :param loadbalancer_id: loadbalancer id
+        :return: scheduled host
+        """
         return getattr(
             self.repositories.amphora.get(
                 db_apis.get_session(),

--- a/octavia_f5/common/config.py
+++ b/octavia_f5/common/config.py
@@ -20,8 +20,8 @@ import sys
 
 from oslo_config import cfg
 from oslo_log import log as logging
-from octavia_f5.common import constants
 
+from octavia_f5.common import constants
 from octavia_lib.i18n import _
 
 LOG = logging.getLogger(__name__)
@@ -30,6 +30,7 @@ LOG = logging.getLogger(__name__)
 def init(args, **kwargs):
     cfg.CONF(args=args, project='octavia_f5',
              **kwargs)
+
 
 def setup_logging(conf):
     """Sets up the logging options for a log with supplied name.
@@ -75,10 +76,19 @@ f5_agent_opts = [
                 help=_("Enable prometheus metrics exporter")),
     cfg.PortOpt('prometheus_port', default=8000,
                 help=_('Port for prometheus to expose, defaults to 8000.')),
+    cfg.BoolOpt('dry_run', default=False,
+                help=_("Run in dry-run, do not realize AS3 definitions.")),
 
 ]
 
 f5_networking_opts = [
+    cfg.BoolOpt('caching', default=True,
+                help=_('Enable caching of segmentation ids and ports')),
+    cfg.IntOpt('cache_time', default=3600,
+               help=_('Caching time in seconds (default=3600)')),
+    cfg.StrOpt('f5_network_segment_physical_network', default="",
+               help=_('Restrict discovery of network segmentation ID '
+                      'to a specific physical network name.')),
 ]
 
 # Register the configuration options

--- a/octavia_f5/controller/statusmanager/status_manager.py
+++ b/octavia_f5/controller/statusmanager/status_manager.py
@@ -209,17 +209,17 @@ class StatusManager(BigipAS3RestClient):
         try:
             lock_session = db_api.get_session(autocommit=False)
             device_amp = self.amp_repo.get(lock_session,
-                                           compute_flavor=self.bigip.hostname,
+                                           compute_flavor=CONF.host,
                                            load_balancer_id=None)
             if not device_amp:
                 device_amp = self.amp_repo.create(
                     lock_session,
-                    compute_flavor=self.bigip.hostname,
-                    status=constants.ACTIVE,
+                    compute_flavor=CONF.host,
+                    status=constants.AMPHORA_READY,
                     vrrp_priority=num_listeners)
             else:
                 self.amp_repo.update(lock_session, device_amp.id,
-                                     status=constants.ACTIVE,
+                                     status=constants.AMPHORA_READY,
                                      vrrp_priority=num_listeners)
             self.amphora_id = device_amp.id
             lock_session.commit()

--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -112,7 +112,7 @@ class ControllerWorker(object):
         lbs.extend([l7policy.listener.load_balancer for l7policy in l7policies])
 
         for lb in lbs:
-            LOG.info("Found pending tennant network %s, syncing...", lb.vip.network_id)
+            LOG.info("Found pending tenant network %s, syncing...", lb.vip.network_id)
             if self._refresh(lb.vip.network_id).ok:
                 self.status.update_status([lb])
 

--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -90,16 +90,16 @@ class ControllerWorker(object):
         """ Reconciliation loop that pics up un-scheduled loadbalancers and
             schedules them to this worker.
         """
-        lbs = self._loadbalancer_repo.get_all(
+        lbs = []
+        pending_create_lbs = self._loadbalancer_repo.get_all(
             db_apis.get_session(),
             provisioning_status=lib_consts.PENDING_CREATE,
             show_deleted=False)[0]
-        for lb in lbs:
+        for lb in pending_create_lbs:
             # bind to loadbalancer if scheduled to this host
             if CONF.host == self.network_driver.get_scheduled_host(lb.vip.port_id):
                 self.ensure_amphora_exists(lb.id)
-            else:
-                lbs.remove(lb)
+                lbs.append(lb)
 
         lbs.extend(self._loadbalancer_repo.get_all_from_host(
             db_apis.get_session(),

--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -24,6 +24,7 @@ from oslo_log import log as logging
 from sqlalchemy.orm import exc as db_exceptions
 
 from octavia.db import repositories as repo
+from octavia_f5.db import repositories as f5_repos
 from octavia_f5.controller.worker import status
 from octavia_f5.controller.worker.f5agent_driver import member_create
 from octavia_f5.controller.worker.f5agent_driver import tenant_delete
@@ -48,15 +49,15 @@ class ControllerWorker(object):
     """Worker class to update load balancers."""
 
     def __init__(self):
-        self._loadbalancer_repo = repo.LoadBalancerRepository()
+        self._loadbalancer_repo = f5_repos.LoadBalancerRepository()
         self._esd = esd_repo.EsdRepository()
         self._amphora_repo = repo.AmphoraRepository()
         self._health_mon_repo = repo.HealthMonitorRepository()
         self._lb_repo = repo.LoadBalancerRepository()
         self._listener_repo = repo.ListenerRepository()
         self._member_repo = repo.MemberRepository()
-        self._pool_repo = repo.PoolRepository()
-        self._l7policy_repo = repo.L7PolicyRepository()
+        self._pool_repo = f5_repos.PoolRepository()
+        self._l7policy_repo = f5_repos.L7PolicyRepository()
         self._l7rule_repo = repo.L7RuleRepository()
         self._flavor_repo = repo.FlavorRepository()
         self._vip_repo = repo.VipRepository()
@@ -86,28 +87,40 @@ class ControllerWorker(object):
     @periodics.periodic(120, run_immediately=True)
     @lockutils.synchronized('tenant_refresh')
     def pending_sync(self):
+        """ Reconciliation loop that pics up un-scheduled loadbalancers and
+            schedules them to this worker.
+        """
         lbs = self._loadbalancer_repo.get_all(
             db_apis.get_session(),
-            provisioning_status=lib_consts.PENDING_UPDATE,
-            show_deleted=False)[0]
-        lbs.extend(self._loadbalancer_repo.get_all(
-            db_apis.get_session(),
             provisioning_status=lib_consts.PENDING_CREATE,
-            show_deleted=False)[0])
+            show_deleted=False)[0]
+        for lb in lbs:
+            # bind to loadbalancer if scheduled to this host
+            if CONF.host == self.network_driver.get_scheduled_host(lb.vip.port_id):
+                self.ensure_amphora_exists(lb.id)
+            else:
+                lbs.remove(lb)
+
+        lbs.extend(self._loadbalancer_repo.get_all_from_host(
+            db_apis.get_session(),
+            provisioning_status=lib_consts.PENDING_UPDATE))
+
+        pools = self._pool_repo.get_pending_from_host(db_apis.get_session())
+        lbs.extend([pool.load_balancer for pool in pools])
+
+        l7policies = self._l7policy_repo.get_pending_from_host(db_apis.get_session())
+        lbs.extend([l7policy.listener.load_balancer for l7policy in l7policies])
 
         for lb in lbs:
-            self.ensure_amphora_exists(lb.id)
+            LOG.info("Found pending tennant network %s, syncing...", lb.vip.network_id)
+            if self._refresh(lb.vip.network_id).ok:
+                self.status.update_status([lb])
 
-        for network_id in set([lb.vip.network_id for lb in lbs]):
-            LOG.info("Found pending tennant network %s, syncing...", network_id)
-            if self._refresh(network_id).ok:
-                self.status.update_status(lbs)
-
-        lbs_to_delete = self._loadbalancer_repo.get_all(
+        lbs_to_delete = self._loadbalancer_repo.get_all_from_host(
             db_apis.get_session(),
-            provisioning_status=lib_consts.PENDING_DELETE,
-            show_deleted=False)[0]
+            provisioning_status=lib_consts.PENDING_DELETE)
         for lb in lbs_to_delete:
+            LOG.info("Found pending deletion of lb %s", lb.id)
             self.delete_load_balancer(lb.id)
 
     @tenacity.retry(
@@ -116,8 +129,7 @@ class ControllerWorker(object):
             RETRY_INITIAL_DELAY, RETRY_BACKOFF, RETRY_MAX),
         stop=tenacity.stop_after_attempt(RETRY_ATTEMPTS))
     def _get_all_loadbalancer(self, network_id):
-        LOG.debug("Get load balancers from DB for network id: %s ",
-                  network_id)
+        LOG.debug("Get load balancers from DB for network id: %s ", network_id)
         vips = self._vip_repo.get_all(
             db_apis.get_session(),
             network_id=network_id)
@@ -173,8 +185,7 @@ class ControllerWorker(object):
 
     @lockutils.synchronized('tenant_refresh')
     def delete_load_balancer(self, load_balancer_id, cascade=False):
-        lb = self._lb_repo.get(db_apis.get_session(),
-                               id=load_balancer_id)
+        lb = self._lb_repo.get(db_apis.get_session(), id=load_balancer_id)
         existing_lbs = [loadbalancer for loadbalancer in self._get_all_loadbalancer(lb.vip.network_id)
                         if loadbalancer.id != lb.id]
 
@@ -455,14 +466,14 @@ class ControllerWorker(object):
     def ensure_amphora_exists(self, load_balancer_id):
         device_amp = self._amphora_repo.get(
             db_apis.get_session(),
-            compute_flavor=self.bigip.bigip.hostname,
+            compute_flavor=CONF.host,
             load_balancer_id=load_balancer_id)
         if not device_amp:
             self._amphora_repo.create(
                 db_apis.get_session(),
                 id=load_balancer_id,
                 load_balancer_id=load_balancer_id,
-                compute_flavor=self.bigip.bigip.hostname,
+                compute_flavor=CONF.host,
                 status=lib_consts.ACTIVE)
 
     def create_amphora(self):

--- a/octavia_f5/controller/worker/f5agent_driver.py
+++ b/octavia_f5/controller/worker/f5agent_driver.py
@@ -47,8 +47,7 @@ def tenant_update(bigip,
                   cert_manager,
                   tenant,
                   loadbalancers,
-                  segmentation_id,
-                  action='deploy'):
+                  segmentation_id):
     """Task to update F5s with all specified loadbalancers' configurations
        of a tenant (project).
 
@@ -57,10 +56,13 @@ def tenant_update(bigip,
        :param tenant: tenant_id/project_id
        :param loadbalancers: loadbalancer to update
        :param segmentation_id: segmentation_id of the loadbalancers
-       :param action: AS3 action
        :return: requests post result
 
     """
+
+    action = 'deploy'
+    if CONF.f5_agent.dry_run:
+        action = 'dry-run'
     decl = AS3(
         persist=True,
         action=action,

--- a/octavia_f5/db/repositories.py
+++ b/octavia_f5/db/repositories.py
@@ -1,0 +1,114 @@
+# Copyright 2020 SAP SE
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""
+Extends octavia base repository with enhanced f5-specific queries
+"""
+
+from oslo_config import cfg
+from oslo_log import log as logging
+from sqlalchemy.orm import noload
+from sqlalchemy.orm import subqueryload
+
+from octavia.common import constants as consts
+from octavia.db import models
+from octavia.db import repositories
+from octavia_lib.common import constants as lib_consts
+
+CONF = cfg.CONF
+
+LOG = logging.getLogger(__name__)
+
+
+class AmphoraRepository(repositories.AmphoraRepository):
+    def get_candidates(self, session):
+        """ Get F5 BigIP host candidate depending on the load
+
+        :param session: A Sql Alchemy database session.
+        """
+
+        candidates = session.query(self.model_class)
+        candidates = candidates.filter_by(
+            status=consts.AMPHORA_READY,
+            load_balancer_id=None)
+        candidates = candidates.order_by(
+            self.model_class.vrrp_priority.asc(),
+            self.model_class.updated_at.desc())
+        return [candidate.compute_flavor for candidate in candidates.all()]
+
+
+class LoadBalancerRepository(repositories.LoadBalancerRepository):
+    def get_all_from_host(self, session, host=CONF.host, **filters):
+        """ Get all loadbalancers from specific host
+
+        :param session: A Sql Alchemy database session.
+        :param host: specify amphora host to fetch loadbalancer from.
+        :param filters: Filters to decide which entities should be retrieved.
+        :returns: [octavia.common.data_model]
+        """
+        deleted = filters.pop('show_deleted', True)
+
+        # sub-query load the tables we need
+        # no-load (blank) the tables we don't need
+        query_options = (
+            subqueryload(models.LoadBalancer.vip),
+            subqueryload(models.LoadBalancer.amphorae),
+            noload('*'))
+
+        query = session.query(models.LoadBalancer).filter_by(**filters)
+        query = query.filter(models.Amphora.compute_flavor == host)
+        query = query.options(query_options)
+        if not deleted:
+            query = query.filter(
+                self.model_class.provisioning_status != consts.DELETED)
+
+        return [model.to_data_model() for model in query.all()]
+
+
+class PoolRepository(repositories.PoolRepository):
+    def get_pending_from_host(self, session, host=CONF.host):
+        """Get a list of pending pools from specific host
+
+        :param session: A Sql Alchemy database session.
+        :param host: specify amphora host to fetch loadbalancer from.
+        :returns: [octavia.common.data_model]
+        """
+
+        query = session.query(models.Pool)
+        query = query.filter(models.Amphora.compute_flavor == host,
+                             models.Pool.provisioning_status.in_([
+                                 lib_consts.PENDING_UPDATE,
+                                 lib_consts.PENDING_CREATE
+                             ]))
+
+        return [model.to_data_model() for model in query.all()]
+
+
+class L7PolicyRepository(repositories.L7PolicyRepository):
+    def get_pending_from_host(self, session, host=CONF.host):
+        """Get a list of pending l7policies from specific host
+
+        :param session: A Sql Alchemy database session.
+        :param host: specify amphora host to fetch loadbalancer from.
+        :returns: [octavia.common.data_model]
+        """
+
+        query = session.query(models.L7Policy)
+        query = query.filter(models.Amphora.compute_flavor == host,
+                             models.L7Policy.provisioning_status.in_([
+                                 lib_consts.PENDING_UPDATE,
+                                 lib_consts.PENDING_CREATE
+                             ]))
+
+        return [model.to_data_model() for model in query.all()]

--- a/octavia_f5/network/drivers/neutron/hierarchical_port_binding.py
+++ b/octavia_f5/network/drivers/neutron/hierarchical_port_binding.py
@@ -13,29 +13,33 @@
 # under the License.
 
 from neutronclient.common import exceptions as neutron_client_exceptions
-from oslo_log import log as logging
+from oslo_cache import core as cache
 from oslo_config import cfg
+from oslo_log import log as logging
 
+from octavia.db import api as db_apis
 from octavia.i18n import _
 from octavia.network import base
-from octavia.network.drivers.neutron import allowed_address_pairs
+from octavia.network.drivers.neutron import allowed_address_pairs as aap
 from octavia.network.drivers.neutron import utils
 from octavia_f5.common import constants
+from octavia_f5.db import repositories
 
 LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
-
 PROJECT_ID_ALIAS = 'project-id'
 
+cache.configure(CONF)
+cache_region = cache.create_region()
+MEMOIZE = cache.get_memoization_decorator(
+    CONF, cache_region, "networking")
+cache.configure_cache_region(CONF, cache_region)
 
-class HierachicalPortBindingDriver(allowed_address_pairs.AllowedAddressPairsDriver):
+
+class HierachicalPortBindingDriver(aap.AllowedAddressPairsDriver):
     def __init__(self):
         super(HierachicalPortBindingDriver, self).__init__()
-        cfg_physical = cfg.StrOpt('f5_network_segment_physical_network', default="",
-                                  help=_('Restrict discovery of network segmentation ID '
-                                         'to a specific physical network name.'))
-        CONF.register_opt(cfg_physical,
-                          group='networking')
+        self.amp_repo = repositories.AmphoraRepository()
 
     def allocate_vip(self, load_balancer):
         port_id = load_balancer.vip.port_id
@@ -55,6 +59,20 @@ class HierachicalPortBindingDriver(allowed_address_pairs.AllowedAddressPairsDriv
             project_id_key = 'project_id'
         else:
             project_id_key = 'tenant_id'
+
+        # select a candidate to schedule to
+        try:
+            session = db_apis.get_session()
+            candidate = self.amp_repo.get_candidates(session)[0]
+        except ValueError as e:
+            message = _('Scheduling failed, no ready candidates found')
+            LOG.exception(message)
+            raise base.AllocateVIPException(
+                message,
+                orig_msg=getattr(e, 'message', None),
+                orig_code=getattr(e, 'status_code', None),
+            )
+        LOG.debug("Found candidates for new LB %s: %s", load_balancer.id, candidate)
 
         # It can be assumed that network_id exists
         port = {'port': {'name': 'octavia-lb-{}'.format(load_balancer.id),
@@ -108,6 +126,17 @@ class HierachicalPortBindingDriver(allowed_address_pairs.AllowedAddressPairsDriv
             LOG.info("Port %s will not be deleted by Octavia as it was "
                      "not created by Octavia.", vip.port_id)
 
+    @MEMOIZE
+    def get_scheduled_host(self, port_id):
+        """ Returns binding host port has been scheduled
+
+        :param port_id: the neutron port id
+        :return: hostname of the binding host
+        """
+        res = self.neutron_client.show_port(port_id)
+        return res['port']['binding:host_id']
+
+    @MEMOIZE
     def get_segmentation_id(self, network_id):
         physical_network = CONF.networking.f5_network_segment_physical_network
         # List neutron ports associated with the Amphora

--- a/octavia_f5/network/drivers/neutron/hierarchical_port_binding.py
+++ b/octavia_f5/network/drivers/neutron/hierarchical_port_binding.py
@@ -146,4 +146,5 @@ class HierachicalPortBindingDriver(aap.AllowedAddressPairsDriver):
                     return segment['provider:segmentation_id']
         except Exception as e:
             LOG.error('Error retrieving segmentation id for network "%s": %s', network_id, e)
-        return 0
+            raise e
+        raise base.NetworkException('No segmentation id for network "%s" found', network_id)

--- a/octavia_f5/network/drivers/neutron/hierarchical_port_binding.py
+++ b/octavia_f5/network/drivers/neutron/hierarchical_port_binding.py
@@ -75,13 +75,12 @@ class HierachicalPortBindingDriver(aap.AllowedAddressPairsDriver):
         LOG.debug("Found candidates for new LB %s: %s", load_balancer.id, candidate)
 
         # It can be assumed that network_id exists
-        port = {'port': {'name': 'octavia-lb-{}'.format(load_balancer.id),
+        port = {'port': {'name': 'loadbalancer-{}'.format(load_balancer.id),
                          'network_id': load_balancer.vip.network_id,
-                         'admin_state_up': False,
-                         'device_id': 'lb-{0}'.format(load_balancer.id),
+                         'admin_state_up': True,
+                         'device_id': load_balancer.id,
                          'device_owner': constants.DEVICE_OWNER_LISTENER,
-                         # TODO: needs to be auto-scheduled by agent
-                         'binding:host_id': 'f512-01',
+                         'binding:host_id': candidate,
                          project_id_key: load_balancer.project_id}}
 
         if fixed_ip:

--- a/octavia_f5/network/drivers/noop_driver_f5/driver.py
+++ b/octavia_f5/network/drivers/noop_driver_f5/driver.py
@@ -12,16 +12,24 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from oslo_config import cfg
 from oslo_log import log as logging
 
 from octavia.network.drivers.noop_driver import driver
 
 LOG = logging.getLogger(__name__)
+CONF = cfg.CONF
 
 
 class NoopNetworkDriverF5(driver.NoopNetworkDriver):
     def __init__(self):
         super(NoopNetworkDriverF5, self).__init__()
+
+    def allocate_vip(self, load_balancer):
+        return super(NoopNetworkDriverF5, self).allocate_vip(load_balancer)
+
+    def get_scheduled_host(self, port_id):
+        return CONF.host
 
     def get_segmentation_id(self, network_id):
         return 1234

--- a/octavia_f5/restclient/as3restclient.py
+++ b/octavia_f5/restclient/as3restclient.py
@@ -153,7 +153,7 @@ class BigipAS3RestClient(object):
         params = kwargs.copy()
         params.update({'op': operation, 'path': path})
         response = self.session.patch(self._url(AS3_DECLARE_PATH), json=[params])
-        self._metric_httpstatus.labels(method='patch', httpstatus=response.status_code).inc()
+        self._metric_httpstatus.labels(method='patch', statuscode=response.status_code).inc()
         if response.headers.get('Content-Type') == 'application/json':
             LOG.debug(json.dumps(json.loads(response.text), indent=4, sort_keys=True))
         else:
@@ -172,7 +172,7 @@ class BigipAS3RestClient(object):
 
         LOG.debug("Calling DELETE for tenants %s", tenants)
         response = self.session.delete(self._url('{}/{}'.format(AS3_DECLARE_PATH, ','.join(tenants))))
-        self._metric_httpstatus.labels(method='delete', httpstatus=response.status_code).inc()
+        self._metric_httpstatus.labels(method='delete', statuscode=response.status_code).inc()
         LOG.debug("DELETE finished with %d", response.status_code)
         if response.headers.get('Content-Type') == 'application/json':
             LOG.debug(json.dumps(json.loads(response.text)['results'], indent=4, sort_keys=True))

--- a/octavia_f5/tests/unit/api/__init__.py
+++ b/octavia_f5/tests/unit/api/__init__.py
@@ -1,0 +1,11 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.

--- a/octavia_f5/tests/unit/api/drivers/__init__.py
+++ b/octavia_f5/tests/unit/api/drivers/__init__.py
@@ -1,0 +1,11 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.

--- a/octavia_f5/tests/unit/api/drivers/f5_provider_driver/__init__.py
+++ b/octavia_f5/tests/unit/api/drivers/f5_provider_driver/__init__.py
@@ -1,0 +1,11 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.

--- a/octavia_f5/tests/unit/api/drivers/f5_provider_driver/test_f5_driver.py
+++ b/octavia_f5/tests/unit/api/drivers/f5_provider_driver/test_f5_driver.py
@@ -1,0 +1,299 @@
+# Copyright 2020 SAP SE
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import mock
+from oslo_config import cfg
+from oslo_config import fixture as oslo_fixture
+
+from octavia.common import constants as consts
+from octavia.tests.unit import base
+from octavia.tests.unit.api.drivers import sample_data_models
+from octavia_f5.api.drivers.f5_driver import driver
+from octavia_lib.api.drivers import data_models as driver_dm
+
+
+class TestF5Driver(base.TestRpc):
+
+    def setUp(self):
+        super(TestF5Driver, self).setUp()
+        conf = self.useFixture(oslo_fixture.Config(cfg.CONF))
+        self.patches = [
+            mock.patch('octavia.db.repositories.AmphoraRepository.get'),
+            mock.patch('octavia.db.api.get_session')
+        ]
+        conf.config(group="oslo_messaging", topic='foo_topic')
+        self.amp_driver = driver.F5ProviderDriver()
+        self.sample_data = sample_data_models.SampleDriverDataModels()
+
+        for patch in self.patches:
+            patch.start()
+
+    def tearDown(self):
+        super(TestF5Driver, self).tearDown()
+        for patch in self.patches:
+            patch.stop()
+
+    # Load Balancer
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_loadbalancer_create(self, mock_cast):
+        provider_lb = driver_dm.LoadBalancer(
+            loadbalancer_id=self.sample_data.lb_id)
+        self.amp_driver.loadbalancer_create(provider_lb)
+        payload = {consts.LOAD_BALANCER_ID: self.sample_data.lb_id,
+                   consts.FLAVOR: None}
+        mock_cast.assert_called_with({}, 'create_load_balancer', **payload)
+
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_loadbalancer_delete(self, mock_cast):
+        provider_lb = driver_dm.LoadBalancer(
+            loadbalancer_id=self.sample_data.lb_id)
+        self.amp_driver.loadbalancer_delete(provider_lb)
+        payload = {consts.LOAD_BALANCER_ID: self.sample_data.lb_id,
+                   'cascade': False}
+        mock_cast.assert_called_with({}, 'delete_load_balancer', **payload)
+
+    # Listener
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_listener_create(self, mock_cast):
+        provider_listener = driver_dm.Listener(
+            listener_id=self.sample_data.listener1_id)
+        self.amp_driver.listener_create(provider_listener)
+        payload = {consts.LISTENER_ID: self.sample_data.listener1_id}
+        mock_cast.assert_called_with({}, 'create_listener', **payload)
+
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_listener_delete(self, mock_cast):
+        provider_listener = driver_dm.Listener(
+            listener_id=self.sample_data.listener1_id)
+        self.amp_driver.listener_delete(provider_listener)
+        payload = {consts.LISTENER_ID: self.sample_data.listener1_id}
+        mock_cast.assert_called_with({}, 'delete_listener', **payload)
+
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_listener_update(self, mock_cast):
+        old_provider_listener = driver_dm.Listener(
+            listener_id=self.sample_data.listener1_id)
+        provider_listener = driver_dm.Listener(
+            listener_id=self.sample_data.listener1_id, admin_state_up=False)
+        self.amp_driver.listener_update(old_provider_listener,
+                                        provider_listener)
+        payload = {consts.LISTENER_ID: self.sample_data.listener1_id,
+                   consts.LISTENER_UPDATES: {}}
+        mock_cast.assert_called_with({}, 'update_listener', **payload)
+
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_listener_update_name(self, mock_cast):
+        old_provider_listener = driver_dm.Listener(
+            listener_id=self.sample_data.listener1_id)
+        provider_listener = driver_dm.Listener(
+            listener_id=self.sample_data.listener1_id, name='Great Listener')
+        self.amp_driver.listener_update(old_provider_listener,
+                                        provider_listener)
+        payload = {consts.LISTENER_ID: self.sample_data.listener1_id,
+                   consts.LISTENER_UPDATES: {}}
+        mock_cast.assert_called_with({}, 'update_listener', **payload)
+
+    # Pool
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_pool_create(self, mock_cast):
+        provider_pool = driver_dm.Pool(
+            pool_id=self.sample_data.pool1_id)
+        self.amp_driver.pool_create(provider_pool)
+        payload = {consts.POOL_ID: self.sample_data.pool1_id}
+        mock_cast.assert_called_with({}, 'create_pool', **payload)
+
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_pool_delete(self, mock_cast):
+        provider_pool = driver_dm.Pool(
+            pool_id=self.sample_data.pool1_id)
+        self.amp_driver.pool_delete(provider_pool)
+        payload = {consts.POOL_ID: self.sample_data.pool1_id}
+        mock_cast.assert_called_with({}, 'delete_pool', **payload)
+
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_pool_update(self, mock_cast):
+        old_provider_pool = driver_dm.Pool(
+            pool_id=self.sample_data.pool1_id)
+        provider_pool = driver_dm.Pool(
+            pool_id=self.sample_data.pool1_id, admin_state_up=True)
+        self.amp_driver.pool_update(old_provider_pool, provider_pool)
+        payload = {consts.POOL_ID: self.sample_data.pool1_id,
+                   consts.POOL_UPDATES: {}}
+        mock_cast.assert_called_with({}, 'update_pool', **payload)
+
+    # Member
+    @mock.patch('octavia.db.repositories.PoolRepository.get')
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_member_create(self, mock_cast, mock_pool_get):
+        provider_member = driver_dm.Member(
+            member_id=self.sample_data.member1_id)
+        self.amp_driver.member_create(provider_member)
+        payload = {consts.MEMBER_ID: self.sample_data.member1_id}
+        mock_cast.assert_called_with({}, 'create_member', **payload)
+
+    @mock.patch('octavia.db.repositories.PoolRepository.get')
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_member_create_udp_ipv4(self, mock_cast, mock_pool_get):
+        mock_lb = mock.MagicMock()
+        mock_lb.vip = mock.MagicMock()
+        mock_lb.vip.ip_address = "192.0.1.1"
+        mock_listener = mock.MagicMock()
+        mock_listener.load_balancer = mock_lb
+        mock_pool = mock.MagicMock()
+        mock_pool.protocol = consts.PROTOCOL_UDP
+        mock_pool.listeners = [mock_listener]
+        mock_pool_get.return_value = mock_pool
+
+        provider_member = driver_dm.Member(
+            member_id=self.sample_data.member1_id,
+            address="192.0.2.1")
+        self.amp_driver.member_create(provider_member)
+        payload = {consts.MEMBER_ID: self.sample_data.member1_id}
+        mock_cast.assert_called_with({}, 'create_member', **payload)
+
+    @mock.patch('octavia.db.repositories.PoolRepository.get')
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_member_create_udp_ipv4_ipv6(self, mock_cast, mock_pool_get):
+        mock_lb = mock.MagicMock()
+        mock_lb.vip = mock.MagicMock()
+        mock_lb.vip.ip_address = "fe80::1"
+        mock_listener = mock.MagicMock()
+        mock_listener.load_balancer = mock_lb
+        mock_pool = mock.MagicMock()
+        mock_pool.protocol = consts.PROTOCOL_UDP
+        mock_pool.listeners = [mock_listener]
+        mock_pool_get.return_value = mock_pool
+
+        provider_member = driver_dm.Member(
+            member_id=self.sample_data.member1_id,
+            address="192.0.2.1")
+        self.amp_driver.member_create(provider_member)
+        payload = {consts.MEMBER_ID: self.sample_data.member1_id}
+        mock_cast.assert_called_with({}, 'create_member', **payload)
+
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_member_delete(self, mock_cast):
+        provider_member = driver_dm.Member(
+            member_id=self.sample_data.member1_id)
+        self.amp_driver.member_delete(provider_member)
+        payload = {consts.MEMBER_ID: self.sample_data.member1_id}
+        mock_cast.assert_called_with({}, 'delete_member', **payload)
+
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_member_update(self, mock_cast):
+        old_provider_member = driver_dm.Member(
+            member_id=self.sample_data.member1_id)
+        provider_member = driver_dm.Member(
+            member_id=self.sample_data.member1_id, admin_state_up=True)
+        self.amp_driver.member_update(old_provider_member, provider_member)
+        payload = {consts.MEMBER_ID: self.sample_data.member1_id,
+                   consts.MEMBER_UPDATES: {}}
+        mock_cast.assert_called_with({}, 'update_member', **payload)
+
+    # L7 Policy
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_l7policy_create(self, mock_cast):
+        provider_l7policy = driver_dm.L7Policy(
+            l7policy_id=self.sample_data.l7policy1_id)
+        self.amp_driver.l7policy_create(provider_l7policy)
+        payload = {consts.L7POLICY_ID: self.sample_data.l7policy1_id}
+        mock_cast.assert_called_with({}, 'create_l7policy', **payload)
+
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_l7policy_delete(self, mock_cast):
+        provider_l7policy = driver_dm.L7Policy(
+            l7policy_id=self.sample_data.l7policy1_id)
+        self.amp_driver.l7policy_delete(provider_l7policy)
+        payload = {consts.L7POLICY_ID: self.sample_data.l7policy1_id}
+        mock_cast.assert_called_with({}, 'delete_l7policy', **payload)
+
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_l7policy_update(self, mock_cast):
+        old_provider_l7policy = driver_dm.L7Policy(
+            l7policy_id=self.sample_data.l7policy1_id)
+        provider_l7policy = driver_dm.L7Policy(
+            l7policy_id=self.sample_data.l7policy1_id, admin_state_up=True)
+        self.amp_driver.l7policy_update(old_provider_l7policy,
+                                        provider_l7policy)
+        payload = {consts.L7POLICY_ID: self.sample_data.l7policy1_id,
+                   consts.L7POLICY_UPDATES: {}}
+        mock_cast.assert_called_with({}, 'update_l7policy', **payload)
+
+    # Health Monitor
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_health_monitor_create(self, mock_cast):
+        provider_HM = driver_dm.HealthMonitor(
+            healthmonitor_id=self.sample_data.hm1_id)
+        self.amp_driver.health_monitor_create(provider_HM)
+        payload = {consts.HEALTH_MONITOR_ID: self.sample_data.hm1_id}
+        mock_cast.assert_called_with({}, 'create_health_monitor', **payload)
+
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_health_monitor_delete(self, mock_cast):
+        provider_HM = driver_dm.HealthMonitor(
+            healthmonitor_id=self.sample_data.hm1_id)
+        self.amp_driver.health_monitor_delete(provider_HM)
+        payload = {consts.HEALTH_MONITOR_ID: self.sample_data.hm1_id}
+        mock_cast.assert_called_with({}, 'delete_health_monitor', **payload)
+
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_health_monitor_update(self, mock_cast):
+        old_provider_hm = driver_dm.HealthMonitor(
+            healthmonitor_id=self.sample_data.hm1_id)
+        provider_hm = driver_dm.HealthMonitor(
+            healthmonitor_id=self.sample_data.hm1_id, admin_state_up=True,
+            max_retries=1, max_retries_down=2)
+        self.amp_driver.health_monitor_update(old_provider_hm, provider_hm)
+        payload = {consts.HEALTH_MONITOR_ID: self.sample_data.hm1_id,
+                   consts.HEALTH_MONITOR_UPDATES: {}}
+        mock_cast.assert_called_with({}, 'update_health_monitor', **payload)
+
+    # L7 Rules
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_l7rule_create(self, mock_cast):
+        provider_l7rule = driver_dm.L7Rule(
+            l7rule_id=self.sample_data.l7rule1_id)
+        self.amp_driver.l7rule_create(provider_l7rule)
+        payload = {consts.L7RULE_ID: self.sample_data.l7rule1_id}
+        mock_cast.assert_called_with({}, 'create_l7rule', **payload)
+
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_l7rule_delete(self, mock_cast):
+        provider_l7rule = driver_dm.L7Rule(
+            l7rule_id=self.sample_data.l7rule1_id)
+        self.amp_driver.l7rule_delete(provider_l7rule)
+        payload = {consts.L7RULE_ID: self.sample_data.l7rule1_id}
+        mock_cast.assert_called_with({}, 'delete_l7rule', **payload)
+
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_l7rule_update(self, mock_cast):
+        old_provider_l7rule = driver_dm.L7Rule(
+            l7rule_id=self.sample_data.l7rule1_id)
+        provider_l7rule = driver_dm.L7Rule(
+            l7rule_id=self.sample_data.l7rule1_id, admin_state_up=True)
+        self.amp_driver.l7rule_update(old_provider_l7rule, provider_l7rule)
+        payload = {consts.L7RULE_ID: self.sample_data.l7rule1_id,
+                   consts.L7RULE_UPDATES: {}}
+        mock_cast.assert_called_with({}, 'update_l7rule', **payload)
+
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_l7rule_update_invert(self, mock_cast):
+        old_provider_l7rule = driver_dm.L7Rule(
+            l7rule_id=self.sample_data.l7rule1_id)
+        provider_l7rule = driver_dm.L7Rule(
+            l7rule_id=self.sample_data.l7rule1_id, invert=True)
+        self.amp_driver.l7rule_update(old_provider_l7rule, provider_l7rule)
+        payload = {consts.L7RULE_ID: self.sample_data.l7rule1_id,
+                   consts.L7RULE_UPDATES: {}}
+        mock_cast.assert_called_with({}, 'update_l7rule', **payload)

--- a/octavia_f5/tests/unit/api/drivers/f5_provider_driver/test_f5_driver.py
+++ b/octavia_f5/tests/unit/api/drivers/f5_provider_driver/test_f5_driver.py
@@ -33,6 +33,7 @@ class TestF5Driver(base.TestRpc):
             mock.patch('octavia.db.api.get_session')
         ]
         conf.config(group="oslo_messaging", topic='foo_topic')
+        conf.config(group="controller_worker", network_driver='network_noop_driver_f5')
         self.amp_driver = driver.F5ProviderDriver()
         self.sample_data = sample_data_models.SampleDriverDataModels()
 

--- a/octavia_f5/tests/unit/controller/__init__.py
+++ b/octavia_f5/tests/unit/controller/__init__.py
@@ -1,0 +1,11 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.

--- a/octavia_f5/tests/unit/controller/worker/__init__.py
+++ b/octavia_f5/tests/unit/controller/worker/__init__.py
@@ -1,0 +1,11 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.

--- a/octavia_f5/tests/unit/controller/worker/test_endpoint.py
+++ b/octavia_f5/tests/unit/controller/worker/test_endpoint.py
@@ -1,0 +1,44 @@
+# Copyright 2020 SAP SE
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import mock
+from oslo_config import cfg
+from oslo_config import fixture as oslo_fixture
+from oslo_utils import uuidutils
+
+from octavia.controller.queue import endpoint
+from octavia.controller.worker import controller_worker
+from octavia.tests.unit.controller.queue import test_endpoint
+
+
+class TestEndpoint(test_endpoint.TestEndpoint):
+
+    def setUp(self):
+        super(TestEndpoint, self).setUp()
+
+        conf = self.useFixture(oslo_fixture.Config(cfg.CONF))
+        conf.config(octavia_plugins='f5_plugin')
+
+        mock_class = mock.create_autospec(controller_worker.ControllerWorker)
+        self.worker_patcher = mock.patch('octavia.controller.queue.endpoint.'
+                                         'stevedore_driver')
+        self.worker_patcher.start().ControllerWorker = mock_class
+
+        self.ep = endpoint.Endpoint()
+        self.context = {}
+        self.resource_updates = {}
+        self.resource_id = 1234
+        self.server_group_id = 3456
+        self.flavor_id = uuidutils.generate_uuid()
+


### PR DESCRIPTION
loadbalancers will be automatically scheduled to the device with the lowest
amount of listeners.
(amphorae with loadbalancer_id == None and status == AMPHORAE_READY are
BigIP devices)

After scheduling, the agent creates an amphora binding with amphora.id ==
loadbalancer.id.

In case of failed scheduling, the reconciliation loop of any working agent
will pick up the pending loadbalancer and associate it.

fixes #4