### PR TITLE
Track availability of F5 devices, full-sync reappearing device

### DIFF
--- a/octavia_f5/common/config.py
+++ b/octavia_f5/common/config.py
@@ -97,6 +97,9 @@ f5_agent_opts = [
                help=_("Use Cipher String for ciphers used in server TLS profiles")),
     cfg.StrOpt('default_client_ciphers', default=None,
                help=_("Use Cipher String for ciphers used in client TLS profiles")),
+    cfg.IntOpt('availability_timeout', default=5.0, # TODO: Is this really in seconds?
+               help=_("Time in seconds before a device is marked as offline."
+                      "This is only used by status manager, NOT for AS3 requests.")),
 
 ]
 

--- a/octavia_f5/common/config.py
+++ b/octavia_f5/common/config.py
@@ -97,7 +97,7 @@ f5_agent_opts = [
                help=_("Use Cipher String for ciphers used in server TLS profiles")),
     cfg.StrOpt('default_client_ciphers', default=None,
                help=_("Use Cipher String for ciphers used in client TLS profiles")),
-    cfg.IntOpt('availability_timeout', default=5.0,
+    cfg.IntOpt('availability_timeout', default=2.0,
                help=_("Time in seconds before a device is marked as offline."
                       "This is only used by status manager, NOT for AS3 requests.")),
 

--- a/octavia_f5/common/config.py
+++ b/octavia_f5/common/config.py
@@ -97,7 +97,7 @@ f5_agent_opts = [
                help=_("Use Cipher String for ciphers used in server TLS profiles")),
     cfg.StrOpt('default_client_ciphers', default=None,
                help=_("Use Cipher String for ciphers used in client TLS profiles")),
-    cfg.IntOpt('availability_timeout', default=5.0, # TODO: Is this really in seconds?
+    cfg.IntOpt('availability_timeout', default=5.0,
                help=_("Time in seconds before a device is marked as offline."
                       "This is only used by status manager, NOT for AS3 requests.")),
 

--- a/octavia_f5/controller/statusmanager/status_manager.py
+++ b/octavia_f5/controller/statusmanager/status_manager.py
@@ -242,12 +242,10 @@ class StatusManager(BigipAS3RestClient):
                 device_amp = self.amp_repo.create(
                     lock_session,
                     compute_flavor=CONF.host,
-                    status=constants.AMPHORA_READY,
                     vrrp_priority=num_listeners,
                     cached_zone=device_name)
             else:
                 self.amp_repo.update(lock_session, device_amp.id,
-                                     status=constants.AMPHORA_READY,
                                      vrrp_priority=num_listeners)
             lock_session.commit()
         except db_exc.DBDeadlock:

--- a/octavia_f5/controller/statusmanager/status_manager.py
+++ b/octavia_f5/controller/statusmanager/status_manager.py
@@ -256,7 +256,7 @@ class StatusManager(BigipAS3RestClient):
 
         :param num_listeners: number of listener for the bigip device
         """
-        with DatabaseLockSession as session:
+        with DatabaseLockSession() as session:
             device_name = self.active_bigip.hostname
             device_entry = self.amp_repo.get(session,
                                              compute_flavor=CONF.host,
@@ -283,7 +283,7 @@ class StatusManager(BigipAS3RestClient):
         :param device_name: Name of device. This usually is the domain under which the device can be reached.
         :param available: Whether the device is available or not
         """
-        with DatabaseLockSession as session:
+        with DatabaseLockSession() as session:
             # update table entry
             device_entry = self.amp_repo.get(session,
                                              compute_flavor=CONF.host,

--- a/octavia_f5/controller/statusmanager/status_manager.py
+++ b/octavia_f5/controller/statusmanager/status_manager.py
@@ -18,6 +18,7 @@ import time
 
 import futurist
 import prometheus_client as prometheus
+import requests
 from oslo_config import cfg
 from oslo_db import exception as db_exc
 from oslo_log import log as logging
@@ -150,8 +151,10 @@ class StatusManager(BigipAS3RestClient):
             # Try reaching device
             available = True
             try:
-                self.get(path='', timeout=timeout)
-            except Exception as e:
+                requests.get(device.scheme + '://' + device.hostname, timeout=timeout);
+            except requests.exceptions.Timeout as e:
+                LOG.info('Device timed out, considering it unavailable. Timeout: {}s Hostname: {}'.format(
+                         timeout, device.hostname));
                 available = False
 
             # Update database entry

--- a/octavia_f5/controller/statusmanager/status_manager.py
+++ b/octavia_f5/controller/statusmanager/status_manager.py
@@ -293,9 +293,9 @@ class StatusManager(BigipAS3RestClient):
             # determine status
             status = constants.AMPHORA_ALLOCATED  # offline if not available
             if available:
-                status = constants.AMPHORA_BOOTING  # back online if available (needs full sync)
-                if device_entry.status == constants.AMPHORA_READY:
-                    status = constants.AMPHORA_READY  # ready if it had been available before
+                status = constants.AMPHORA_READY  # back online if available
+                if device_entry is None or device_entry.status != constants.AMPHORA_READY:
+                    status = constants.AMPHORA_BOOTING  # needs full sync if no DB entry or not yet marked as ready
 
             # create/modify entry
             if not device_entry:

--- a/octavia_f5/controller/statusmanager/status_manager.py
+++ b/octavia_f5/controller/statusmanager/status_manager.py
@@ -241,7 +241,7 @@ class StatusManager(BigipAS3RestClient):
                                            load_balancer_id=None,
                                            cached_zone=device_name)
             if not device_entry:
-                device_entry = self.amp_repo.create(
+                self.amp_repo.create(
                     lock_session,
                     compute_flavor=CONF.host,
                     vrrp_priority=num_listeners,
@@ -289,7 +289,7 @@ class StatusManager(BigipAS3RestClient):
 
             # create/modify entry
             if not device_entry:
-                device_entry = self.amp_repo.create(
+                self.amp_repo.create(
                     lock_session,
                     compute_flavor=CONF.host,
                     status=status,

--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -146,8 +146,8 @@ class ControllerWorker(object):
             lbs = self._loadbalancer_repo.get_all_from_host(session)
 
             # Use a new instance of BigipAS3RestClient because we don't know whether the correct BigIP is set in self.bigip
-            bigip_to_sync = self.bigip = BigipAS3RestClient(
-                bigip_urls=[device],
+            bigip_to_sync = BigipAS3RestClient(
+                bigip_urls=[device.geturl()],
                 enable_verify=self.bigip.enable_verify,
                 enable_token=self.bigip.enable_token,
                 esd=self.bigip.esd)

--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -502,12 +502,12 @@ class ControllerWorker(object):
 
         This function creates an amphora entry in the database, if it doesn't already exist.
         """
-        device_amp = self._amphora_repo.get(
+        device_entry = self._amphora_repo.get(
             db_apis.get_session(),
             load_balancer_id=load_balancer_id)
 
         # create amphora mapping if missing
-        if not device_amp:
+        if not device_entry:
             self._amphora_repo.create(
                 db_apis.get_session(),
                 id=load_balancer_id,
@@ -517,10 +517,10 @@ class ControllerWorker(object):
             return
 
         # update host if not updated yet
-        if device_amp.compute_flavor != CONF.host:
+        if device_entry.compute_flavor != CONF.host:
             self._amphora_repo.update(
                 db_apis.get_session(),
-                id=device_amp.id,
+                id=device_entry.id,
                 compute_flavor=CONF.host)
 
     def create_amphora(self):


### PR DESCRIPTION
Fixes #61 
I'm not fully happy with this, so I need feedback and ideas how to improve it.

The following values are used for the 'status' column in 'amphora' table:
| value | actual meaning |
|-|-|
| `READY` | device is online |
| `ALLOCATED` | device is offline |
| `BOOTING` | device was offline but is online again, so it needs a full-sync. It is the responsibility of the syncing mechanism to set the status to `READY` once it's done. |