### PR TITLE
[pool] Skip member if the IP is used by a VIP/Load-Balancer

### DIFF
--- a/octavia_f5/controller/worker/status_manager.py
+++ b/octavia_f5/controller/worker/status_manager.py
@@ -176,4 +176,5 @@ class StatusManager(object):
         """Set provisioning_state of octavia object to ERROR
         :param obj: octavia object like loadbalancer, pools, etc.
         """
+        obj.provisioning_status = lib_consts.ERROR
         self._update_status_to_octavia({self.get_obj_type(obj): [self._status_obj(obj, lib_consts.ERROR)]})


### PR DESCRIPTION
Since BigIP doesn't support chaining of loadbalancers, skip members
if the same ip-address is used in the same tenant as a load balancer
IP. Also sets the member provisioning_status = ERROR to give
feedback to user.