### PR TITLE
ESDs: Allow HTTP to HTTPS redirect via AS3 instead of iRule

### DIFF
--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -83,6 +83,12 @@ def get_esd_entities(servicetype, esd):
         if compression:
             service_args['profileHTTPCompression'] = as3.BigIP(compression)
 
+    if servicetype == const.SERVICE_HTTPS:
+        # HTTP redirect
+        redirect = esd.get('redirect80')
+        if redirect:
+            service_args['redirect80'] = True
+
     return service_args
 
 

--- a/octavia_f5/utils/esd_repo.py
+++ b/octavia_f5/utils/esd_repo.py
@@ -172,5 +172,7 @@ class EsdRepository(EsdJSONValidation):
         'lbaas_persist': {
             'value_type': six.string_types},
         'lbaas_fallback_persist': {
-            'value_type': six.string_types}
+            'value_type': six.string_types},
+        'redirect80': {
+            'value_type': bool}
     }


### PR DESCRIPTION
The ESD just needs to have 'redirect80' set to true and it will be set accordingly in the HTTPS service AS3 object.

When this is merged we can test in QA simply by temporarily changing the ESD in the Octavia configuration configmap.

Closes #119 