### PR TITLE
l2: Fix race condions and missing neutron network handling

### DIFF
--- a/octavia_f5/network/data_models.py
+++ b/octavia_f5/network/data_models.py
@@ -12,8 +12,13 @@
 #  License for the specific language governing permissions and limitations
 #  under the License.
 
+from oslo_log import log as logging
+
 from octavia.common.data_models import BaseDataModel
+from octavia.network import base
 from octavia_f5.utils import driver_utils
+
+LOG = logging.getLogger(__name__)
 
 
 class Network(BaseDataModel):
@@ -50,10 +55,18 @@ class Network(BaseDataModel):
             subnet = self._network_driver.get_subnet(subnet_id)
             return subnet.gateway_ip
 
+    def has_bound_segment(self):
+        for segment in self.segments:
+            if segment['provider:physical_network'] == self._network_driver.physical_network:
+                return True
+        return False
+
     @property
     def vlan_id(self):
         for segment in self.segments:
             if segment['provider:physical_network'] == self._network_driver.physical_network:
                 return segment['provider:segmentation_id']
 
-        return None
+        err = 'Error retrieving segment id for physical network {} of network {}'.format(
+                  self._network_driver.physical_network, self.id)
+        raise base.NetworkException(err)

--- a/octavia_f5/network/drivers/neutron/neutron_client.py
+++ b/octavia_f5/network/drivers/neutron/neutron_client.py
@@ -248,7 +248,15 @@ class NeutronClient(neutron_base.BaseNeutronDriver):
 
         :rtype: octavia_f5 network object
         """
-        network_dict = self.neutron_client.show_network(network_id)
+        try:
+            network_dict = self.neutron_client.show_network(network_id)
+        except neutron_client_exceptions.NotFound:
+            message = _(f"Network not found (network id: {network_id}).")
+            raise base.NetworkNotFound(message)
+        except Exception:
+            message = _(f"Error retrieving network (network id: {network_id}.")
+            LOG.exception(message)
+            raise base.NetworkException(message)
         return f5_utils.convert_network_dict_to_model(network_dict)
 
     @MEMOIZE

--- a/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
+++ b/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
@@ -197,7 +197,7 @@ class TestF5Flows(base.TestCase):
                            'bigip_guest_names': ['test-host-1']})
 
         get_calls = [
-            mock.call(path='/mgmt/tm/net/vlan/vlan-1234?expandSubcollections=true'),
+            mock.call(path='/mgmt/tm/net/vlan/~Common~vlan-1234?expandSubcollections=true'),
             mock.call(path='/mgmt/tm/vcmp/guest'),
         ]
         patch_calls = [


### PR DESCRIPTION
* Fix race condition where vlan is created by vcmp host
The fix includes a retry decoration for ensureVLAN, which detects the
created vlan and updates it's properties.

* Fix handling of missing networks
If a network has been already deleted or manually deleted, don't fail to delete
the load balancer. The l2 full sync will also cleanup any orphaned stuff in this case.

* Fix handling of networks with missing segment bindings
Don't bail of in case a network already lost it's bindings.