### PR TITLE
Migration Mode: f5agent.migration allows only passive devices to sync

### DIFF
--- a/octavia_f5/common/config.py
+++ b/octavia_f5/common/config.py
@@ -93,6 +93,8 @@ f5_agent_opts = [
                 help=_("Run in dry-run, do not realize AS3 definitions.")),
     cfg.BoolOpt('snat_virtual', default=False,
                 help=_("Use the virtual-server address as SNAT address.")),
+    cfg.BoolOpt('migration', default=False,
+                help=_("Enable migration mode (disable syncing active devices)")),
 ]
 
 f5_tls_shared = {

--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -107,6 +107,10 @@ class ControllerWorker(object):
             compute_flavor=CONF.host, load_balancer_id=None)
 
         for device in booting_devices[0]:
+            if CONF.f5_agent.migration and device.role != constants.ROLE_BACKUP:
+                LOG.warning("[Migration Mode] Skipping full sync of active device %s", device.cached_zone)
+                continue
+
             LOG.info("Device reappeared: %s. Doing a full sync.", device.cached_zone)
 
             # get all load balancers (of this host)

--- a/octavia_f5/restclient/as3classes.py
+++ b/octavia_f5/restclient/as3classes.py
@@ -92,6 +92,9 @@ class AS3(BaseDescription):
     def set_adc(self, adc):
         setattr(self, 'declaration', adc)
 
+    def set_sync_to_group(self, group):
+        setattr(self, 'syncToGroup', group)
+
 
 class ADC(BaseDescription):
     def __init__(self, schemaVersion='3.0.0', updateMode='selective', **kwargs):  # noqa


### PR DESCRIPTION
this option disables:
  * full reappearing sync of active devices
  * failover to active devices
  * sync_to_group (automatic device sync)