### PR TITLE
Implement ALPN/HTTP2

### DIFF
--- a/octavia_f5/common/config.py
+++ b/octavia_f5/common/config.py
@@ -66,6 +66,9 @@ f5_agent_opts = [
     cfg.StrOpt('profile_http', default=None,
                help=_("Path to default HTTP profile"
                       "(e.g. custom_http)")),
+    cfg.StrOpt('profile_http2', default=None,
+               help=_("Path to default HTTP2 profile"
+                      "(e.g. custom_http2)")),
     cfg.StrOpt('profile_http_compression', default=None,
                help=_("Path to default http compression profile"
                       " profile (e.g. custom_http_compression)")),

--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -149,9 +149,13 @@ def get_service(listener, cert_manager, esd_repository):
             except exceptions.CertificateRetrievalException as e:
                 LOG.error("Error fetching certificate: %s", e)
 
+        # TLS renegotiation has to be turned off for HTTP2, in order to be compliant.
+        allow_renegotiation = not hasattr(listener, 'alpn_protocols')
+
         entities.append((
             m_tls.get_listener_name(listener.id),
-            m_tls.get_tls_server([cert['id'] for cert in certificates], listener, auth_name)
+            m_tls.get_tls_server([cert['id'] for cert in certificates], listener, auth_name,
+                                 allow_renegotiation)
         ))
         entities.extend([(cert['id'], cert['as3']) for cert in certificates])
     # Proxy

--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -335,7 +335,7 @@ def get_service(listener, cert_manager, esd_repository):
     if CONF.f5_agent.profile_http2 and service_args['_servicetype'] in f5_const.SERVICE_HTTPS and is_http2(listener):
         if 'profileHTTP' not in service_args:
             LOG.error("Misconfiguration detected: listener %s should be configured with"
-                      " HTTP/2 profile but does not contain HTTP/1 profile.")
+                      " HTTP/2 profile but does not contain HTTP/1 profile.", listener.id)
         elif 'profileHTTP2' not in service_args:
             service_args['profileHTTP2'] = as3.BigIP(CONF.f5_agent.profile_http2)
     if CONF.f5_agent.profile_l4 and service_args['_servicetype'] == f5_const.SERVICE_L4:

--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -319,6 +319,12 @@ def get_service(listener, cert_manager, esd_repository):
     if CONF.f5_agent.profile_http and service_args['_servicetype'] in f5_const.SERVICE_HTTP_TYPES:
         if 'profileHTTP' not in service_args:
             service_args['profileHTTP'] = as3.BigIP(CONF.f5_agent.profile_http)
+    if CONF.f5_agent.profile_http2 and service_args['_servicetype'] in f5_const.SERVICE_HTTPS \
+            and listener.alpn_protocols:
+        # We don't need to check whether listener.alpn_protocols contains HTTP2, because
+        # if it doesn't, the HTTP2 profile will simply behave like the normal HTTP profile.
+        if 'profileHTTP' not in service_args:
+            service_args['profileHTTP'] = as3.BigIP(CONF.f5_agent.profile_http2)
     if CONF.f5_agent.profile_l4 and service_args['_servicetype'] == f5_const.SERVICE_L4:
         if 'profileL4' not in service_args:
             service_args['profileL4'] = as3.BigIP(CONF.f5_agent.profile_l4)

--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -334,7 +334,10 @@ def get_service(listener, cert_manager, esd_repository):
             service_args['profileHTTP'] = as3.BigIP(CONF.f5_agent.profile_http)
     if CONF.f5_agent.profile_http2 and service_args['_servicetype'] in f5_const.SERVICE_HTTPS and is_http2(listener):
         if 'profileHTTP' not in service_args:
-            service_args['profileHTTP'] = as3.BigIP(CONF.f5_agent.profile_http2)
+            LOG.error("Misconfiguration detected: listener %s should be configured with"
+                      " HTTP/2 profile but does not contain HTTP/1 profile.")
+        elif 'profileHTTP2' not in service_args:
+            service_args['profileHTTP2'] = as3.BigIP(CONF.f5_agent.profile_http2)
     if CONF.f5_agent.profile_l4 and service_args['_servicetype'] == f5_const.SERVICE_L4:
         if 'profileL4' not in service_args:
             service_args['profileL4'] = as3.BigIP(CONF.f5_agent.profile_l4)

--- a/octavia_f5/restclient/as3objects/tls.py
+++ b/octavia_f5/restclient/as3objects/tls.py
@@ -69,12 +69,13 @@ def filter_cipher_suites(cipher_suites, object_print_name, object_id):
     return ':'.join(cipher_suites_list)
 
 
-def get_tls_server(certificate_ids, listener, authentication_ca=None):
+def get_tls_server(certificate_ids, listener, authentication_ca=None, allow_renegotiation=True):
     """ returns AS3 TLS_Server
 
     :param certificate_ids: reference ids to AS3 certificate objs
     :param listener: Listener object
     :param authentication_ca: reference id to AS3 auth-ca obj
+    :param allow_renegotiation: Whether to allow TLS renegotiation. Has to be False when HTTP2 is used.
     :return: TLS_Server
     """
     mode_map = {
@@ -118,6 +119,7 @@ def get_tls_server(certificate_ids, listener, authentication_ca=None):
     # Note: tls_1_1 is only supported in tmos version 14.0+
     service_args['tls1_1Enabled'] = lib_consts.TLS_VERSION_1_1 in tls_versions
     service_args['tls1_2Enabled'] = lib_consts.TLS_VERSION_1_2 in tls_versions
+    service_args['renegotiationEnabled'] = allow_renegotiation
 
     return TLS_Server(**service_args)
 


### PR DESCRIPTION
HTTP2 profile will be activated when listener has parameter `alpn_protocols` set. If that parameter does not contain HTTP2, the HTTP2 profile will behave like the already existing "normal" HTTP profile.
This PR will be merged together with other PRs in the milestone.

To do:
- [x] Create HTTP2 profile on F5s with name given in https://github.com/sapcc/helm-charts/pull/3861
- [x] Merge https://github.com/sapcc/helm-charts/pull/3861