### PR TITLE
X-Forwarded-For iRule: Append XF header instead of replacing

### DIFF
--- a/octavia_f5/restclient/as3objects/irule.py
+++ b/octavia_f5/restclient/as3objects/irule.py
@@ -23,11 +23,8 @@ when SERVER_CONNECTED {
     TCP::respond $proxyheader
 }"""
 X_FORWARDED_FOR = """when HTTP_REQUEST {
-  if {[HTTP::header exists X-Forwarded-For]}{
-    HTTP::header replace X-Forwarded-For "[HTTP::header X-Forwarded-For], [getfield [IP::client_addr] "%" 1]"
-  } else {
-    HTTP::header insert X-Forwarded-For [getfield [IP::client_addr] "%" 1]
-  }
+    if { [HTTP::has_responded] }{ return }
+    HTTP::header insert "X-Forwarded-For" [getfield [IP::remote_addr] "%" 1]
 }"""
 X_FORWARDED_PORT = """when HTTP_REQUEST {
     if { [HTTP::has_responded] }{ return }

--- a/octavia_f5/restclient/as3objects/irule.py
+++ b/octavia_f5/restclient/as3objects/irule.py
@@ -23,9 +23,11 @@ when SERVER_CONNECTED {
     TCP::respond $proxyheader
 }"""
 X_FORWARDED_FOR = """when HTTP_REQUEST {
-    if { [HTTP::has_responded] }{ return }
-    HTTP::header remove "X-Forwarded-For"
-    HTTP::header insert "X-Forwarded-For" [getfield [IP::remote_addr] "%" 1]
+  if {[HTTP::header exists X-Forwarded-For]}{
+    HTTP::header replace X-Forwarded-For "[HTTP::header X-Forwarded-For], [getfield [IP::client_addr] "%" 1]"
+  } else {
+    HTTP::header insert X-Forwarded-For [getfield [IP::client_addr] "%" 1]
+  }
 }"""
 X_FORWARDED_PORT = """when HTTP_REQUEST {
     if { [HTTP::has_responded] }{ return }

--- a/octavia_f5/restclient/as3objects/irule.py
+++ b/octavia_f5/restclient/as3objects/irule.py
@@ -28,7 +28,6 @@ X_FORWARDED_FOR = """when HTTP_REQUEST {
 }"""
 X_FORWARDED_PORT = """when HTTP_REQUEST {
     if { [HTTP::has_responded] }{ return }
-    HTTP::header remove "X-Forwarded-Port"
     HTTP::header insert "X-Forwarded-Port" [TCP::local_port]
 }"""
 X_FORWARDED_PROTO = """when CLIENT_ACCEPTED {


### PR DESCRIPTION
This solves #64 by changing the behavior of the already existing XF header iRule to appending instead of replacing.
This is the easiest possible code change, but not strictly backwards compatible, in case some already existing pool members expect the XF header to be just one value instead of a list. However, header chaining via a list as value for `X-Forwarded-For` header is allowed per RFC 2616 section 4.2.
There are two reasons for replacing the XF header-replacing iRule with a XF chaining iRule:
- It's a simpler code change - we don't have to introduce another tag
- RFC 2616 section 4.2 recommends doing it just one way:
  > Applications ought to follow "common form", where one is known or indicated, when generating HTTP constructs, since there might exist some implementations that fail to accept anything beyond the common forms.
