### PR TITLE
Multiple Fixes for as3, sanitation

### DIFF
--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -477,6 +477,8 @@ class ControllerWorker(object):
         device_amp = self._amphora_repo.get(
             db_apis.get_session(),
             load_balancer_id=load_balancer_id)
+
+        # create amphora mapping if missing
         if not device_amp:
             self._amphora_repo.create(
                 db_apis.get_session(),
@@ -484,11 +486,13 @@ class ControllerWorker(object):
                 load_balancer_id=load_balancer_id,
                 compute_flavor=CONF.host,
                 status=lib_consts.ACTIVE)
+
+        # update host if not updated yet
         if device_amp.compute_flavor != CONF.host:
             self._amphora_repo.update(
                 db_apis.get_session(),
-                device_amp.id,
-                **{'compute_flavor': CONF.host})
+                id=device_amp.id,
+                compute_flavor=CONF.host)
 
     def create_amphora(self):
         pass

--- a/octavia_f5/restclient/as3objects/certificate.py
+++ b/octavia_f5/restclient/as3objects/certificate.py
@@ -15,6 +15,7 @@
 import base64
 
 from octavia_f5.common import constants
+from octavia_f5.restclient import as3types
 from octavia_f5.restclient.as3classes import Certificate, CA_Bundle
 
 
@@ -42,7 +43,7 @@ def get_certificate(remark, tlscontainer):
             return pem
 
     service_args = {
-        'remark': remark,
+        'remark': as3types.f5remark(remark),
         'certificate': _decode(tlscontainer.certificate)
     }
 
@@ -66,8 +67,8 @@ def get_ca_bundle(bundle, remark='', label=''):
     :return: AS3 CA_Bundle
     """
     service_args = {
-        'remark': remark,
-        'label': label,
+        'remark': as3types.f5remark(remark),
+        'label': as3types.f5label(label),
         'bundle': bundle.decode('utf-8').replace('\r',  '')
     }
     return CA_Bundle(**service_args)

--- a/octavia_f5/restclient/as3objects/policy_endpoint.py
+++ b/octavia_f5/restclient/as3objects/policy_endpoint.py
@@ -11,32 +11,38 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+
 from octavia_f5.restclient import as3types
 from octavia_f5.restclient.as3classes import *
-from octavia_f5.utils.exceptions import *
 from octavia_f5.restclient.as3objects import pool
+from octavia_f5.utils.exceptions import *
+
+COMPARE_TYPE_MAP = {
+    'STARTS_WITH': 'starts-with',
+    'ENDS_WITH': 'ends-with',
+    'CONTAINS': 'contains',
+    'EQUAL_TO': 'equals'
+}
+COND_TYPE_MAP = {
+    'HOST_NAME': {'match_key': 'host', 'type': 'httpUri'},
+    'PATH': {'match_key': 'path', 'type': 'httpUri'},
+    'FILE_TYPE': {'match_key': 'extension', 'type': 'httpUri'},
+    'HEADER': {'match_key': 'all', 'type': 'httpHeader'},
+    'SSL_DN_FIELD': {'match_key': 'serverName', 'type': 'sslExtension'}
+}
+SUPPORTED_ACTION_TYPE = [
+    'REDIRECT_TO_POOL',
+    'REDIRECT_TO_URL',
+    'REJECT'
+]
 
 
 def get_name(policy_id):
     return constants.PREFIX_POLICY + \
-           policy_id.replace('/', '').replace('-','_')
+           policy_id.replace('/', '').replace('-', '_')
 
 
 def _get_condition(l7rule):
-    COMPARE_TYPE_MAP = {
-        'STARTS_WITH': 'startsWith',
-        'ENDS_WITH': 'endsWith',
-        'CONTAINS': 'contains',
-        'EQUAL_TO': 'equals'
-    }
-    COND_TYPE_MAP = {
-        'HOST_NAME': {'match_key': 'host', 'type': 'httpUri'},
-        'PATH': {'match_key': 'path', 'type': 'httpUri'},
-        'FILE_TYPE': {'match_key': 'extension', 'type': 'httpUri'},
-        'HEADER': {'match_key': 'all', 'type': 'httpHeader'},
-        'SSL_DN_FIELD': {'match_key': 'serverName', 'type': 'sslExtension'}
-    }
-
     if l7rule.type not in COND_TYPE_MAP:
         raise PolicyTypeNotSupported()
     if l7rule.compare_type not in COMPARE_TYPE_MAP:
@@ -55,7 +61,6 @@ def _get_condition(l7rule):
 
 def _get_action(l7policy):
     # TODO!!! REDIRECT_PREFIX (http://abc.de -> https://abc.de)
-    SUPPORTED_ACTION_TYPE = ['REDIRECT_TO_POOL', 'REDIRECT_TO_URL', 'REJECT']
     if l7policy.action not in SUPPORTED_ACTION_TYPE:
         raise PolicyActionNotSupported()
 

--- a/octavia_f5/restclient/as3objects/policy_endpoint.py
+++ b/octavia_f5/restclient/as3objects/policy_endpoint.py
@@ -11,7 +11,7 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-
+from octavia_f5.restclient import as3types
 from octavia_f5.restclient.as3classes import *
 from octavia_f5.utils.exceptions import *
 from octavia_f5.restclient.as3objects import pool
@@ -78,9 +78,9 @@ def _get_action(l7policy):
 def get_endpoint_policy(l7policy):
     args = dict()
     if l7policy.name:
-        args['label'] = l7policy.name
+        args['label'] = as3types.f5label(l7policy.name)
     if l7policy.description:
-        args['remark'] = l7policy.description
+        args['remark'] = as3types.f5remark(l7policy.description)
     args['rules'] = [Endpoint_Policy_Rule(
         name=get_name(l7policy.id),
         conditions=[_get_condition(l7rule) for l7rule in l7policy.l7rules],

--- a/octavia_f5/restclient/as3objects/policy_endpoint.py
+++ b/octavia_f5/restclient/as3objects/policy_endpoint.py
@@ -23,6 +23,12 @@ COMPARE_TYPE_MAP = {
     'CONTAINS': 'contains',
     'EQUAL_TO': 'equals'
 }
+COMPARE_TYPE_INVERT_MAP = {
+    'STARTS_WITH': 'does-not-start-with',
+    'ENDS_WITH': 'does-not-end-with',
+    'CONTAINS': 'does-not-contain',
+    'EQUAL_TO': 'does-not-equal'
+}
 COND_TYPE_MAP = {
     'HOST_NAME': {'match_key': 'host', 'type': 'httpUri'},
     'PATH': {'match_key': 'path', 'type': 'httpUri'},
@@ -47,11 +53,12 @@ def _get_condition(l7rule):
         raise PolicyTypeNotSupported()
     if l7rule.compare_type not in COMPARE_TYPE_MAP:
         raise CompareTypeNotSupported()
-    if l7rule.invert:
-        raise PolicyRuleInvertNotSupported()
 
     args = dict()
-    operand = COMPARE_TYPE_MAP[l7rule.compare_type]
+    if l7rule.invert:
+        operand = COMPARE_TYPE_INVERT_MAP[l7rule.compare_type]
+    else:
+        operand = COMPARE_TYPE_MAP[l7rule.compare_type]
     condition = COND_TYPE_MAP[l7rule.type]
     compare_string = Policy_Compare_String(operand=operand, values=[l7rule.value])
     args[condition['match_key']] = compare_string

--- a/octavia_f5/restclient/as3objects/pool.py
+++ b/octavia_f5/restclient/as3objects/pool.py
@@ -16,6 +16,7 @@
 from octavia_f5.common import constants
 from oslo_log import log as logging
 
+from octavia_f5.restclient import as3types
 from octavia_f5.restclient.as3classes import Pool, Pointer
 from octavia_f5.restclient.as3objects import monitor as m_monitor
 from octavia_f5.restclient.as3objects import pool_member as m_member
@@ -45,8 +46,8 @@ def get_pool(pool):
     lbmode = _set_lb_method(lbaas_lb_method, pool.members)
 
     service_args = {
-        'label': (pool.name or pool.id)[:64],
-        'remark': (pool.description or pool.id)[:64],
+        'label': as3types.f5label(pool.name or pool.id),
+        'remark': as3types.f5remark(pool.description or pool.id),
         'loadBalancingMode': lbmode,
         'members': [],
     }

--- a/octavia_f5/restclient/as3objects/pool_member.py
+++ b/octavia_f5/restclient/as3objects/pool_member.py
@@ -13,6 +13,7 @@
 # under the License.
 
 from octavia_f5.common import constants
+from octavia_f5.restclient import as3types
 from octavia_f5.restclient.as3classes import Member
 
 
@@ -37,5 +38,5 @@ def get_member(member):
     else:
         args['ratio'] = member.weight
 
-    args['remark'] = member.id
+    args['remark'] = as3types.f5remark(member.id)
     return Member(**args)

--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -103,15 +103,14 @@ def get_service(listener, cert_manager):
     entities = []
     vip = listener.load_balancer.vip
     project_id = listener.load_balancer.project_id
+    label = as3types.f5label(listener.description or listener.id)
     service_args = {
         'virtualPort': listener.protocol_port,
         'virtualAddresses': [vip.ip_address],
         'persistenceMethods': [],
-        'iRules': []
+        'iRules': [],
+        'label': label
     }
-
-    if listener.description:
-        service_args['label'] = as3types.f5label(listener.description or listener.id)
 
     # Determine service type
     if listener.protocol == const.PROTOCOL_TCP:

--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -17,7 +17,7 @@ from oslo_log import log as logging
 
 from octavia.common import exceptions
 from octavia_f5.common import constants as const
-from octavia_f5.restclient import as3classes as as3
+from octavia_f5.restclient import as3classes as as3, as3types
 from octavia_f5.restclient.as3objects import certificate as m_cert
 from octavia_f5.restclient.as3objects import irule as m_irule
 from octavia_f5.restclient.as3objects import persist as m_persist
@@ -111,7 +111,7 @@ def get_service(listener, cert_manager):
     }
 
     if listener.description:
-        service_args['label'] = listener.description
+        service_args['label'] = as3types.f5label(listener.description or listener.id)
 
     # Determine service type
     if listener.protocol == const.PROTOCOL_TCP:

--- a/octavia_f5/restclient/as3objects/tls.py
+++ b/octavia_f5/restclient/as3objects/tls.py
@@ -51,7 +51,7 @@ def get_tls_server(certificate_ids, authentication_ca=None, authentication_mode=
     }
 
     service_args = {
-        'certificates': [{'certificate': cert_id} for cert_id in certificate_ids]
+        'certificates': [{'certificate': cert_id} for cert_id in set(certificate_ids)]
     }
 
     if authentication_ca:

--- a/octavia_f5/restclient/as3restclient.py
+++ b/octavia_f5/restclient/as3restclient.py
@@ -23,6 +23,8 @@ from requests.auth import HTTPBasicAuth
 from six.moves.urllib import parse
 from urllib3.util.retry import Retry
 
+from octavia_f5.utils import exceptions
+
 LOG = logging.getLogger(__name__)
 
 AS3_LOGIN_PATH = '/mgmt/shared/authn/login'
@@ -101,6 +103,20 @@ class BigipAS3RestClient(object):
         session.verify = self.enable_verify
         return session
 
+    @staticmethod
+    def _check_response(response):
+        if response.headers.get('Content-Type') == 'application/json':
+            text = response.json()
+            if not response.ok:
+                if 'errors' in text:
+                    raise exceptions.AS3Exception(text.get('errors'))
+                if 'message' in text:
+                    raise exceptions.AS3Exception(text.get('message'))
+            else:
+                LOG.debug(json.dumps(text.get('results'), indent=4, sort_keys=True))
+        else:
+            LOG.debug(response.text)
+
     @_metric_authorization_exceptions.count_exceptions()
     @_metric_authorization_duration.time()
     def reauthorize(self):
@@ -136,10 +152,7 @@ class BigipAS3RestClient(object):
         response = self.session.post(self._url(AS3_DECLARE_PATH), **kwargs)
         self._metric_httpstatus.labels(method='post', statuscode=response.status_code).inc()
         LOG.debug("POST finished with %d", response.status_code)
-        if response.headers.get('Content-Type') == 'application/json':
-            LOG.debug(json.dumps(json.loads(response.text)['results'], indent=4, sort_keys=True))
-        else:
-            LOG.debug(response.text)
+        self._check_response(response)
         return response
 
     @_metric_patch_exceptions.count_exceptions()
@@ -154,10 +167,7 @@ class BigipAS3RestClient(object):
         params.update({'op': operation, 'path': path})
         response = self.session.patch(self._url(AS3_DECLARE_PATH), json=[params])
         self._metric_httpstatus.labels(method='patch', statuscode=response.status_code).inc()
-        if response.headers.get('Content-Type') == 'application/json':
-            LOG.debug(json.dumps(json.loads(response.text), indent=4, sort_keys=True))
-        else:
-            LOG.debug(response.text)
+        self._check_response(response)
         return response
 
     @_metric_delete_exceptions.count_exceptions()
@@ -174,8 +184,5 @@ class BigipAS3RestClient(object):
         response = self.session.delete(self._url('{}/{}'.format(AS3_DECLARE_PATH, ','.join(tenants))))
         self._metric_httpstatus.labels(method='delete', statuscode=response.status_code).inc()
         LOG.debug("DELETE finished with %d", response.status_code)
-        if response.headers.get('Content-Type') == 'application/json':
-            LOG.debug(json.dumps(json.loads(response.text)['results'], indent=4, sort_keys=True))
-        else:
-            LOG.debug(response.text)
+        self._check_response(response)
         return response

--- a/octavia_f5/restclient/as3types.py
+++ b/octavia_f5/restclient/as3types.py
@@ -1,4 +1,4 @@
-# Copyright 2019 SAP SE
+# Copyright 2019, 2020 SAP SE
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -11,3 +11,22 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+
+import re
+import unicodedata
+
+
+def f5remark(remark):
+    # Remove control characters.
+    nstr = "".join(ch for ch in remark
+                   if unicodedata.category(ch)[0] != "C")
+
+    # Remove double-quote (“), and backslash (\), limit to 64 characters.
+    return re.sub('["]', '', nstr)[:63]
+
+
+def f5label(label):
+    # Remove control characters and limit to 64 characters.
+    nstr = "".join(ch for ch in label
+                   if unicodedata.category(ch)[0] != "C")
+    return nstr[:63]

--- a/octavia_f5/restclient/as3types.py
+++ b/octavia_f5/restclient/as3types.py
@@ -22,11 +22,11 @@ def f5remark(remark):
                    if unicodedata.category(ch)[0] != "C")
 
     # Remove double-quote (“), and backslash (\), limit to 64 characters.
-    return re.sub('["]', '', nstr)[:63]
+    return re.sub('["]', '', nstr)[:64]
 
 
 def f5label(label):
     # Remove control characters and limit to 64 characters.
     nstr = "".join(ch for ch in label
                    if unicodedata.category(ch)[0] != "C")
-    return nstr[:63]
+    return nstr[:64]

--- a/octavia_f5/restclient/as3types.py
+++ b/octavia_f5/restclient/as3types.py
@@ -22,7 +22,7 @@ def f5remark(remark):
                    if unicodedata.category(ch)[0] != "C")
 
     # Remove double-quote (“), and backslash (\), limit to 64 characters.
-    return re.sub('["]', '', nstr)[:64]
+    return re.sub('["\\\\]', '', nstr)[:64]
 
 
 def f5label(label):

--- a/octavia_f5/utils/exceptions.py
+++ b/octavia_f5/utils/exceptions.py
@@ -13,20 +13,29 @@
 # under the License.
 
 
-class PolicyHasNoRules(Exception):
+class AS3Exception(Exception):
     pass
 
-class NoActionFoundForPolicy(Exception):
+
+class PolicyHasNoRules(AS3Exception):
     pass
 
-class CompareTypeNotSupported(Exception):
+
+class NoActionFoundForPolicy(AS3Exception):
     pass
 
-class PolicyTypeNotSupported(Exception):
+
+class CompareTypeNotSupported(AS3Exception):
     pass
 
-class PolicyRuleInvertNotSupported(Exception):
+
+class PolicyTypeNotSupported(AS3Exception):
     pass
 
-class PolicyActionNotSupported(Exception):
+
+class PolicyRuleInvertNotSupported(AS3Exception):
+    pass
+
+
+class PolicyActionNotSupported(AS3Exception):
     pass

--- a/octavia_f5/utils/exceptions.py
+++ b/octavia_f5/utils/exceptions.py
@@ -33,9 +33,5 @@ class PolicyTypeNotSupported(AS3Exception):
     pass
 
 
-class PolicyRuleInvertNotSupported(AS3Exception):
-    pass
-
-
 class PolicyActionNotSupported(AS3Exception):
     pass


### PR DESCRIPTION
depends on #46

This fixes following points:
 * [BUGFIX] do not use duplicate certificates (else AS3 Error)
 * [FEATURE] support inverted conditions
 * [BUGFIX] fixed wrongly-spelled as3 compare types
 * [BUGFIX] improve as3restclient debug logging in error case and throw exceptions
 * [BUGFIX] catch as3 exceptions in reconciliation loop and skip update