### PR TITLE
Add LB/host migration endpoints and migration logic

### DIFF
--- a/octavia_f5/common/constants.py
+++ b/octavia_f5/common/constants.py
@@ -73,6 +73,8 @@ VIF_TYPE = 'f5'
 ESD = 'esd'
 DEVICE_OWNER_LISTENER = 'network:' + 'f5listener'
 DEVICE_OWNER_LEGACY = 'network:' + 'f5lbaasv2'
+# networking-f5 handles self IP port creation, we only need to create self IP ports when moving LBs between devices
+DEVICE_OWNER_SELF_IP = 'network:' + 'f5selfip'
 PROFILE_L4 = 'basic'
 
 OPEN = 'OPEN'

--- a/octavia_f5/network/drivers/neutron/hierarchical_port_binding.py
+++ b/octavia_f5/network/drivers/neutron/hierarchical_port_binding.py
@@ -174,3 +174,6 @@ class HierachicalPortBindingDriver(aap.AllowedAddressPairsDriver):
         except Exception as e:
             LOG.error('Error retrieving physical network dict for f5 network agent "%s": %s', CONF.host, e)
             raise e
+
+    def invalidate_cache(self, hard=True):
+        cache_region.invalidate(hard=hard)


### PR DESCRIPTION
Note: The branch is called `failover_loadbalancer` because [originally I tried using the already existing `failover_*` endpoints](https://github.com/sapcc/octavia/pull/9), which turned out to not work as desired.