### PR TITLE
[status_manager] Only set pool status to DOWN if it has members

### DIFF
--- a/octavia_f5/controller/statusmanager/status_manager.py
+++ b/octavia_f5/controller/statusmanager/status_manager.py
@@ -284,7 +284,8 @@ class StatusManager(object):
             loadbalancer_id = self._loadbalancer_from_path(stats['tmName'].get('description'))
             status = constants.UP
             availability = stats['status.availabilityState'].get('description')
-            if availability == 'offline':
+            member_count = stats['availableMemberCnt'].get('value')
+            if availability == 'offline' and member_count != 0:
                 status = constants.DOWN
             msg = _get_lb_msg(loadbalancer_id)
             msg['pools'][pool_id] = {


### PR DESCRIPTION
I've noticed that the status of freshly created pools is shown as erroneous in the UI. This is due to empty pools being treated as being DOWN. That is unexpected and misleading behavior.