### PR TITLE
Skip members that conflict with a selfip

### DIFF
--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -128,7 +128,7 @@ class ControllerWorker(object):
                              for lb in loadbalancers):
                         # Network already exists, just ensure correct selfips
                         self.l2sync.sync_l2_selfips_flow(selfips, network_id, device)
-                    self.sync.tenant_update(network_id, device).raise_for_status()
+                    self.sync.tenant_update(network_id, device, selfips).raise_for_status()
 
                 # update status of just-synced LBs
                 self.status.update_status(loadbalancers)

--- a/octavia_f5/controller/worker/sync_manager.py
+++ b/octavia_f5/controller/worker/sync_manager.py
@@ -161,7 +161,7 @@ class SyncManager(object):
             RETRY_INITIAL_DELAY, RETRY_BACKOFF, RETRY_MAX),
         stop=tenacity.stop_after_attempt(RETRY_ATTEMPTS)
     )
-    def tenant_update(self, network_id, device=None, selfips=[]):
+    def tenant_update(self, network_id, device=None, selfips=None):
         """ Synchronous call to update F5s with all loadbalancers of a tenant (network_id).
 
            :param network_id: the as3 tenant
@@ -171,7 +171,10 @@ class SyncManager(object):
 
         """
 
-        skip_ips = [fixed_ip.ip_address for selfip in selfips for fixed_ip in selfip.fixed_ips]
+        if selfips is None:
+            skip_ips = []
+        else:
+            skip_ips = [fixed_ip.ip_address for selfip in selfips for fixed_ip in selfip.fixed_ips]
         loadbalancers = self._loadbalancer_repo.get_all_by_network(
             db_apis.get_session(), network_id=network_id, show_deleted=False)
         if not loadbalancers:
@@ -205,7 +208,7 @@ class SyncManager(object):
         :param network_id: network id
         :return: True if success, else False
         """
-        decl = self._declaration_manager.get_declaration({network_id: []})
+        decl = self._declaration_manager.get_declaration({network_id: []}, [])
 
         if CONF.f5_agent.dry_run:
             decl.set_action('dry-run')

--- a/octavia_f5/controller/worker/sync_manager.py
+++ b/octavia_f5/controller/worker/sync_manager.py
@@ -161,20 +161,25 @@ class SyncManager(object):
             RETRY_INITIAL_DELAY, RETRY_BACKOFF, RETRY_MAX),
         stop=tenacity.stop_after_attempt(RETRY_ATTEMPTS)
     )
-    def tenant_update(self, network_id, device=None):
+    def tenant_update(self, network_id, device=None, selfips=None):
         """ Synchronous call to update F5s with all loadbalancers of a tenant (network_id).
 
            :param network_id: the as3 tenant
            :param device: hostname of the bigip device, if none use active device
+           :param selfips: list of selfips related to this tenant
            :return: True if success, else False
 
         """
 
+        if selfips is None:
+            skip_members = []
+        else:
+            skip_members = [fixed_ip.ip_address for selfip in selfips for fixed_ip in selfip.fixed_ips]
         loadbalancers = self._loadbalancer_repo.get_all_by_network(
             db_apis.get_session(), network_id=network_id, show_deleted=False)
         if not loadbalancers:
             return False
-        decl = self._declaration_manager.get_declaration({network_id: loadbalancers})
+        decl = self._declaration_manager.get_declaration({network_id: loadbalancers}, skip_members)
 
         if CONF.f5_agent.dry_run:
             decl.set_action('dry-run')
@@ -203,7 +208,7 @@ class SyncManager(object):
         :param network_id: network id
         :return: True if success, else False
         """
-        decl = self._declaration_manager.get_declaration({network_id: []})
+        decl = self._declaration_manager.get_declaration({network_id: []}, [])
 
         if CONF.f5_agent.dry_run:
             decl.set_action('dry-run')

--- a/octavia_f5/controller/worker/sync_manager.py
+++ b/octavia_f5/controller/worker/sync_manager.py
@@ -172,15 +172,15 @@ class SyncManager(object):
         """
 
         if selfips is None:
-            skip_ips = []
+            self_ips = []
         else:
-            skip_ips = [fixed_ip.ip_address for selfip in selfips for fixed_ip in selfip.fixed_ips]
+            self_ips = [fixed_ip.ip_address for selfip in selfips for fixed_ip in selfip.fixed_ips]
         loadbalancers = self._loadbalancer_repo.get_all_by_network(
             db_apis.get_session(), network_id=network_id, show_deleted=False)
         if not loadbalancers:
             return False
 
-        decl = self._declaration_manager.get_declaration({network_id: loadbalancers}, skip_ips)
+        decl = self._declaration_manager.get_declaration({network_id: loadbalancers}, self_ips)
         if CONF.f5_agent.dry_run:
             decl.set_action('dry-run')
 

--- a/octavia_f5/controller/worker/sync_manager.py
+++ b/octavia_f5/controller/worker/sync_manager.py
@@ -161,7 +161,7 @@ class SyncManager(object):
             RETRY_INITIAL_DELAY, RETRY_BACKOFF, RETRY_MAX),
         stop=tenacity.stop_after_attempt(RETRY_ATTEMPTS)
     )
-    def tenant_update(self, network_id, device=None, selfips=None):
+    def tenant_update(self, network_id, device=None, selfips=[]):
         """ Synchronous call to update F5s with all loadbalancers of a tenant (network_id).
 
            :param network_id: the as3 tenant
@@ -171,20 +171,17 @@ class SyncManager(object):
 
         """
 
-        if selfips is None:
-            skip_members = []
-        else:
-            skip_members = [fixed_ip.ip_address for selfip in selfips for fixed_ip in selfip.fixed_ips]
+        skip_ips = [fixed_ip.ip_address for selfip in selfips for fixed_ip in selfip.fixed_ips]
         loadbalancers = self._loadbalancer_repo.get_all_by_network(
             db_apis.get_session(), network_id=network_id, show_deleted=False)
         if not loadbalancers:
             return False
-        decl = self._declaration_manager.get_declaration({network_id: loadbalancers}, skip_members)
 
+        decl = self._declaration_manager.get_declaration({network_id: loadbalancers}, skip_ips)
         if CONF.f5_agent.dry_run:
             decl.set_action('dry-run')
 
-        # No config syncing if we are in migration mode or specificly syncing one device
+        # No config syncing if we are in migration mode or specifically syncing one device
         if not CONF.f5_agent.migration and not device and CONF.f5_agent.sync_to_group:
             decl.set_sync_to_group(CONF.f5_agent.sync_to_group)
 
@@ -208,7 +205,7 @@ class SyncManager(object):
         :param network_id: network id
         :return: True if success, else False
         """
-        decl = self._declaration_manager.get_declaration({network_id: []}, [])
+        decl = self._declaration_manager.get_declaration({network_id: []})
 
         if CONF.f5_agent.dry_run:
             decl.set_action('dry-run')

--- a/octavia_f5/restclient/as3declaration.py
+++ b/octavia_f5/restclient/as3declaration.py
@@ -27,7 +27,7 @@ class AS3DeclarationManager(object):
         self._cert_manager = cert_manager.CertManagerWrapper()
         self._status_manager = status_manager
 
-    def get_declaration(self, tenants, skip_ips=[]):
+    def get_declaration(self, tenants, skip_ips):
         """ Returns complete AS3 declaration
 
         :param tenants: dict of network_id: loadbalancers, multiple tenants supported

--- a/octavia_f5/restclient/as3declaration.py
+++ b/octavia_f5/restclient/as3declaration.py
@@ -27,10 +27,11 @@ class AS3DeclarationManager(object):
         self._cert_manager = cert_manager.CertManagerWrapper()
         self._status_manager = status_manager
 
-    def get_declaration(self, tenants):
+    def get_declaration(self, tenants, skip_members):
         """ Returns complete AS3 declaration
 
         :param tenants: dict of network_id: loadbalancers, multiple tenants supported
+        :param skip_members: list of ip-addresses to remove from declaration (and print error)
         :param status: status manager instance (optional) for certifcate error callback
 
         :return: complete AS3 declaration
@@ -54,7 +55,7 @@ class AS3DeclarationManager(object):
 
             # get Tenant
             name = m_tenant.get_name(network_id)
-            tenant = m_tenant.get_tenant(segmentation_id, loadbalancers,
+            tenant = m_tenant.get_tenant(segmentation_id, loadbalancers, skip_members,
                                          self._status_manager, self._cert_manager, self._esd_repo)
             adc.set_tenant(name, tenant)
 

--- a/octavia_f5/restclient/as3declaration.py
+++ b/octavia_f5/restclient/as3declaration.py
@@ -27,11 +27,11 @@ class AS3DeclarationManager(object):
         self._cert_manager = cert_manager.CertManagerWrapper()
         self._status_manager = status_manager
 
-    def get_declaration(self, tenants, skip_ips):
+    def get_declaration(self, tenants, self_ips):
         """ Returns complete AS3 declaration
 
         :param tenants: dict of network_id: loadbalancers, multiple tenants supported
-        :param skip_ips: list of ip-addresses to remove from declaration (and print error).
+        :param self_ips: list of SelfIPs. They are removed from the declaration and an error is printed.
         :param status: status manager instance (optional) for certifcate error callback
 
         :return: complete AS3 declaration
@@ -55,7 +55,7 @@ class AS3DeclarationManager(object):
 
             # get Tenant
             name = m_tenant.get_name(network_id)
-            tenant = m_tenant.get_tenant(segmentation_id, loadbalancers, skip_ips,
+            tenant = m_tenant.get_tenant(segmentation_id, loadbalancers, self_ips,
                                          self._status_manager, self._cert_manager, self._esd_repo)
             adc.set_tenant(name, tenant)
 

--- a/octavia_f5/restclient/as3declaration.py
+++ b/octavia_f5/restclient/as3declaration.py
@@ -27,11 +27,11 @@ class AS3DeclarationManager(object):
         self._cert_manager = cert_manager.CertManagerWrapper()
         self._status_manager = status_manager
 
-    def get_declaration(self, tenants, skip_members):
+    def get_declaration(self, tenants, skip_ips=[]):
         """ Returns complete AS3 declaration
 
         :param tenants: dict of network_id: loadbalancers, multiple tenants supported
-        :param skip_members: list of ip-addresses to remove from declaration (and print error)
+        :param skip_ips: list of ip-addresses to remove from declaration (and print error).
         :param status: status manager instance (optional) for certifcate error callback
 
         :return: complete AS3 declaration
@@ -55,7 +55,7 @@ class AS3DeclarationManager(object):
 
             # get Tenant
             name = m_tenant.get_name(network_id)
-            tenant = m_tenant.get_tenant(segmentation_id, loadbalancers, skip_members,
+            tenant = m_tenant.get_tenant(segmentation_id, loadbalancers, skip_ips,
                                          self._status_manager, self._cert_manager, self._esd_repo)
             adc.set_tenant(name, tenant)
 

--- a/octavia_f5/restclient/as3objects/pool.py
+++ b/octavia_f5/restclient/as3objects/pool.py
@@ -35,11 +35,11 @@ def get_name(pool_id):
     return "{}{}".format(f5_consts.PREFIX_POOL, pool_id)
 
 
-def get_pool(pool, loadbalancer_ips, status):
+def get_pool(pool, ips_to_skip, status):
     """Map Octavia Pool -> AS3 Pool object
 
     :param pool: octavia pool object
-    :param loadbalancer_ips: already used loadbalancer_ips
+    :param ips_to_skip: already used VIPs and SelfIPs
     :param status: status manager instance
     :return: AS3 pool
     """
@@ -60,7 +60,7 @@ def get_pool(pool, loadbalancer_ips, status):
     enable_priority_group = any([member.backup for member in pool.members])
     for member in pool.members:
         if not utils.pending_delete(member):
-            if member.ip_address in loadbalancer_ips:
+            if member.ip_address in ips_to_skip:
                 LOG.warning("The member address %s of member %s (pool %s, LB %s) is already in use by another load balancer.",
                             member.ip_address, member.id, member.pool.id, member.pool.load_balancer.id)
                 if status:

--- a/octavia_f5/restclient/as3objects/tenant.py
+++ b/octavia_f5/restclient/as3objects/tenant.py
@@ -34,7 +34,7 @@ def get_name(network_id):
                          network_id.replace('-', '_'))
 
 
-def get_tenant(segmentation_id, loadbalancers, status_manager, cert_manager, esd_repo):
+def get_tenant(segmentation_id, loadbalancers, skip_members, status_manager, cert_manager, esd_repo):
 
     project_id = None
     if loadbalancers:
@@ -47,9 +47,9 @@ def get_tenant(segmentation_id, loadbalancers, status_manager, cert_manager, esd
 
     tenant = as3.Tenant(**tenant_dict)
 
-    # Skip members that re-use load balancer vips
+    # Skip members that re-use load balancer vips and selfips
     loadbalancer_ips = [load_balancer.vip.ip_address for load_balancer in loadbalancers
-                        if not driver_utils.pending_delete(load_balancer)]
+                        if not driver_utils.pending_delete(load_balancer)] + skip_members
 
     for loadbalancer in loadbalancers:
         # Skip load balancer in (pending) deletion

--- a/octavia_f5/restclient/as3objects/tenant.py
+++ b/octavia_f5/restclient/as3objects/tenant.py
@@ -34,7 +34,7 @@ def get_name(network_id):
                          network_id.replace('-', '_'))
 
 
-def get_tenant(segmentation_id, loadbalancers, skip_ips, status_manager, cert_manager, esd_repo):
+def get_tenant(segmentation_id, loadbalancers, self_ips, status_manager, cert_manager, esd_repo):
 
     project_id = None
     if loadbalancers:
@@ -47,9 +47,9 @@ def get_tenant(segmentation_id, loadbalancers, skip_ips, status_manager, cert_ma
 
     tenant = as3.Tenant(**tenant_dict)
 
-    # Skip some IP addresses. This is used for skipping members with existing VIPs and SelfIPs.
-    loadbalancer_ips = [load_balancer.vip.ip_address for load_balancer in loadbalancers
-                        if not driver_utils.pending_delete(load_balancer)] + skip_ips
+    # Skip members with the same IP as a VIP or SelfIP
+    ips_to_skip = [load_balancer.vip.ip_address for load_balancer in loadbalancers
+                        if not driver_utils.pending_delete(load_balancer)] + self_ips
 
     for loadbalancer in loadbalancers:
         # Skip load balancer in (pending) deletion
@@ -78,7 +78,7 @@ def get_tenant(segmentation_id, loadbalancers, skip_ips, status_manager, cert_ma
         # Attach pools
         for pool in loadbalancer.pools:
             if not driver_utils.pending_delete(pool):
-                app.add_entities(m_pool.get_pool(pool, loadbalancer_ips, status_manager))
+                app.add_entities(m_pool.get_pool(pool, ips_to_skip, status_manager))
 
         # Attach newly created application
         tenant.add_application(m_app.get_name(loadbalancer.id), app)

--- a/octavia_f5/restclient/as3objects/tenant.py
+++ b/octavia_f5/restclient/as3objects/tenant.py
@@ -34,7 +34,7 @@ def get_name(network_id):
                          network_id.replace('-', '_'))
 
 
-def get_tenant(segmentation_id, loadbalancers, skip_members, status_manager, cert_manager, esd_repo):
+def get_tenant(segmentation_id, loadbalancers, skip_ips, status_manager, cert_manager, esd_repo):
 
     project_id = None
     if loadbalancers:
@@ -47,9 +47,9 @@ def get_tenant(segmentation_id, loadbalancers, skip_members, status_manager, cer
 
     tenant = as3.Tenant(**tenant_dict)
 
-    # Skip members that re-use load balancer vips and selfips
+    # Skip some IP addresses. This is used for skipping members with existing VIPs and SelfIPs.
     loadbalancer_ips = [load_balancer.vip.ip_address for load_balancer in loadbalancers
-                        if not driver_utils.pending_delete(load_balancer)] + skip_members
+                        if not driver_utils.pending_delete(load_balancer)] + skip_ips
 
     for loadbalancer in loadbalancers:
         # Skip load balancer in (pending) deletion

--- a/octavia_f5/tests/unit/controller/worker/test_sync_manager.py
+++ b/octavia_f5/tests/unit/controller/worker/test_sync_manager.py
@@ -1,0 +1,66 @@
+#  Copyright 2022 SAP SE
+#
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License. You may obtain
+#  a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+
+from unittest import mock
+
+from oslo_config import cfg
+from oslo_config import fixture as oslo_fixture
+from oslo_log import log as logging
+
+import octavia.tests.unit.base as base
+from octavia.db import models
+from octavia.network import data_models as network_models
+# pylint: disable=unused-import
+from octavia_f5.common import config  # noqa
+from octavia_f5.controller.worker import sync_manager
+
+CONF = cfg.CONF
+LOG = logging.getLogger(__name__)
+
+MOCK_BIGIP_HOSTNAME = 'test-guest-hostname'
+
+class TestSyncManager(base.TestCase):
+    def setUp(self):
+        conf = self.useFixture(oslo_fixture.Config(cfg.CONF))
+        conf.config(group='controller_worker',
+                    network_driver='network_noop_driver_f5')
+        super(TestSyncManager, self).setUp()
+
+    @mock.patch("octavia_f5.controller.worker.sync_manager.SyncManager"
+                        ".initialize_bigips")
+    @mock.patch("octavia_f5.utils.esd_repo.EsdRepository")
+    @mock.patch("octavia_f5.restclient.as3declaration.AS3DeclarationManager")
+    def test_tenant_update_skip_selfips(self, mock_as3, mock_esd_repo, mock_init_bigips):
+        mock_decl_manager = mock.Mock()
+        mock_as3.return_value = mock_decl_manager
+
+        bigip = mock.Mock()
+        bigip.hostname = MOCK_BIGIP_HOSTNAME
+
+        mock_init_bigips.side_effect = [[bigip]]
+        status_manger = mock.MagicMock()
+        loadbalancer_repo = mock.MagicMock()
+        manager = sync_manager.SyncManager(
+            status_manger, loadbalancer_repo)
+
+        selfips = [network_models.Port(fixed_ips=[
+            network_models.FixedIP(ip_address='1.2.3.4')])]
+
+        mock_lb = mock.Mock(spec=models.LoadBalancer)
+        loadbalancer_repo.get_all_by_network.return_value = [mock_lb]
+        with mock.patch('octavia_f5.db.api.get_session'):
+            manager.tenant_update('test-net-id', selfips=selfips)
+        mock_decl_manager.get_declaration.assert_called_with(
+            {'test-net-id': [mock_lb]}, ['1.2.3.4'])
+        pass

--- a/octavia_f5/tests/unit/restclient/test_tenant.py
+++ b/octavia_f5/tests/unit/restclient/test_tenant.py
@@ -48,7 +48,7 @@ class TestGetTenant(base.TestCase):
         as3 = tenant.get_tenant(
             segmentation_id=1234,
             loadbalancers=[mock_lb],
-            skip_ips=[skip_ip],
+            self_ips=[skip_ip],
             status_manager=mock_status_manager,
             cert_manager=None,
             esd_repo=None)

--- a/octavia_f5/tests/unit/restclient/test_tenant.py
+++ b/octavia_f5/tests/unit/restclient/test_tenant.py
@@ -43,12 +43,12 @@ class TestGetTenant(base.TestCase):
                     members=mock_members
                 )],
         )
-        skip_member = '2.3.4.5'
+        skip_ip = '2.3.4.5'
 
         as3 = tenant.get_tenant(
             segmentation_id=1234,
             loadbalancers=[mock_lb],
-            skip_members=[skip_member],
+            skip_ips=[skip_ip],
             status_manager=mock_status_manager,
             cert_manager=None,
             esd_repo=None)

--- a/octavia_f5/tests/unit/restclient/test_tenant.py
+++ b/octavia_f5/tests/unit/restclient/test_tenant.py
@@ -1,0 +1,65 @@
+#  Copyright 2022 SAP SE
+#
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License. You may obtain
+#  a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+
+import mock
+
+from octavia.common import constants
+from octavia.db import models
+from octavia.tests.unit import base
+from octavia_f5.restclient.as3classes import Tenant
+from octavia_f5.restclient.as3objects import tenant
+
+
+class TestGetTenant(base.TestCase):
+
+    def test_get_tenant_with_skip_ips(self):
+        mock_status_manager = mock.MagicMock()
+
+        mock_members = [
+            models.Member(id='test_id_1', ip_address='1.2.3.4', weight=1, protocol_port=1234),
+            models.Member(id='test_id_2', ip_address='2.3.4.5', weight=1, protocol_port=2345),
+            models.Member(id='test_id_3', ip_address='3.4.5.6', weight=1, protocol_port=3456)]
+
+        mock_lb = models.LoadBalancer(
+            id='test_lb_id',
+            vip=models.Vip(ip_address='1.2.3.4'),
+            listeners=[],
+            pools=[
+                models.Pool(
+                    id='test_pool_id',
+                    name='test_pool',
+                    lb_algorithm=constants.LB_ALGORITHM_ROUND_ROBIN,
+                    members=mock_members
+                )],
+        )
+        skip_member = '2.3.4.5'
+
+        as3 = tenant.get_tenant(
+            segmentation_id=1234,
+            loadbalancers=[mock_lb],
+            skip_members=[skip_member],
+            status_manager=mock_status_manager,
+            cert_manager=None,
+            esd_repo=None)
+
+        self.assertIsInstance(as3, Tenant)
+        members = as3.lb_test_lb_id.pool_test_pool_id.members
+        self.assertEqual(1, len(members))
+        self.assertEqual(['3.4.5.6'], members[0].serverAddresses)
+        self.assertEqual(3456, members[0].servicePort)
+        self.assertEqual('test_id_3', members[0].remark)
+        mock_status_manager.set_error.assert_has_calls([
+            mock.call(mock_members[0]),
+            mock.call(mock_members[1]),
+        ])


### PR DESCRIPTION
This commit fixes a forbidden declaration where a member ip equals
a selfip in the same network. Those declarations would be rejected by AS3.

This commit adds selfips to the list of to excluding IPs, thus setting the member
into ERROR state and omitting them as members.

Fixes also internal bug [CCM-22407]