### PR TITLE
[controller_worker] avoid redundant syncs

### DIFF
--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -116,7 +116,7 @@ class ControllerWorker(object):
             if lb not in pending_networks[lb.vip.network_id]:
                 pending_networks[lb.vip.network_id].append(lb)
 
-        for network_id, loadbalancers in pending_networks:
+        for network_id, loadbalancers in pending_networks.items():
             LOG.info("Found pending tenant network %s, syncing...", network_id)
             try:
                 if self._refresh(network_id).ok:


### PR DESCRIPTION
also sets error correctly to all pending LBs since we cannot be sure
which of the lb's in the tenant caused the error. Although, this should
be no issue since there is no mass-update api of lb's so there should
be only one pending lb in the tenant.