### PR TITLE
[AS3] Rework monitor handling in case of custom monitor ports/ips

### DIFF
--- a/octavia_f5/restclient/as3classes.py
+++ b/octavia_f5/restclient/as3classes.py
@@ -178,12 +178,6 @@ class Monitor(BaseDescription):
         super(Monitor, self).__init__(locals())
         setattr(self, 'class', 'Monitor')
 
-    def set_target_address(self, address):
-        setattr(self, 'targetAddress', address)
-
-    def set_target_port(self, port):
-        setattr(self, 'targetPort', port)
-
 
 class BigIP(BaseDescription):
     def __init__(self, bigip):


### PR DESCRIPTION
This was needed due to bugs in monitor creation with custom ip/port members.
Now, it's checked if all members have the same custom attributes so the amount
of monitors created can be reduced.

Also cleaner seperation of monitor-object creation