### PR TITLE
Omit AZ-aware agents for non-az aware loadbalancers, use of az profil…

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:
@@ -15,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7]
+        python-version: [3.6]
 
     steps:
     - uses: actions/checkout@v2
@@ -26,8 +25,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pbr "octavia==4.1.4" -c https://raw.githubusercontent.com/sapcc/requirements/stable/stein/upper-constraints.txt
-        pip install -e . -c https://raw.githubusercontent.com/sapcc/requirements/stable/stein/upper-constraints.txt
+        pip install pbr "octavia<7.0.0" -c https://raw.githubusercontent.com/sapcc/requirements/stable/ussuri/upper-constraints.txt
+        pip install -e . -c https://raw.githubusercontent.com/sapcc/requirements/stable/ussuri/upper-constraints.txt
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pbr "octavia<7.0.0" -c https://raw.githubusercontent.com/sapcc/requirements/stable/ussuri/upper-constraints.txt
+        pip install pbr oslotest "octavia<7.0.0" -c https://raw.githubusercontent.com/sapcc/requirements/stable/ussuri/upper-constraints.txt
         pip install -e . -c https://raw.githubusercontent.com/sapcc/requirements/stable/ussuri/upper-constraints.txt
     - name: Lint with flake8
       run: |

--- a/octavia_f5/api/drivers/f5_driver/driver.py
+++ b/octavia_f5/api/drivers/f5_driver/driver.py
@@ -234,16 +234,6 @@ class F5ProviderDriver(driver.AmphoraProviderDriver):
         # Let Octavia create the port
         raise exceptions.NotImplementedError()
 
-    def loadbalancer_failover(self, loadbalancer_id):
-        """Performs a fail over of a load balancer.
-
-        :param loadbalancer_id (string): ID of the load balancer to failover.
-        :return: Nothing if the failover request was accepted.
-        :raises DriverError: An unexpected error occurred in the driver.
-        :raises: NotImplementedError if driver does not support request.
-        """
-        raise exceptions.NotImplementedError()
-
     def get_supported_flavor_metadata(self):
         """Returns the valid flavor metadata keys and descriptions.
 
@@ -280,4 +270,11 @@ class F5ProviderDriver(driver.AmphoraProviderDriver):
         :raises UnsupportedOptionError: If the driver does not support
           one of the availability zone settings.
         """
-        raise exceptions.NotImplementedError()
+        if len(availability_zone_dict.get('hosts', [])) > 0:
+            return
+
+        raise exceptions.UnsupportedOptionError(
+                user_fault_string='Failed to get the supported availability '
+                                  'zone metadata.',
+                operator_fault_string='Failed to get hosts from availability '
+                                  'zone metadata: {}'.format(availability_zone_dict))

--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -583,19 +583,18 @@ class ControllerWorker(object):
     @oslo_db_api.wrap_db_retry(max_retries=5, retry_on_deadlock=True)
     def register_in_availability_zone(self, az_name):
         """
-        Register this worker to its assigned availability zone by creating/modifying the corresponding DB entry.
+        Register this worker to an availability zone by creating/modifying the corresponding DB entry.
 
-        An AZ can have multiple workers (multiple F5 device-pairs), so the worker host are set in the
+        An AZ can have multiple workers (multiple F5 device-pairs), so the worker hosts are set in the
         corresponding availability zone profile metadata as a json array.
         """
-
         with db_apis.get_lock_session() as lock_session:
             az = self._az_repo.get(lock_session, name=az_name)
-            metadata = self._az_repo.get_availability_zone_metadata_dict(lock_session, az_name)
-            hosts = metadata.get('hosts', [])
             if az:
+                metadata = self._az_repo.get_availability_zone_metadata_dict(lock_session, az_name)
+                hosts = metadata.get('hosts', [])
                 if not CONF.host in hosts:
-                    # add host to availibility zone metadata (profile)
+                    # add host to availibility zone profile metadata
                     hosts.append(CONF.host)
                     self._azp_repo.update(lock_session, id=az.availability_zone_profile_id,
                                           availability_zone_data=json.dumps({'hosts': hosts}))

--- a/octavia_f5/db/api.py
+++ b/octavia_f5/db/api.py
@@ -11,9 +11,11 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+import contextlib
 
 from oslo_db.sqlalchemy import session as db_session
 from oslo_config import cfg
+from oslo_utils import excutils
 
 _FACADE = None
 
@@ -35,3 +37,15 @@ def get_session(expire_on_commit=True, autocommit=True):
     facade = _create_facade_lazily()
     return facade.get_session(expire_on_commit=expire_on_commit,
                               autocommit=autocommit)
+
+
+@contextlib.contextmanager
+def get_lock_session():
+    """Context manager for using a locking (not auto-commit) session."""
+    lock_session = get_session(autocommit=False)
+    try:
+        yield lock_session
+        lock_session.commit()
+    except Exception:
+        with excutils.save_and_reraise_exception():
+            lock_session.rollback()

--- a/octavia_f5/db/repositories.py
+++ b/octavia_f5/db/repositories.py
@@ -18,95 +18,15 @@ Extends octavia base repository with enhanced f5-specific queries
 
 from octavia_lib.common import constants as lib_consts
 from oslo_config import cfg
-from oslo_db import exception as db_exc
 from oslo_log import log as logging
-from oslo_utils import excutils
-from sqlalchemy import func, asc, or_
 
 from octavia.common import constants as consts
-from octavia.common import exceptions
-from octavia.db import api as db_api
 from octavia.db import models
 from octavia.db import repositories
 
 CONF = cfg.CONF
-
 LOG = logging.getLogger(__name__)
 
-
-class DatabaseLockSession(object):
-    """Provides a database session and rolls it back if an exception occured before exiting with-statement. """
-    def __enter__(self):
-        self._lock_session = db_api.get_session(autocommit=False)
-        return self._lock_session
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        if exc_tb is None:
-            self._lock_session.commit()
-        else:
-            if isinstance(exc_type, db_exc.DBDeadlock):
-                LOG.debug('Database reports deadlock. Skipping.')
-                self._lock_session.rollback()
-            elif isinstance(exc_type, db_exc.RetryRequest):
-                LOG.debug('Database is requesting a retry. Skipping.')
-                self._lock_session.rollback()
-            else:
-                with excutils.save_and_reraise_exception():
-                    self._lock_session.rollback()
-
-class AmphoraRepository(repositories.AmphoraRepository):
-    def get_candidates(self, session, az_name=None):
-        """ Get F5 (active) BigIP host candidate depending on the load (amount of listeners in amphora vrrp_priority
-        column) and the desired availability zone.
-
-        :param session: A Sql Alchemy database session.
-        :param az_name: Name of the availability zone to schedule to. If it is None, all F5 amphora are considered.
-        """
-
-        # get all hosts
-        candidates = session.query(self.model_class.compute_flavor)
-        candidates = candidates.filter_by(
-            role=consts.ROLE_MASTER,
-            load_balancer_id=None,
-        ).filter(or_(
-            # !='disabled' gives False on NULL, so we need to check for NULL (None) explicitly
-            self.model_class.vrrp_interface == None, self.model_class.vrrp_interface != 'disabled'))
-
-        # order by listener count
-        candidates = candidates.order_by(
-            self.model_class.vrrp_priority.asc(),
-            self.model_class.updated_at.desc())
-        candidates = candidates.all()
-
-        # optionally schedule according to load balancer count instead of (just) listener count
-        if CONF.networking.agent_scheduler == "loadbalancer":
-            lb_count = session.query(models.LoadBalancer.server_group_id.label('host'),
-                                     func.count(models.LoadBalancer.id))\
-                .group_by('host').order_by(func.count(models.LoadBalancer.id).asc()).all()
-            lb_count = { host:lbs for (host,lbs) in lb_count }
-            # Now we have LB count per host, but some may have no LBs, so no entry in lb_count.
-            # But we need to include all hosts from the candidates list.
-            candidates = [ (c[0], lb_count.get(c[0]) or 0) for c in candidates]
-            candidates.sort(key=lambda x: x[1]) # TODO check that sort is ascending
-
-        # If no specific AZ is requested, just return all candidates
-        if not az_name:
-            return [ c[0] for c in candidates ]
-
-        # get hosts from AZ
-        az_repo = repositories.AvailabilityZoneRepository()
-        az = az_repo.get(session, name=az_name)
-        if not az:
-            LOG.error("Can't schedule VIP/LB: Availability zone not found: {}".format(az_name))
-            raise exceptions.NotFound()
-        hosts_in_az = az.description.split()
-
-        # get hosts from AZ that are candidates
-        candidates = [ c[0] for c in candidates if c[0] in hosts_in_az ]
-        if len(candidates) == 0:
-            LOG.error("Can't schedule VIP/LB: No host candidates in availability zone {}".format(az_name))
-            raise exceptions.NotFound()
-        return candidates
 
 class LoadBalancerRepository(repositories.LoadBalancerRepository):
     def get_all_from_host(self, session, host=None, **filters):

--- a/octavia_f5/db/scheduler.py
+++ b/octavia_f5/db/scheduler.py
@@ -1,0 +1,81 @@
+#  Copyright 2021 SAP SE
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License. You may obtain
+#  a copy of the License at
+#  #
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+
+from sqlalchemy import func, or_
+from oslo_config import cfg
+from oslo_log import log as logging
+
+from octavia.common import constants as consts
+from octavia.db import models
+from octavia.db import repositories
+
+CONF = cfg.CONF
+LOG = logging.getLogger(__name__)
+
+
+class Scheduler(object):
+    def __init__(self):
+        self.az_repo = repositories.AvailabilityZoneRepository()
+
+    def get_candidates(self, session, az_name=None):
+        """ Get F5 (active) BigIP host candidate depending on the load (amount of listeners in amphora vrrp_priority
+        column) and the desired availability zone.
+
+        :param session: A Sql Alchemy database session.
+        :param az_name: Name of the availability zone to schedule to. If it is None, all F5 amphora are considered.
+        """
+
+        # get all hosts
+        candidates = session.query(
+            models.Amphora.compute_flavor,
+            func.count(models.LoadBalancer.id)
+        ).join(
+            models.LoadBalancer,
+            models.Amphora.compute_flavor == models.LoadBalancer.server_group_id
+        ).filter(
+            models.Amphora.role == consts.ROLE_MASTER,
+            models.Amphora.load_balancer_id == None,
+            or_(
+                # !='disabled' gives False on NULL, so we need to check for NULL (None) explicitly
+                models.Amphora.vrrp_interface == None,
+                models.Amphora.vrrp_interface != 'disabled')
+        ).group_by(models.Amphora.compute_flavor)
+
+        if CONF.networking.agent_scheduler == "loadbalancer":
+            # order by loadbalancer count
+            candidates.order_by(
+                func.count(models.LoadBalancer.id).asc(),
+                models.Amphora.updated_at.desc())
+        else:
+            # order by listener count
+            candidates = candidates.order_by(
+                models.Amphora.vrrp_priority.asc(),
+                models.Amphora.updated_at.desc())
+
+        if az_name:
+            # if az provided, filter hosts
+            metadata = self.az_repo.get_availability_zone_metadata_dict(session, az_name)
+            hosts = metadata.get('hosts', [])
+            candidates = candidates.filter(
+                models.Amphora.compute_flavor.in_(hosts))
+        else:
+            # we need to filter out all az-aware hosts
+            azs = set([az.name for az in self.az_repo.get_all(session)[0]])
+            omit_hosts = set()
+            for az in azs:
+                metadata = self.az_repo.get_availability_zone_metadata_dict(session, az)
+                omit_hosts.add(metadata.get('hosts', []))
+            candidates = candidates.filter(
+                models.Amphora.compute_flavor.notin_(omit_hosts))
+        return [candidate[0] for candidate in candidates.all()]

--- a/octavia_f5/db/scheduler.py
+++ b/octavia_f5/db/scheduler.py
@@ -30,7 +30,7 @@ class Scheduler(object):
 
     def get_candidates(self, session, az_name=None):
         """ Get F5 (active) BigIP host candidate depending on the load (amount of listeners in amphora vrrp_priority
-        column) and the desired availability zone.
+        column or amount of load balancers) and the desired availability zone.
 
         :param session: A Sql Alchemy database session.
         :param az_name: Name of the availability zone to schedule to. If it is None, all F5 amphora are considered.

--- a/octavia_f5/network/drivers/neutron/hierarchical_port_binding.py
+++ b/octavia_f5/network/drivers/neutron/hierarchical_port_binding.py
@@ -24,6 +24,7 @@ from octavia.network.drivers.neutron import allowed_address_pairs as aap
 from octavia.network.drivers.neutron import utils
 from octavia_f5.common import constants
 from octavia_f5.db import repositories
+from octavia_f5.db import scheduler
 
 LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
@@ -40,8 +41,7 @@ cache.configure_cache_region(CONF, cache_region)
 class HierachicalPortBindingDriver(aap.AllowedAddressPairsDriver):
     def __init__(self):
         super(HierachicalPortBindingDriver, self).__init__()
-        self.amp_repo = repositories.AmphoraRepository()
-        self.lb_repo = repositories.LoadBalancerRepository()
+        self.scheduler = scheduler.Scheduler()
         self.physical_network = self.get_physical_network()
 
     def allocate_vip(self, load_balancer):
@@ -66,7 +66,7 @@ class HierachicalPortBindingDriver(aap.AllowedAddressPairsDriver):
         # select a candidate to schedule to
         try:
             session = db_apis.get_session()
-            candidate = self.amp_repo.get_candidates(session, load_balancer.availability_zone)[0]
+            candidate = self.scheduler.get_candidates(session, load_balancer.availability_zone)[0]
         except (ValueError, IndexError) as e:
             message = _('Scheduling failed, no ready candidates found')
             LOG.exception(message)

--- a/octavia_f5/tests/unit/api/drivers/f5_provider_driver/test_f5_driver.py
+++ b/octavia_f5/tests/unit/api/drivers/f5_provider_driver/test_f5_driver.py
@@ -18,7 +18,7 @@ from oslo_config import fixture as oslo_fixture
 
 from octavia.common import constants as consts
 from octavia.tests.unit import base
-from octavia.tests.unit.api.drivers import sample_data_models
+from octavia.tests.common import sample_data_models
 from octavia_f5.api.drivers.f5_driver import driver
 from octavia_lib.api.drivers import data_models as driver_dm
 

--- a/octavia_f5/tests/unit/controller/worker/test_controller_worker.py
+++ b/octavia_f5/tests/unit/controller/worker/test_controller_worker.py
@@ -1,0 +1,74 @@
+#  Copyright 2021 SAP SE
+#
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License. You may obtain
+#  a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+
+import json
+from unittest import mock
+
+from oslo_config import cfg
+from oslo_utils import uuidutils
+
+import octavia.tests.unit.base as base
+from octavia_f5.controller.worker import controller_worker
+
+CONF = cfg.CONF
+
+_health_mon_mock = mock.MagicMock()
+_status_manager = mock.MagicMock()
+_vip_mock = mock.MagicMock()
+_listener_mock = mock.MagicMock()
+_load_balancer_mock = mock.MagicMock()
+_load_balancer_mock.listeners = [_listener_mock]
+_load_balancer_mock.flavor_id = None
+_load_balancer_mock.availability_zone = None
+_member_mock = mock.MagicMock()
+_pool_mock = mock.MagicMock()
+_l7policy_mock = mock.MagicMock()
+_l7rule_mock = mock.MagicMock()
+_az_mock = mock.MagicMock()
+_db_session = mock.MagicMock()
+
+
+@mock.patch('octavia_f5.controller.worker.status_manager.StatusManager')
+@mock.patch('octavia_f5.controller.worker.sync_manager.SyncManager')
+@mock.patch('octavia_f5.db.api.get_session', return_value=_db_session)
+class TestControllerWorker(base.TestCase):
+    @mock.patch('octavia.db.repositories.AvailabilityZoneRepository')
+    @mock.patch('octavia.db.repositories.AvailabilityZoneProfileRepository')
+    def test_register_in_availability_zone(self,
+                                           mock_azp_repo,
+                                           mock_az_repo,
+                                           mock_api_get_session,
+                                           mock_sync_manager,
+                                           mock_status_manager):
+        az = 'fake_az'
+        fake_azp_id = uuidutils.generate_uuid()
+        cw = controller_worker.ControllerWorker()
+
+        # existing empty az
+        mock_az_repo_instance = mock_az_repo.return_value
+        mock_az_repo_instance.get.return_value.availability_zone_profile_id = fake_azp_id
+        mock_az_repo_instance.get_availability_zone_metadata_dict.return_value = {'hosts': []}
+
+        cw.register_in_availability_zone(az)
+
+        mock_az_repo_instance.get.assert_called_once_with(_db_session, name=az)
+        mock_az_repo_instance.get_availability_zone_metadata_dict.assert_called_once_with(_db_session, az)
+        mock_azp_repo.return_value.update.assert_called_once_with(
+            _db_session, id=fake_azp_id, availability_zone_data=json.dumps({'hosts': [CONF.host]}))
+
+        # non-existing az
+        mock_az_repo_instance.get.return_value = None
+        cw.register_in_availability_zone(az)
+        mock_az_repo.return_value.create.assert_called_once()
+        mock_azp_repo.return_value.create.assert_called_once()

--- a/octavia_f5/tests/unit/controller/worker/test_endpoint.py
+++ b/octavia_f5/tests/unit/controller/worker/test_endpoint.py
@@ -17,12 +17,12 @@ from oslo_config import cfg
 from oslo_config import fixture as oslo_fixture
 from oslo_utils import uuidutils
 
-from octavia.controller.queue import endpoint
-from octavia.controller.worker import controller_worker
-from octavia.tests.unit.controller.queue import test_endpoint
+from octavia.controller.queue.v1 import endpoints
+from octavia.controller.worker.v1 import controller_worker
+from octavia.tests.unit.controller.queue.v1 import test_endpoints
 
 
-class TestEndpoint(test_endpoint.TestEndpoint):
+class TestEndpoint(test_endpoints.TestEndpoints):
 
     def setUp(self):
         super(TestEndpoint, self).setUp()
@@ -31,11 +31,11 @@ class TestEndpoint(test_endpoint.TestEndpoint):
         conf.config(octavia_plugins='f5_plugin')
 
         mock_class = mock.create_autospec(controller_worker.ControllerWorker)
-        self.worker_patcher = mock.patch('octavia.controller.queue.endpoint.'
-                                         'stevedore_driver')
+        self.worker_patcher = mock.patch('octavia.controller.queue.v1.'
+                                         'endpoints.stevedore_driver')
         self.worker_patcher.start().ControllerWorker = mock_class
 
-        self.ep = endpoint.Endpoint()
+        self.ep = endpoints.Endpoints()
         self.context = {}
         self.resource_updates = {}
         self.resource_id = 1234

--- a/octavia_f5/tests/unit/db/__init__.py
+++ b/octavia_f5/tests/unit/db/__init__.py
@@ -1,0 +1,11 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.

--- a/octavia_f5/tests/unit/db/test_scheduler.py
+++ b/octavia_f5/tests/unit/db/test_scheduler.py
@@ -1,0 +1,121 @@
+#  Copyright 2021 SAP SE
+#
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License. You may obtain
+#  a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+
+from unittest import mock
+
+from oslo_config import cfg
+from oslo_config import fixture as oslo_fixture
+from oslo_utils import uuidutils
+
+from octavia.db import repositories as repo
+from octavia.tests.functional.db import base
+from octavia_f5.common import config, constants  # noqa
+from octavia_f5.controller.worker import controller_worker
+from octavia_f5.db import scheduler
+
+CONF = cfg.CONF
+
+
+class TestScheduler(base.OctaviaDBTestBase):
+    FAKE_AZ = "fake-az"
+    FAKE_LB_ID = uuidutils.generate_uuid()
+    FAKE_PROJ_ID = uuidutils.generate_uuid()
+    FAKE_DEVICE_AMPHORA_ID_1 = uuidutils.generate_uuid()
+    FAKE_DEVICE_AMPHORA_ID_2 = uuidutils.generate_uuid()
+    FAKE_DEVICE_PAIR_1 = "fake.device.pair1"
+    FAKE_DEVICE_PAIR_2 = "fake.device.pair2"
+
+    def setUp(self):
+        super(TestScheduler, self).setUp()
+        self.repos = repo.Repositories()
+        self.device_amphora_1 = self.repos.amphora.create(
+            self.session, id=self.FAKE_DEVICE_AMPHORA_ID_1,
+            role=constants.ROLE_MASTER, vrrp_interface=None,
+            status=constants.ACTIVE, compute_flavor=self.FAKE_DEVICE_PAIR_1,
+            vrrp_priority=1
+        )
+        self.device_amphora_2 = self.repos.amphora.create(
+            self.session, id=self.FAKE_DEVICE_AMPHORA_ID_2,
+            role=constants.ROLE_MASTER, vrrp_interface=None,
+            status=constants.ACTIVE, compute_flavor=self.FAKE_DEVICE_PAIR_2,
+            vrrp_priority=100
+        )
+        self.scheduler = scheduler.Scheduler()
+        self.conf = self.useFixture(oslo_fixture.Config(cfg.CONF))
+
+    def test_get_candidate_without_lbs(self):
+        self.conf.config(group="networking", agent_scheduler="loadbalancer")
+
+        candidates = self.scheduler.get_candidates(self.session)
+        self.assertEqual(
+            candidates, [self.FAKE_DEVICE_PAIR_1, self.FAKE_DEVICE_PAIR_2],
+            "Active device pairs without lbs not considered as candidates")
+
+    def test_get_candidate_with_lbs(self):
+        self.conf.config(group="networking", agent_scheduler="loadbalancer")
+        lb = self._create_lb(self.FAKE_LB_ID, self.FAKE_DEVICE_PAIR_1)
+
+        candidates = self.scheduler.get_candidates(self.session)
+        self.assertEqual(
+            candidates, [self.FAKE_DEVICE_PAIR_2, self.FAKE_DEVICE_PAIR_1],
+            "Order of device pairs not consistent")
+        self.repos.load_balancer.delete(self.session, id=lb.id)
+
+    def test_get_candidate_by_listener(self):
+        self.conf.config(group="networking", agent_scheduler="listener")
+
+        candidates = self.scheduler.get_candidates(self.session)
+        self.assertEqual(
+            candidates, [self.FAKE_DEVICE_PAIR_1, self.FAKE_DEVICE_PAIR_2],
+            "Order of device pairs not consistent")
+
+        old_prio = self.device_amphora_1.vrrp_priority
+        self.repos.amphora.update(self.session, self.device_amphora_1.id,
+                                  vrrp_priority=1000)
+        candidates = self.scheduler.get_candidates(self.session)
+        self.assertEqual(
+            candidates, [self.FAKE_DEVICE_PAIR_2, self.FAKE_DEVICE_PAIR_1],
+            "Order of device pairs not consistent")
+        self.repos.amphora.update(self.session, self.device_amphora_1.id,
+                                  vrrp_priority=old_prio)
+
+    @mock.patch('octavia_f5.controller.worker.status_manager.StatusManager')
+    @mock.patch('octavia_f5.controller.worker.sync_manager.SyncManager')
+    def test_get_candidate_by_az(self, mock_sync_manager, mock_status_manager):
+        self.conf.config(group="networking", agent_scheduler="loadbalancer")
+
+        # Register host FAKE_DEVICE_PAIR_1 as fake-az
+        self.session.autocommit = False
+        with mock.patch('octavia_f5.db.api.get_session', return_value=self.session):
+            cw = controller_worker.ControllerWorker()
+            self.conf.config(host=self.FAKE_DEVICE_PAIR_1)
+            cw.register_in_availability_zone(self.FAKE_AZ)
+        self.session.autocommit = True
+
+        candidates = self.scheduler.get_candidates(self.session, az_name=self.FAKE_AZ)
+        self.assertEqual([self.FAKE_DEVICE_PAIR_1], candidates,
+                         "Candidates should only include AZ device pairs")
+
+        candidates = self.scheduler.get_candidates(self.session)
+        self.assertEqual([self.FAKE_DEVICE_PAIR_2], candidates,
+                         "Candidates should only include non-AZ device pairs")
+
+    def _create_lb(self, id, host=FAKE_DEVICE_PAIR_1):
+        return self.repos.load_balancer.create(
+            self.session, id=id, project_id=self.FAKE_PROJ_ID,
+            name="lb_name", description="lb_description",
+            provisioning_status=constants.ACTIVE,
+            operating_status=constants.ONLINE,
+            server_group_id=host, enabled=True
+        )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,4 @@
+# The order of packages is significant, because pip processes them in the order
+# of appearance. Changing the order has an impact on the overall integration
+# process, which may cause wedges in the gate later.
+oslotest>=3.2.0 # Apache-2.0


### PR DESCRIPTION
…e metadata

Moved get_candidates from amphora_repository to it's own scheduler class.
Reworked get_candidates to support both, listener and load_balancer aware
scheduling within the same sql query.
Support az validation.
Minor cleanups
Auto-creation of AZs is now safguarded by transaction and automatically retried.