### PR TITLE
Get rid of futures overhead by cleanly separating lock-annotated functions

### DIFF
--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -15,7 +15,6 @@
 import collections
 import threading
 
-import futurist
 import prometheus_client as prometheus
 import tenacity
 from futurist import periodics
@@ -72,7 +71,6 @@ class ControllerWorker(object):
         self.network_driver = driver_utils.get_network_driver()
         self.cert_manager = cert_manager.CertManagerWrapper()
         self.status = status.StatusManager(self.bigip)
-        self.executor = futurist.ThreadPoolExecutor()
         worker = periodics.PeriodicWorker(
             [(self.pending_sync, None, None)]
         )
@@ -88,8 +86,14 @@ class ControllerWorker(object):
         super(ControllerWorker, self).__init__()
 
     @periodics.periodic(120, run_immediately=True)
-    @lockutils.synchronized('tenant_refresh')
     def pending_sync(self):
+        lbs_to_delete = self.get_lbs_to_delete()
+        for lb in lbs_to_delete:
+            LOG.info("Found pending deletion of lb %s", lb.id)
+            self.delete_load_balancer(lb.id)
+
+    @lockutils.synchronized('tenant_refresh')
+    def get_lbs_to_delete(self):
         """ Reconciliation loop that pics up un-scheduled loadbalancers and
             schedules them to this worker.
         """
@@ -137,9 +141,8 @@ class ControllerWorker(object):
         lbs_to_delete = self._loadbalancer_repo.get_all_from_host(
             db_apis.get_session(),
             provisioning_status=lib_consts.PENDING_DELETE)
-        for lb in lbs_to_delete:
-            LOG.info("Found pending deletion of lb %s", lb.id)
-            self.executor.submit(self.delete_load_balancer, lb.id)
+
+        return lbs_to_delete
 
     @tenacity.retry(
         retry=tenacity.retry_if_exception_type(db_exceptions.NoResultFound),

--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -94,7 +94,7 @@ class ControllerWorker(object):
         """
 
         # schedule unscheduled load balancers to this worker
-        self.schedule_lbs_to_worker()
+        self.sync_loadbalancers()
 
         # delete load balancers that are PENDING_DELETE
         lbs_to_delete = self._loadbalancer_repo.get_all_from_host(
@@ -105,8 +105,8 @@ class ControllerWorker(object):
             self.delete_load_balancer(lb.id)
 
     @lockutils.synchronized('tenant_refresh')
-    def schedule_lbs_to_worker(self):
-        """Pick up unscheduled load balancers and schedule them to this worker"""
+    def sync_loadbalancers(self):
+        """Sync loadbalancers that are in a PENDING state"""
         lbs = []
         pending_create_lbs = self._loadbalancer_repo.get_all(
             db_apis.get_session(),


### PR DESCRIPTION
There is no need to use futures when a clean separation of concerns does the job.

This PR
- makes `pending_sync` a small function that calls `schedule_lbs_to_worker` and `delete_load_balancer` separately
- introduces the two aforementioned functions, `schedule_lbs_to_worker` doing almost everything `pending_sync` did before, except deleting load balanceres which is now done by `delete_load_balancer`.