### PR TITLE
Status manager failover

### DIFF
--- a/octavia_f5/common/config.py
+++ b/octavia_f5/common/config.py
@@ -48,8 +48,9 @@ f5_agent_opts = [
                 help=_('Use token authentication.')),
     cfg.BoolOpt('bigip_verify', default=False,
                 help=_('Verify AS3 endpoint TLS cert.')),
-    cfg.StrOpt('bigip_url_a', help=_('The URL to the bigip host device with AS3 endpoint')),
-    cfg.StrOpt('bigip_url_b', help=_('The URL to the bigip host device with AS3 endpoint')),
+    cfg.ListOpt('bigip_urls',
+                item_type=cfg.types.URI(schemes=['http', 'https']),
+                help=_('The URL to the bigip host device with AS3 endpoint')),
     cfg.StrOpt('esd_dir',
                help=_('Directory of the esd files')),
 

--- a/octavia_f5/common/config.py
+++ b/octavia_f5/common/config.py
@@ -48,8 +48,8 @@ f5_agent_opts = [
                 help=_('Use token authentication.')),
     cfg.BoolOpt('bigip_verify', default=False,
                 help=_('Verify AS3 endpoint TLS cert.')),
-    cfg.StrOpt('bigip_url',
-               help=_('The URL to the bigip host device with AS3 endpoint')),
+    cfg.StrOpt('bigip_url_a', help=_('The URL to the bigip host device with AS3 endpoint')),
+    cfg.StrOpt('bigip_url_b', help=_('The URL to the bigip host device with AS3 endpoint')),
     cfg.StrOpt('esd_dir',
                help=_('Directory of the esd files')),
 

--- a/octavia_f5/controller/statusmanager/status_manager.py
+++ b/octavia_f5/controller/statusmanager/status_manager.py
@@ -52,7 +52,7 @@ def update_stats(obj):
 
 class StatusManager(BigipAS3RestClient):
     def __init__(self):
-        super(StatusManager, self).__init__(bigip_url=CONF.f5_agent.bigip_url,
+        super(StatusManager, self).__init__(bigip_urls=(CONF.f5_agent.bigip_url_a, CONF.f5_agent.bigip_url_b),
                                             enable_verify=CONF.f5_agent.bigip_verify,
                                             enable_token=CONF.f5_agent.bigip_token)
         self.amphora_id = None

--- a/octavia_f5/controller/statusmanager/status_manager.py
+++ b/octavia_f5/controller/statusmanager/status_manager.py
@@ -120,8 +120,15 @@ class StatusManager(BigipAS3RestClient):
         Also updates listener_count for amphora database via update_listener_count() function. This is needed for
         scheduling decisions.
         """
-        self._metric_heartbeat.inc()
 
+        # Check for failover
+        device_json = self.get(path='/tm/cm/device').json()
+        for device in device_json['items']:
+            if device['name'] == self.active_bigip.hostname and device['failoverState'] != 'active':
+                self._failover()
+                return
+
+        self._metric_heartbeat.inc()
         amphora_messages = {}
 
         def _get_lb_msg(lb_id):

--- a/octavia_f5/controller/statusmanager/status_manager.py
+++ b/octavia_f5/controller/statusmanager/status_manager.py
@@ -52,7 +52,7 @@ def update_stats(obj):
 
 class StatusManager(BigipAS3RestClient):
     def __init__(self):
-        super(StatusManager, self).__init__(bigip_urls=(CONF.f5_agent.bigip_url_a, CONF.f5_agent.bigip_url_b),
+        super(StatusManager, self).__init__(bigip_urls=CONF.f5_agent.bigip_urls,
                                             enable_verify=CONF.f5_agent.bigip_verify,
                                             enable_token=CONF.f5_agent.bigip_token)
         self.amphora_id = None

--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -64,7 +64,7 @@ class ControllerWorker(object):
         self._flavor_repo = repo.FlavorRepository()
         self._vip_repo = repo.VipRepository()
         self.bigip = BigipAS3RestClient(
-            bigip_url=CONF.f5_agent.bigip_url,
+            bigip_urls=(CONF.f5_agent.bigip_url_a, CONF.f5_agent.bigip_url_b),
             enable_verify=CONF.f5_agent.bigip_verify,
             enable_token=CONF.f5_agent.bigip_token,
             esd=self._esd)

--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -64,7 +64,7 @@ class ControllerWorker(object):
         self._flavor_repo = repo.FlavorRepository()
         self._vip_repo = repo.VipRepository()
         self.bigip = BigipAS3RestClient(
-            bigip_urls=(CONF.f5_agent.bigip_url_a, CONF.f5_agent.bigip_url_b),
+            bigip_urls=CONF.f5_agent.bigip_urls,
             enable_verify=CONF.f5_agent.bigip_verify,
             enable_token=CONF.f5_agent.bigip_token,
             esd=self._esd)

--- a/octavia_f5/restclient/as3restclient.py
+++ b/octavia_f5/restclient/as3restclient.py
@@ -100,13 +100,19 @@ class BigipAS3RestClient(object):
     _metric_authorization_duration = prometheus.metrics.Summary(
         'octavia_as3_authorization_duration', 'Time it needs to (re)authorize')
     _metric_authorization_exceptions = prometheus.metrics.Counter(
-        'octavia_as3_authorization_exceptions', 'Number of exceptions at (re)authorization')
+        'octavia_as3_authorization_exceptions', 'Number of exceptions during (re)authorization')
+    _metric_failover = prometheus.metrics.Counter(
+        'octavia_as3_failover',
+        'How often the F5 provider driver switched to another BigIP device')
+    _metric_failover_exceptions = prometheus.metrics.Counter(
+        'octavia_as3_failover_exceptions', 'Number of exceptions during failover')
     _metric_version = prometheus.Info(
         'octavia_as3_version', 'AS3 Version')
 
-    def __init__(self, bigip_url, enable_verify=True, enable_token=True,
-                 esd=None):
-        self.bigip = parse.urlsplit(bigip_url, allow_fragments=False)
+    def __init__(self, bigip_urls, enable_verify=True, enable_token=True, esd=None):
+        self.bigips = [ parse.urlsplit(url, allow_fragments=False) for url in bigip_urls ]
+        # Use the first BigIP device by default
+        self.active_bigip = self.bigips[0]
         self.enable_verify = enable_verify
         self.enable_token = enable_token
         self.token = None
@@ -123,8 +129,8 @@ class BigipAS3RestClient(object):
 
     def _url(self, path):
         return parse.urlunsplit(
-            parse.SplitResult(scheme=self.bigip.scheme,
-                              netloc=self.bigip.hostname,
+            parse.SplitResult(scheme=self.active_bigip.scheme,
+                              netloc=self.active_bigip.hostname,
                               path=path,
                               query='',
                               fragment='')
@@ -150,14 +156,24 @@ class BigipAS3RestClient(object):
         LOG.debug("%s finished with %d", method, response.status_code)
         return response
 
+    @_metric_failover_exceptions.count_exceptions()
+    def _failover(self):
+        self._metric_failover.inc()
+        for bigip in self.bigips:
+            if bigip != self.active_bigip:
+                LOG.debug("Failover to {}".format(bigip.hostname))
+                self.active_bigip = bigip
+                return
+        raise exceptions.FailoverException("No BigIP to failover to")
+
     @_metric_authorization_exceptions.count_exceptions()
     @_metric_authorization_duration.time()
     def reauthorize(self):
         self._metric_authorization.inc()
         # Login
         credentials = {
-            "username": self.bigip.username,
-            "password": self.bigip.password,
+            "username": self.active_bigip.username,
+            "password": self.active_bigip.password,
             "loginProviderName": "tmos"
         }
 

--- a/octavia_f5/utils/exceptions.py
+++ b/octavia_f5/utils/exceptions.py
@@ -21,6 +21,10 @@ class RetryException(Exception):
     pass
 
 
+class FailoverException(Exception):
+    pass
+
+
 class PolicyHasNoRules(AS3Exception):
     pass
 


### PR DESCRIPTION
This adds failover functionality to `as3restclient` and
- makes it fail over when a F5 is not reachable
- makes the status manager fail over when the observed F5 is no longer in status `ACTIVE`

A few notes:
- Failover doesn't check whether the F5 that's being failed over to is actually in `ACTIVE` state. That functionality would imply traffic overhead.
- Currently more than two F5s aren't supported. That's because failover always selects the next F5 that is not currently selected, thus alternating between the first two F5s provided to the constructor.
  AFAIK we don't use more than two F5s anywhere though, so I don't think that's a problem.