### PR TITLE
Also try to delete ports that are assigned to legacy lbaasv2 driver

### DIFF
--- a/octavia_f5/common/constants.py
+++ b/octavia_f5/common/constants.py
@@ -72,6 +72,7 @@ SEGMENT = 'segment'
 VIF_TYPE = 'f5'
 ESD = 'esd'
 DEVICE_OWNER_LISTENER = 'network:' + 'f5listener'
+DEVICE_OWNER_LEGACY = 'network:' + 'f5lbaasv2'
 PROFILE_L4 = 'basic'
 
 OPEN = 'OPEN'

--- a/octavia_f5/network/drivers/neutron/hierarchical_port_binding.py
+++ b/octavia_f5/network/drivers/neutron/hierarchical_port_binding.py
@@ -118,7 +118,7 @@ class HierachicalPortBindingDriver(aap.AllowedAddressPairsDriver):
                         "Continuing cleanup.".format(vip.port_id))
             port = None
 
-        if port and port.device_owner == constants.DEVICE_OWNER_LISTENER:
+        if port and port.device_owner in [constants.DEVICE_OWNER_LISTENER, constants.DEVICE_OWNER_LEGACY]:
             try:
                 self.neutron_client.delete_port(vip.port_id)
             except (neutron_client_exceptions.NotFound,


### PR DESCRIPTION
Octavia-F5 is re-using the ports initially created by the lbaasv2-f5 driver
which have a different device_owner (network:f5lbaasv2). These ports should also
correctly cleaned up by Octavia.