### PR TITLE
[controller_worker] QuotasRepository.update expects an autocommit session

### DIFF
--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -284,16 +284,14 @@ class ControllerWorker(object):
             'in_use_member': None,
         }
 
-        lock_session = db_apis.get_session(autocommit=False)
         try:
-            self._quota_repo.update(lock_session, project_id=project_id, quota=reset_dict)
-            lock_session.commit()
+            self._quota_repo.update(db_apis.get_session(),
+                                    project_id=project_id, quota=reset_dict)
         except Exception:
             with excutils.save_and_reraise_exception():
                 LOG.error('Failed to reset quota for '
                           'project: %(proj)s the project may have excess '
                           'quota in use.', {'proj': project_id})
-                lock_session.rollback()
 
     """
     Loadbalancer


### PR DESCRIPTION
according to upstream code:
https://github.com/sapcc/octavia/blob/a2982e0d93b9cad233756d54e3fb5b7f5c20572e/octavia/db/repositories.py#L1936
`This is used with an autocommit session (non-lock_session)`

also, since this function is build as an transaction, no rollback is needed in case
of failure.