### PR TITLE
Added alias F5Networks for provider driver

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ console_scripts =
     octavia-f5-util = octavia_f5.cmd.f5_util:main
 octavia.api.drivers =
     f5 = octavia_f5.api.drivers.f5_driver.driver:F5ProviderDriver
+    F5Networks = octavia_f5.api.drivers.f5_driver.driver:F5ProviderDriver
 octavia.plugins =
     f5_plugin = octavia_f5.controller.worker.controller_worker:ControllerWorker
 octavia.network.drivers =


### PR DESCRIPTION
This adds the provider 'F5Networks' as an alias for the octavia-f5
provider driver.

Why?
With switching to L7 neutron redirect, legacy clients could try to create new
loadbalancers with the old lbaasv2 provider name "F5Networks". The old proxy-driver
just stripped the provider completely.