### PR TITLE
Correctly remove non-allowed characters in AS3 declaration for label+remark

### DIFF
--- a/octavia_f5/restclient/as3types.py
+++ b/octavia_f5/restclient/as3types.py
@@ -16,16 +16,20 @@
 import re
 import string
 
+REMARK_FORBIDDEN = ["\"", "\\"]
+LABEL_FORBIDDEN = ["#", "&", "*", "<", ">", "?", "[", "\\", "]", "`", "\""]
 
 def f5remark(remark):
     if not remark:
         return ""
 
     # Remove control characters.
-    nstr = "".join(ch for ch in remark if ch in string.printable)
+    nstr = "".join(ch for ch in remark if
+                   ch in string.printable and
+                   ch not in REMARK_FORBIDDEN)
 
     # Remove double-quote ("), and backslash (\), limit to 64 characters.
-    return re.sub('["\\\\]', '', nstr)[:64]
+    return nstr[:64]
 
 
 def f5label(label):
@@ -33,5 +37,7 @@ def f5label(label):
         return ""
 
     # Remove control characters and limit to 64 characters.
-    nstr = "".join(ch for ch in label if ch in string.printable and ch not in ["&", "`"])
+    nstr = "".join(ch for ch in label if
+                   ch in string.printable and
+                   ch not in LABEL_FORBIDDEN)
     return nstr[:64]

--- a/octavia_f5/tests/unit/restclient/test_as3types.py
+++ b/octavia_f5/tests/unit/restclient/test_as3types.py
@@ -1,0 +1,36 @@
+# Copyright 2021 SAP SE
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from octavia.tests.unit import base
+from octavia_f5.restclient.as3types import f5label, f5remark
+
+
+class TestAS3Types(base.TestCase):
+    def test_f5remark(self):
+        self.assertEqual(f5remark("test test test"), "test test test")
+        self.assertEqual(f5remark("\Programm Files"), "Programm Files")
+        self.assertEqual(len(f5remark(65 * "A")), 64)
+
+        FORBIDDEN_CHARACTERS = "\\\""
+        for forbidden_char in FORBIDDEN_CHARACTERS:
+            self.assertEqual(f5label(forbidden_char), "")
+
+    def test_f5label(self):
+        self.assertEqual(f5label("test test test"), "test test test")
+        self.assertEqual(f5label("[dev]"), "dev")
+        self.assertEqual(len(f5label(65 * "A")), 64)
+
+        FORBIDDEN_CHARACTERS = "#&*<>?[\\]`\""
+        for forbidden_char in FORBIDDEN_CHARACTERS:
+            self.assertEqual(f5label(forbidden_char), "")


### PR DESCRIPTION
Based on the regexes provided by upstream documentation, also includes tests
that check all conditions.

Fixes CCM-26032