### PR TITLE
Replace APP_COOKIE persistance with universal persistance iRule

### DIFF
--- a/octavia_f5/restclient/as3objects/irule.py
+++ b/octavia_f5/restclient/as3objects/irule.py
@@ -132,6 +132,16 @@ when HTTP_REQUEST {
         HTTP::header insert "X-SSL-Client-Not-After" $validity
     }
 }"""
+APP_COOKIE_SESSION_PERSIST = """when HTTP_REQUEST {{
+    if {{ [HTTP::cookie exists "{_cookie}"] }} {{
+        persist uie [HTTP::cookie "{_cookie}"] 3600
+    }}
+}}
+when HTTP_RESPONSE {{
+    if {{ [HTTP::cookie exists "{_cookie}"] }} {{
+        persist add uie [HTTP::cookie "{_cookie}"] 3600
+    }}
+}}"""
 
 
 def get_proxy_irule():
@@ -142,6 +152,18 @@ def get_proxy_irule():
     irule = IRule(PROXY_PROTOCOL_INITIATIOR,
                   remark="Insert Proxy Protocol Header V1")
     name = '{}proxy_protocol_initiator'.format(constants.PREFIX_IRULE)
+    return name, irule
+
+
+def get_app_cookie_irule(cookie_name):
+    """
+    Returns iRule for app cookie persistance with cookie_name.
+    :return: iRule entity (tuple with iRule name and definition)
+    """
+    app_cookie_irule = APP_COOKIE_SESSION_PERSIST.format(_cookie=cookie_name)
+    irule = IRule(app_cookie_irule,
+                  remark="Persistance app cookie")
+    name = '{}app_cookie_{}'.format(constants.PREFIX_IRULE, cookie_name)
     return name, irule
 
 

--- a/octavia_f5/restclient/as3objects/persist.py
+++ b/octavia_f5/restclient/as3objects/persist.py
@@ -35,7 +35,7 @@ def get_source_ip(timeout, granularity):
 def get_app_cookie(cookie_name):
     persist = Persist(
         persistenceMethod='universal',
-        iRule='{}_app_cookie_{}'.format(constants.PREFIX_IRULE, cookie_name),
+        iRule='{}app_cookie_{}'.format(constants.PREFIX_IRULE, cookie_name),
         duration=0
     )
     name = 'persist_app_cookie_{}'.format(cookie_name)

--- a/octavia_f5/restclient/as3objects/persist.py
+++ b/octavia_f5/restclient/as3objects/persist.py
@@ -11,9 +11,11 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from octavia_f5.restclient.as3classes import Persist
+
 import hashlib
-from octavia_f5.common import constants as const
+
+from octavia_f5.common import constants
+from octavia_f5.restclient.as3classes import Persist
 
 
 def get_source_ip(timeout, granularity):
@@ -31,12 +33,10 @@ def get_source_ip(timeout, granularity):
 
 
 def get_app_cookie(cookie_name):
-    m = hashlib.md5()
     persist = Persist(
-        persistenceMethod='cookie',
-        cookieName=cookie_name,
-        cookieMethod='hash'
+        persistenceMethod='universal',
+        iRule='{}_app_cookie_{}'.format(constants.PREFIX_IRULE, cookie_name),
+        duration=0
     )
-    m.update(cookie_name.encode('utf-8'))
-    name = 'persist_{}'.format(m.hexdigest())
+    name = 'persist_app_cookie_{}'.format(cookie_name)
     return name, persist

--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -225,8 +225,15 @@ def get_service(listener, cert_manager, esd_repository):
         persistence = listener.default_pool.session_persistence
         lb_algorithm = listener.default_pool.lb_algorithm
 
-        if persistence.type == 'APP_COOKIE':
-            name, obj_persist = m_persist.get_app_cookie(persistence.cookie_name)
+        if persistence.type == 'APP_COOKIE' and persistence.cookie_name:
+            # generate iRule for cookie_name
+            escaped_cookie = persistence.cookie_name
+            escaped_cookie.replace("\"", "")
+            irule_name, irule = m_irule.get_app_cookie_irule(escaped_cookie)
+            entities.append((irule_name, irule))
+
+            # add iRule to universal persistance profile
+            name, obj_persist = m_persist.get_app_cookie(escaped_cookie)
             service_args['persistenceMethods'] = [as3.Pointer(name)]
             entities.append((name, obj_persist))
             if lb_algorithm == 'SOURCE_IP':


### PR DESCRIPTION
cookie method 'hash' seems to be buggy or wrongly configured,
use upstream method of iRule persistance instead.