### PR TITLE
Map listener tags to Extended Service Definitions

### DIFF
--- a/octavia_f5/controller/worker/f5agent_driver.py
+++ b/octavia_f5/controller/worker/f5agent_driver.py
@@ -90,8 +90,18 @@ def tenant_update(bigip,
 
             # Translate L7policies to endpoint policies
             for l7policy in listener.l7policies:
+
+                # Skip policies marked for deletion
                 if utils.pending_delete(l7policy):
                     continue
+
+                # Skip ESD policies
+                # TODO: Remove this as soon as all customers have migrated their scripts.
+                #  Triggering ESDs via L7policies is considered deprecated. Tags should be used instead.
+                #  ESD tags are handled in octavia_f5/restclient/as3objects/service.py:279 so no need to do it here.
+                if bigip.esd.get_esd(l7policy.name):
+                    continue
+
                 app.add_endpoint_policy(
                     m_policy.get_name(l7policy.id),
                     m_policy.get_endpoint_policy(l7policy)

--- a/octavia_f5/controller/worker/f5agent_driver.py
+++ b/octavia_f5/controller/worker/f5agent_driver.py
@@ -83,39 +83,16 @@ def tenant_update(bigip,
         # Create generic application
         app = Application(constants.APPLICATION_GENERIC, label=loadbalancer.id)
 
-        # Attach L7Policies and ESDs to listeners
+        # Attach Octavia listeners as AS3 service objects
         for listener in loadbalancer.listeners:
-            if utils.pending_delete(listener):
-                continue
+            if not utils.pending_delete(listener):
+                service_entities = m_service.get_service(listener, cert_manager, bigip.esd)
+                app.add_entities(service_entities)
 
-            # Translate L7policies to endpoint policies
-            for l7policy in listener.l7policies:
-
-                # Skip policies marked for deletion
-                if utils.pending_delete(l7policy):
-                    continue
-
-                # Skip ESD policies
-                # TODO: Remove this as soon as all customers have migrated their scripts.
-                #  Triggering ESDs via L7policies is considered deprecated. Tags should be used instead.
-                #  ESD tags are handled in octavia_f5/restclient/as3objects/service.py:279 so no need to do it here.
-                if bigip.esd.get_esd(l7policy.name):
-                    continue
-
-                app.add_endpoint_policy(
-                    m_policy.get_name(l7policy.id),
-                    m_policy.get_endpoint_policy(l7policy)
-                )
-
-            # add service
-            service_entities = m_service.get_service(listener, cert_manager, bigip.esd)
-            app.add_entities(service_entities)
-
-        # attach pools
+        # Attach pools
         for pool in loadbalancer.pools:
-            if utils.pending_delete(pool):
-                continue
-            app.add_entities(m_pool.get_pool(pool))
+            if not utils.pending_delete(pool):
+                app.add_entities(m_pool.get_pool(pool))
 
         # Attach newly created application
         tenant.add_application(m_app.get_name(loadbalancer.id), app)

--- a/octavia_f5/restclient/as3classes.py
+++ b/octavia_f5/restclient/as3classes.py
@@ -123,8 +123,8 @@ class Application(BaseDescription):
         self.serviceMain = service  # noqa
 
     def add_entities(self, entities):
-        for name, entinty in entities:
-            setattr(self, name, entinty)
+        for name, entity in entities:
+            setattr(self, name, entity)
 
     def add_endpoint_policy(self, name, policy_endpoint):
         if hasattr(self, name):

--- a/octavia_f5/restclient/as3objects/irule.py
+++ b/octavia_f5/restclient/as3objects/irule.py
@@ -151,6 +151,9 @@ def get_header_irules(insert_headers):
     :param insert_headers: headers of listener (listener.insert_headers)
     :return: List of iRule entities (tuples with iRule name and definition)
     """
+
+    # Entities is a list of tuples, which each describe AS3 objects
+    # which may reference each other but do not form a hierarchy.
     entities = []
     if insert_headers.get('X-Forwarded-For', False):
         irule = IRule(X_FORWARDED_FOR,

--- a/octavia_f5/restclient/as3objects/pool.py
+++ b/octavia_f5/restclient/as3objects/pool.py
@@ -40,6 +40,9 @@ def get_pool(pool):
     :param pool: octavia pool object
     :return: AS3 pool
     """
+
+    # Entities is a list of tuples, which each describe AS3 objects
+    # which may reference each other but do not form a hierarchy.
     entities = []
     lbaas_lb_method = pool.lb_algorithm.upper()
     lbmode = _set_lb_method(lbaas_lb_method, pool.members)

--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -276,7 +276,7 @@ def get_service(listener, cert_manager, esd_repository):
         esd = esd_repository.get_esd(policy.name)
 
         # Add ESD or regular endpoint policy
-        if esd is not None:
+        if esd:
 
             # enrich service with iRules and other things defined in ESD
             esd_entities = get_esd_entities(service_args['_servicetype'], esd)

--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -43,9 +43,9 @@ def get_name(listener_id):
            listener_id.replace('/', '').replace('-', '_')
 
 
-def process_esd(servicetype, esd):
+def get_esd_entities(servicetype, esd):
     """
-    Translate F5 ESD (Enhanced Service Definition) into profile.
+    Map F5 ESD (Enhanced Service Definition) to service components.
 
     :param servicetype: octavia listener type
     :param esd: parsed ESD repository
@@ -91,13 +91,14 @@ def process_esd(servicetype, esd):
     return service_args
 
 
-def get_service(listener, cert_manager):
+def get_service(listener, cert_manager, esd_repository):
     """ Map Octavia listener -> AS3 Service
 
     :param listener: Octavia listener
     :param cert_manager: cert_manager wrapper instance
     :return: AS3 Service + additional AS3 application objects
     """
+
     # Entities is a list of tuples, which each describe AS3 objects
     # which may reference each other but do not form a hierarchy.
     entities = []
@@ -154,6 +155,7 @@ def get_service(listener, cert_manager):
         ))
         entities.extend([(cert['id'], cert['as3']) for cert in certificates])
 
+    # add profile
     if CONF.f5_agent.profile_l4:
         service_args['profileL4'] = as3.BigIP(CONF.f5_agent.profile_l4)
     if CONF.f5_agent.profile_multiplex:
@@ -254,6 +256,43 @@ def get_service(listener, cert_manager):
             if l7policy.provisioning_status != lib_consts.PENDING_DELETE
         ]
 
+    # Map listener tags to ESDs
+    for tag in listener.tags:
+
+        # get ESD of same name
+        esd = esd_repository.get_esd(tag)
+        if esd is None:
+            continue
+
+        # enrich service with iRules and other things defined in ESD
+        esd_entities = get_esd_entities(service_args['_servicetype'], esd)
+        for entity_name in esd_entities:
+            if entity_name == 'iRules':
+                service_args['iRules'].extend(esd_entities['iRules'])
+            else:
+                service_args[entity_name] = esd_entities[entity_name]
+
+    # Map special L7policies to ESDs
+    # TODO: Remove this as soon as all customers have migrated their scripts.
+    #  Triggering ESDs via L7policies is considered deprecated. Tags should be used instead. See the code above.
+    for policy in listener.l7policies:
+
+        # get ESD of same name
+        esd = esd_repository.get_esd(policy.name)
+        if esd is None:
+            continue
+
+        # enrich service with iRules and other things defined in ESD
+        esd_entities = get_esd_entities(service_args['_servicetype'], esd)
+        for entity_name in esd_entities:
+            if entity_name == 'iRules':
+                service_args['iRules'].extend(esd_entities['iRules'])
+            else:
+                service_args[entity_name] = esd_entities[entity_name]
+
+    # create service object and fill in additional fields
     service = as3.Service(**service_args)
+
+    # add service to entities and return
     entities.append((get_name(listener.id), service))
     return entities

--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -108,7 +108,8 @@ def get_service(listener, cert_manager, esd_repository):
         'virtualPort': listener.protocol_port,
         'virtualAddresses': [vip.ip_address],
         'persistenceMethods': [],
-        'iRules': []
+        'iRules': [],
+        'policyEndpoint': []
     }
 
     if listener.description:
@@ -269,7 +270,6 @@ def get_service(listener, cert_manager, esd_repository):
     # Map special L7policies to ESDs
     # TODO: Remove this as soon as all customers have migrated their scripts.
     #  Triggering ESDs via L7policies is considered deprecated. Tags should be used instead. See the code above.
-    service_args['policyEndpoint'] = []
     for policy in listener.l7policies:
 
         # get ESD of same name

--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -286,11 +286,16 @@ def get_service(listener, cert_manager, esd_repository):
                 else:
                     service_args[entity_name] = esd_entities[entity_name]
 
-        else:
+        elif policy.provisioning_status != lib_consts.PENDING_DELETE:
             # add a regular endpoint policy
-            if policy.provisioning_status != lib_consts.PENDING_DELETE:
-                service_args['policyEndpoint'].append(m_policy.get_name(policy.id))
+            policy_name = m_policy.get_name(policy.id)
 
+            # make endpoint policy object
+            endpoint_policy = (policy_name, m_policy.get_endpoint_policy(policy))
+            entities.append(endpoint_policy)
+
+            # reference endpoint policy object in service
+            service_args['policyEndpoint'].append(policy_name)
 
     # create service object and fill in additional fields
     service = as3.Service(**service_args)


### PR DESCRIPTION
Use tags in addition to special L7policy names to apply ESDs.
This PR belongs to #35.

L7policy-triggered ESDs are considered deprecated though and will be removed once all customers have migrated to tag-triggered ESDs.