### PR TITLE
Support for TLS Cipher strings of listeners.

### DIFF
--- a/octavia_f5/common/config.py
+++ b/octavia_f5/common/config.py
@@ -121,7 +121,7 @@ f5_agent_opts = [
 ]
 
 f5_tls_shared = {
-    cfg.StrOpt('default_ciphers', default=None,
+    cfg.StrOpt('default_ciphers', default=None, deprecated_for_removal=True,
                help=_("Use Cipher String for ciphers used in TLS profiles")),
     cfg.BoolOpt('forward_proxy_bypass', default=None,
                 help=_("Enables or disables (default) SSL forward proxy bypass.")),

--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -154,7 +154,7 @@ def get_service(listener, cert_manager, esd_repository):
 
         entities.append((
             m_tls.get_listener_name(listener.id),
-            m_tls.get_tls_server([cert['id'] for cert in certificates], auth_name, listener.client_authentication)
+            m_tls.get_tls_server([cert['id'] for cert in certificates], listener, auth_name)
         ))
         entities.extend([(cert['id'], cert['as3']) for cert in certificates])
 

--- a/octavia_f5/restclient/as3objects/tls.py
+++ b/octavia_f5/restclient/as3objects/tls.py
@@ -37,7 +37,7 @@ def get_pool_name(pool_id):
     return "{}{}".format(constants.PREFIX_TLS_POOL, pool_id)
 
 
-def get_tls_server(certificate_ids, authentication_ca=None, authentication_mode='NONE'):
+def get_tls_server(certificate_ids, listener, authentication_ca=None):
     """ returns AS3 TLS_Server
 
     :param certificate_ids: reference ids to AS3 certificate objs
@@ -52,16 +52,14 @@ def get_tls_server(certificate_ids, authentication_ca=None, authentication_mode=
     }
 
     service_args = {
-        'certificates': [{'certificate': cert_id} for cert_id in set(certificate_ids)]
+        'certificates': [{'certificate': cert_id} for cert_id in set(certificate_ids)],
+        'ciphers': listener.tls_ciphers
     }
 
     if authentication_ca:
         service_args['authenticationTrustCA'] = authentication_ca
         service_args['authenticationInviteCA'] = authentication_ca
-        service_args['authenticationMode'] = mode_map[authentication_mode]
-
-    if CONF.f5_tls_server.default_ciphers:
-        service_args['ciphers'] = CONF.f5_tls_server.default_ciphers
+        service_args['authenticationMode'] = mode_map[listener.client_authentication]
 
     if CONF.f5_tls_server.forward_proxy_bypass is not None:
         service_args['forwardProxyBypassEnabled'] = CONF.f5_tls_server.forward_proxy_bypass


### PR DESCRIPTION
HTTPS-terminated listeners can now be individually configured with an OpenSSL cipher string. The default cipher string for new listeners can be specified with default_tls_ciphers in octavia.conf.