### PR TITLE
move client cert handling to HTTP_REQUEST event

### DIFF
--- a/octavia_f5/restclient/as3objects/irule.py
+++ b/octavia_f5/restclient/as3objects/irule.py
@@ -44,46 +44,38 @@ when HTTP_REQUEST {
     HTTP::header remove "X-Forwarded-Proto"
     HTTP::header insert "X-Forwarded-Proto" $client_protocol
 }"""
-X_SSL_CLIENT_VERIFY = """when CLIENTSSL_CLIENTCERT {
+X_SSL_CLIENT_VERIFY = """when HTTP_REQUEST {
+    if { [HTTP::has_responded] }{ return }
     if { [SSL::cert count] > 0 }{
         set verify_result [SSL::verify_result]
     }
-}
-when HTTP_REQUEST {
-    if { [HTTP::has_responded] }{ return }
     if { [info exists verify_result] } {
         HTTP::header insert "X-SSL-Client-Verify" $verify_result
     }
 }"""
-X_SSL_CLIENT_HAS_CERT = """when CLIENTSSL_CLIENTCERT {
-  set cert_count [SSL::cert count]
-}
-when HTTP_REQUEST {
+X_SSL_CLIENT_HAS_CERT = """when HTTP_REQUEST {
     if { [HTTP::has_responded] }{ return }
+    set cert_count [SSL::cert count]
     if { [info exists cert_count] && $cert_count > 0 }{
         HTTP::header insert "X-SSL-CLIENT-HAS-CERT" 1
     } else {
         HTTP::header insert "X-SSL-CLIENT-HAS-CERT" 0
     }
 }"""
-X_SSL_CLIENT_ISSUER = """when CLIENTSSL_CLIENTCERT {
+X_SSL_CLIENT_ISSUER = """when HTTP_REQUEST {
+    if { [HTTP::has_responded] }{ return }
     if { [SSL::cert count] > 0 }{
         set issuer [X509::issuer [SSL::cert 0]]
     }
-}
-when HTTP_REQUEST {
-    if { [HTTP::has_responded] }{ return }
     if { [info exists issuer] } {
         HTTP::header insert "X-SSL-Client-Issuer" $issuer
     }
 }"""
-X_SSL_CLIENT_DN = """when CLIENTSSL_CLIENTCERT {
+X_SSL_CLIENT_DN = """when HTTP_REQUEST {
+    if { [HTTP::has_responded] }{ return }
     if { [SSL::cert count] > 0 }{
         set subject_dn [X509::subject [SSL::cert 0]]
     }
-}
-when HTTP_REQUEST {
-    if { [HTTP::has_responded] }{ return }
     if { [info exists subject_dn] } {
         HTTP::header insert "X-SSL-Client-DN" $subject_dn
     }
@@ -99,46 +91,38 @@ X_SSL_CLIENT_CN = """proc x509CNExtract { str } {
     }
     return $res
 }
-when CLIENTSSL_CLIENTCERT {
+when HTTP_REQUEST {
+    if { [HTTP::has_responded] }{ return }
     if { [SSL::cert count] > 0 }{
         set subject_cn [X509::issuer [SSL::cert 0]]
     }
-}
-when HTTP_REQUEST {
-    if { [HTTP::has_responded] }{ return }
     if { [info exists subject_cn] } {
         HTTP::header insert "X-SSL-Client-CN" [call x509CNExtract $subject_cn]
     }
 }"""
-X_SSL_CLIENT_SHA1 = """when CLIENTSSL_CLIENTCERT {
+X_SSL_CLIENT_SHA1 = """when HTTP_REQUEST {
+    if { [HTTP::has_responded] }{ return }
     if { [SSL::cert count] > 0 }{
         set hash [X509::hash [SSL::cert 0]]
     }
-}
-when HTTP_REQUEST {
-    if { [HTTP::has_responded] }{ return }
     if { [info exists hash] } {
         HTTP::header insert "X-SSL-Client-SHA1" $hash
     }
 }"""
-X_SSL_CLIENT_NOT_BEFORE = """when CLIENTSSL_CLIENTCERT {
+X_SSL_CLIENT_NOT_BEFORE = """when HTTP_REQUEST {
+    if { [HTTP::has_responded] }{ return }
     if { [SSL::cert count] > 0 }{
         set validity [X509::not_valid_before [SSL::cert 0]]
     }
-}
-when HTTP_REQUEST {
-    if { [HTTP::has_responded] }{ return }
     if { [info exists validity] } {
         HTTP::header insert "X-SSL-Client-Not-Before" $validity
     }
 }"""
-X_SSL_CLIENT_NOT_AFTER = """when CLIENTSSL_CLIENTCERT {
+X_SSL_CLIENT_NOT_AFTER = """when HTTP_REQUEST {
+    if { [HTTP::has_responded] }{ return }
     if { [SSL::cert count] > 0 }{
         set validity [X509::not_valid_after [SSL::cert 0]]
     }
-}
-when HTTP_REQUEST {
-    if { [HTTP::has_responded] }{ return }
     if { [info exists validity] } {
         HTTP::header insert "X-SSL-Client-Not-After" $validity
     }

--- a/octavia_f5/restclient/as3objects/irule.py
+++ b/octavia_f5/restclient/as3objects/irule.py
@@ -55,8 +55,7 @@ X_SSL_CLIENT_VERIFY = """when HTTP_REQUEST {
 }"""
 X_SSL_CLIENT_HAS_CERT = """when HTTP_REQUEST {
     if { [HTTP::has_responded] }{ return }
-    set cert_count [SSL::cert count]
-    if { [info exists cert_count] && $cert_count > 0 }{
+    if { [SSL::cert count] > 0 }{
         HTTP::header insert "X-SSL-CLIENT-HAS-CERT" 1
     } else {
         HTTP::header insert "X-SSL-CLIENT-HAS-CERT" 0


### PR DESCRIPTION
Based on INC1422907 investigation for failed server-side header insertion F5 proposed not to use the `CLIENTSSL_CLIENTCERT` event in irules when ssl session re-use is enabled and instead move the actions to under `HTTP_REQUEST` event to make sure the client certificate is not ignored.

The resulting irule looks like (example):
```
when HTTP_REQUEST {
    if { [HTTP::has_responded] }{ return }
    set cert_count [SSL::cert count]
    if { [info exists cert_count] && $cert_count > 0 }{
        HTTP::header insert "X-SSL-CLIENT-HAS-CERT" 1
    } else {
        HTTP::header insert "X-SSL-CLIENT-HAS-CERT" 0
    }
}
```