### PR TITLE
Remove erroneous logic that sets listener status to full

### DIFF
--- a/octavia_f5/controller/statusmanager/status_manager.py
+++ b/octavia_f5/controller/statusmanager/status_manager.py
@@ -261,10 +261,6 @@ class StatusManager(object):
             listener_id = self._listener_from_path(stats['tmName'].get('description'))
             loadbalancer_id = self._loadbalancer_from_path(stats['tmName'].get('description'))
             status = constants.OPEN
-            cur_conns = stats['clientside.curConns'].get('value')
-            max_conns = stats['clientside.maxConns'].get('value')
-            if max_conns != 0 and cur_conns >= max_conns:
-                status = constants.FULL
             _get_lb_msg(loadbalancer_id)['listeners'][listener_id] = {
                 'status': status,
                 'stats': {


### PR DESCRIPTION
The implementation wrongly assumed that the clientside.MaxConns Metric is reporting back the maximum allowed conections, but it's just the "highest" number of connections F5 observed over all time.
See #133