### PR TITLE
[l2] Use subnet gateway from selfips that has been synchronized

### DIFF
--- a/octavia_f5/controller/worker/l2_sync_manager.py
+++ b/octavia_f5/controller/worker/l2_sync_manager.py
@@ -140,8 +140,9 @@ class L2SyncManager(BaseTaskFlowEngine):
             if device and bigip.hostname != device:
                 continue
 
-            store = {'bigip': bigip, 'network': network}
             selfips_for_host = [selfip for selfip in selfips if bigip.hostname in selfip.name]
+            subnet_ids = set(sip.fixed_ips[0].subnet_id for sip in selfips_for_host)
+            store = {'bigip': bigip, 'network': network, 'subnet_id': subnet_ids.pop()}
             fs[self.executor.submit(self._do_ensure_l2_flow, selfips=selfips_for_host, store=store)] = bigip
 
         if CONF.networking.override_vcmp_guest_names:

--- a/octavia_f5/controller/worker/tasks/f5_tasks.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks.py
@@ -232,6 +232,7 @@ class EnsureRoute(task.Task):
 
     @decorators.RaisesIControlRestError()
     def execute(self, bigip: bigip_restclient.BigIPRestClient,
+                subnet_id: str,
                 network: f5_network_models.Network):
 
         if CONF.networking.route_on_active and not bigip.is_active:
@@ -239,7 +240,7 @@ class EnsureRoute(task.Task):
             return None
 
         name = f"vlan-{network.vlan_id}"
-        gw = f"{network.default_gateway_ip}%{network.vlan_id}"
+        gw = f"{network.default_gateway_ip(subnet_id)}%{network.vlan_id}"
         network_name = f"default%{network.vlan_id}"
         route = {'name': name, 'gw': gw, 'network': network_name}
 

--- a/octavia_f5/network/data_models.py
+++ b/octavia_f5/network/data_models.py
@@ -49,11 +49,9 @@ class Network(BaseDataModel):
         self.segments = segments
         self._network_driver = driver_utils.get_network_driver()
 
-    @property
-    def default_gateway_ip(self):
-        for subnet_id in sorted(self.subnets):
-            subnet = self._network_driver.get_subnet(subnet_id)
-            return subnet.gateway_ip
+    def default_gateway_ip(self, subnet_id):
+        subnet = self._network_driver.get_subnet(subnet_id)
+        return subnet.gateway_ip
 
     def has_bound_segment(self):
         for segment in self.segments:

--- a/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
+++ b/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
@@ -86,7 +86,8 @@ class TestF5Flows(base.TestCase):
 
         engines.run(f5flows.ensure_l2([selfip_port]),
                     store={'network': mock_network,
-                           'bigip': mock_bigip})
+                           'bigip': mock_bigip,
+                           'subnet_id': selfip_fixed_ip.subnet_id})
 
         calls = [
             mock.call(json={'name': 'vlan-1234', 'tag': 1234,
@@ -160,7 +161,8 @@ class TestF5Flows(base.TestCase):
 
         engines.run(f5flows.ensure_l2([selfip_port]),
                     store={'network': mock_network,
-                           'bigip': mock_bigip})
+                           'bigip': mock_bigip,
+                           'subnet_id': selfip_fixed_ip.subnet_id})
 
         mock_bigip.get.assert_called()
         mock_bigip.patch.assert_not_called()

--- a/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
+++ b/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
@@ -30,8 +30,14 @@ LOG = logging.getLogger(__name__)
 
 MOCK_BIGIP_HOSTNAME = 'test-guest-hostname'
 MOCK_VCMP_HOSTNAME = 'test-vcmp-hostname'
+MOCK_FIXED_IP = network_models.FixedIP(
+    ip_address='1.2.3.4',
+    subnet_id=uuidutils.generate_uuid()
+)
 MOCK_SELFIP = network_models.Port(
-    name=f"local-{MOCK_BIGIP_HOSTNAME}-{uuidutils.generate_uuid()}")
+    name=f"local-{MOCK_BIGIP_HOSTNAME}-{MOCK_FIXED_IP.subnet_id}",
+    fixed_ips=[MOCK_FIXED_IP]
+)
 
 
 class TestL2SyncManager(base.TestCase):
@@ -63,7 +69,8 @@ class TestL2SyncManager(base.TestCase):
             name=f"local-OTHER_HOST-{uuidutils.generate_uuid()}")
         self.manager.ensure_l2_flow([MOCK_SELFIP, other_selfip], 'test-network-id')
         mock_l2_flow.assert_called_once_with(selfips=[MOCK_SELFIP],
-            store={'bigip': self.manager._bigips[0], 'network': mock_get_network.return_value})
+            store={'bigip': self.manager._bigips[0], 'network': mock_get_network.return_value,
+                   'subnet_id': MOCK_FIXED_IP.subnet_id})
         mock_vcmp_l2_flow.assert_called_once_with(
             store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
                    'bigip_guest_names': [MOCK_BIGIP_HOSTNAME]})
@@ -82,7 +89,8 @@ class TestL2SyncManager(base.TestCase):
 
         self.manager.ensure_l2_flow([MOCK_SELFIP], 'test-network-id')
         mock_l2_flow.assert_called_once_with(selfips=[MOCK_SELFIP],
-            store={'bigip': self.manager._bigips[0], 'network': mock_get_network.return_value})
+            store={'bigip': self.manager._bigips[0], 'network': mock_get_network.return_value,
+                   'subnet_id': MOCK_FIXED_IP.subnet_id})
         mock_vcmp_l2_flow.assert_called_once_with(
             store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
                    'bigip_guest_names': ['test-host-2']})
@@ -102,7 +110,8 @@ class TestL2SyncManager(base.TestCase):
                              e.args[0])
 
         mock_l2_flow.assert_called_once_with(selfips=[MOCK_SELFIP],
-            store={'bigip': self.manager._bigips[0], 'network': mock_get_network.return_value})
+            store={'bigip': self.manager._bigips[0], 'network': mock_get_network.return_value,
+                   'subnet_id': MOCK_FIXED_IP.subnet_id})
         mock_vcmp_l2_flow.assert_called_once_with(
             store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
                    'bigip_guest_names': [MOCK_BIGIP_HOSTNAME]})


### PR DESCRIPTION
BigIP doesn't allow to set arbitrary route gateways for networks,
which are missing selfip cidr for that route.

So instead syncing any route, we are syncing only routes that are
in the cidr-range of selfips used.