### PR TITLE
Rescheduling arbiter

### DIFF
--- a/octavia_f5/api/drivers/f5_driver/arbiter.py
+++ b/octavia_f5/api/drivers/f5_driver/arbiter.py
@@ -1,0 +1,93 @@
+# Copyright 2022 SAP SE
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import abc
+
+from oslo_config import cfg
+from oslo_log import log as logging
+from taskflow import flow
+from taskflow.listeners import logging as tf_logging
+from taskflow.patterns import linear_flow, unordered_flow
+
+from octavia.common import base_taskflow
+from octavia_f5.controller.worker.tasks import network_tasks
+from octavia_f5.api.drivers.f5_driver.tasks import reschedule_tasks
+from octavia_f5.utils import driver_utils
+
+CONF = cfg.CONF
+LOG = logging.getLogger(__name__)
+
+
+class RescheduleMixin(object, metaclass=abc.ABCMeta):
+    """Abstract mixin class for reschedule support in loadbalancer RPC
+
+    """
+    def loadbalancer_add(self, loadbalancer_id, target_host):
+        """Forces a loadbalancer to be added to the target host
+
+        :param loadbalancer_id: loadbalancer id
+        :param target_host: agent
+        """
+
+    def loadbalancer_remove(self, loadbalancer_id, target_host):
+        """Forces a loadbalancer to be removed from the target host
+
+        :param loadbalancer_id: loadbalancer id
+        :param target_host: agent
+        """
+
+
+class MigrationArbiter(RescheduleMixin):
+    def __init__(self):
+        self.tf_engine = base_taskflow.BaseTaskFlowEngine()
+        self.network_driver = driver_utils.get_network_driver()
+
+    def run_flow(self, func, *args, **kwargs):
+        tf = self.tf_engine.taskflow_load(
+            func(*args), **kwargs)
+        with tf_logging.DynamicLoggingListener(tf, log=LOG):
+            tf.run()
+
+    def get_reschedule_flow(self) -> flow.Flow:
+        # Prepare Self-IPs for target
+        get_loadbalancer_task = reschedule_tasks.GetLoadBalancerByID()
+        create_selfips_task = network_tasks.CreateSelfIPs(self.network_driver)
+        wait_for_selfip_task = network_tasks.WaitForNewSelfIPs(self.network_driver)
+
+        add_loadbalancer_task = reschedule_tasks.ForceAddLoadbalancer(rpc=self)
+        get_old_agent_task = reschedule_tasks.GetOldAgentFromLoadBalancer()
+        remove_loadbalancer_task = reschedule_tasks.ForceDeleteLoadbalancer(rpc=self)
+        rewrite_loadbalancer_task = reschedule_tasks.RewriteLoadBalancerEntry()
+        rewrite_amphora_task = reschedule_tasks.RewriteAmphoraEntry()
+
+        all_selfips_task = network_tasks.AllSelfIPs(self.network_driver)
+        get_vip_port_task = network_tasks.GetVIPFromLoadBalancer(self.network_driver)
+        update_aap_task = network_tasks.UpdateAAP(self.network_driver)
+        update_vip_task = network_tasks.UpdateVIP(self.network_driver)
+        invalidate_cache_task = network_tasks.InvalidateCache(self.network_driver)
+
+        add_remove_loadbalancer_flow = unordered_flow.Flow('add-remove-lb-flow')
+        add_remove_loadbalancer_flow.add(add_loadbalancer_task, remove_loadbalancer_task)
+
+        update_database_flow = unordered_flow.Flow("database-update-flow")
+        update_database_flow.add(rewrite_loadbalancer_task, rewrite_amphora_task, invalidate_cache_task)
+
+        update_vip_flow = linear_flow.Flow("update-vip-flow")
+        update_vip_flow.add(get_vip_port_task, update_vip_task, all_selfips_task, update_aap_task)
+
+        reschedule_flow = linear_flow.Flow('reschedule-flow')
+        reschedule_flow.add(get_loadbalancer_task, get_old_agent_task, create_selfips_task,
+                            wait_for_selfip_task, add_remove_loadbalancer_flow,
+                            update_database_flow, update_vip_flow)
+        return reschedule_flow

--- a/octavia_f5/api/drivers/f5_driver/arbiter.py
+++ b/octavia_f5/api/drivers/f5_driver/arbiter.py
@@ -91,5 +91,5 @@ class MigrationArbiter(RescheduleMixin):
         reschedule_flow = linear_flow.Flow('reschedule-flow')
         reschedule_flow.add(get_loadbalancer_task, get_old_agent_task, create_selfips_task,
                             wait_for_selfip_task, add_remove_loadbalancer_flow,
-                            update_database_flow, update_vip_sub_flow)
+                            update_database_flow)
         return reschedule_flow

--- a/octavia_f5/api/drivers/f5_driver/tasks/reschedule_tasks.py
+++ b/octavia_f5/api/drivers/f5_driver/tasks/reschedule_tasks.py
@@ -1,0 +1,125 @@
+# Copyright 10/6/22 SAP SE
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from abc import ABCMeta
+
+from oslo_config import cfg
+from oslo_log import log as logging
+from taskflow import task
+from taskflow.types import failure
+
+from octavia.common import constants
+from octavia.common import data_models as models
+from octavia.db import api as db_apis
+from octavia_f5.db import repositories as repo
+
+LOG = logging.getLogger(__name__)
+CONF = cfg.CONF
+
+
+class RescheduleTasks(task.Task, metaclass=ABCMeta):
+    """Base task to load drivers common to the tasks."""
+    def __init__(self, **kwargs):
+        self.rpc = kwargs.pop("rpc", None)
+        super(RescheduleTasks, self).__init__(**kwargs)
+        self._loadbalancer_repo = repo.LoadBalancerRepository()
+        self._amphora_repo = repo.AmphoraRepository()
+
+
+class GetLoadBalancerByID(RescheduleTasks):
+    default_provides = 'load_balancer'
+
+    def execute(self, loadbalancer_id):
+        LOG.debug("Get load balancer from DB by id: %s ", loadbalancer_id)
+        return self._loadbalancer_repo.get(db_apis.get_session(),
+                                           id=loadbalancer_id)
+
+
+class GetOldAgentFromLoadBalancer(RescheduleTasks):
+    default_provides = 'removal_host'
+
+    def execute(self, load_balancer: models.LoadBalancer):
+        return load_balancer.server_group_id
+
+
+class ForceAddLoadbalancer(RescheduleTasks):
+    def execute(self, loadbalancer_id: str, candidate: str):
+        self.rpc.loadbalancer_add(loadbalancer_id=loadbalancer_id,
+                                  target_host=candidate)
+
+    def revert(self, result, loadbalancer_id: str, candidate: str, **kwargs):
+        """Handle a failure to force adding a loadbalancer."""
+
+        if isinstance(result, failure.Failure):
+            LOG.error("ForceAddLoadbalancer: Unable to create loadbalancer")
+            return
+        LOG.warning("ForceAddLoadbalancer: Reverting create loadbalancer %s from %s",
+                    loadbalancer_id, candidate)
+        self.rpc.loadbalancer_remove(loadbalancer_id=loadbalancer_id,
+                                     target_host=candidate)
+
+
+class ForceDeleteLoadbalancer(RescheduleTasks):
+    def execute(self, loadbalancer_id: str, removal_host: str):
+        self.rpc.loadbalancer_remove(loadbalancer_id=loadbalancer_id,
+                                     target_host=removal_host)
+
+    def revert(self, result, loadbalancer_id: str, removal_host: str, **kwargs):
+        """Handle a failure to force adding a loadbalancer."""
+
+        if isinstance(result, failure.Failure):
+            LOG.error("ForceDeleteLoadbalancer: Unable to delete loadbalancer")
+            return
+        LOG.warning("ForceDeleteLoadbalancer: Reverting delete loadbalancer %s from %s",
+                    loadbalancer_id, removal_host)
+        self.rpc.loadbalancer_add(loadbalancer_id=loadbalancer_id,
+                                  target_host=removal_host)
+
+
+class RewriteAmphoraEntry(RescheduleTasks):
+    def execute(self, load_balancer: models.LoadBalancer, candidate: str, *args, **kwargs):
+        LOG.debug("RewriteAmphoraEntry %s: Changing host '%s' to '%s'.",
+                  load_balancer.id, load_balancer.server_group_id, candidate)
+        self._amphora_repo.update(db_apis.get_session(), load_balancer.id, compute_flavor=candidate)
+        self._loadbalancer_repo.update(db_apis.get_session(), load_balancer.id, server_group_id=candidate,
+                                       provisioning_status=constants.PENDING_CREATE)
+
+    def revert(self, result, load_balancer: models.LoadBalancer, candidate: str, removal_host: str, **kwargs):
+        """Handle a failure to force adding a loadbalancer."""
+
+        if isinstance(result, failure.Failure):
+            LOG.error("RewriteAmphoraEntry: Unable to update Amphora entry for %s",
+                      load_balancer.id)
+            return
+        LOG.warning("RewriteAmphoraEntry: Reverting host change of amphora %s from '%s' to '%s'",
+                    load_balancer.id, candidate, removal_host)
+        self._amphora_repo.update(db_apis.get_session(), load_balancer.id, compute_flavor=removal_host)
+
+
+class RewriteLoadBalancerEntry(RescheduleTasks):
+    def execute(self, load_balancer: models.LoadBalancer, candidate: str, *args, **kwargs):
+        LOG.debug("RewriteLoadBalancerEntry %s: Changing host '%s' to '%s'.",
+                  load_balancer.id, load_balancer.server_group_id, candidate)
+        self._loadbalancer_repo.update(db_apis.get_session(), load_balancer.id, server_group_id=candidate)
+
+    def revert(self, result, load_balancer: models.LoadBalancer, candidate: str, removal_host: str, **kwargs):
+        """Handle a failure to force adding a loadbalancer."""
+
+        if isinstance(result, failure.Failure):
+            LOG.error("RewriteLoadBalancerEntry: Unable to update loadbalancer %s",
+                      load_balancer.id)
+            return
+        LOG.warning("RewriteLoadBalancerEntry: Reverting host change of loadbalancer %s from '%s' to '%s'",
+                    load_balancer.id, candidate, removal_host)
+        self._loadbalancer_repo.update(db_apis.get_session(), load_balancer.id, server_group_id=removal_host)

--- a/octavia_f5/api/drivers/f5_driver/tasks/reschedule_tasks.py
+++ b/octavia_f5/api/drivers/f5_driver/tasks/reschedule_tasks.py
@@ -92,8 +92,6 @@ class RewriteAmphoraEntry(RescheduleTasks):
         LOG.debug("RewriteAmphoraEntry %s: Changing host '%s' to '%s'.",
                   load_balancer.id, load_balancer.server_group_id, candidate)
         self._amphora_repo.update(db_apis.get_session(), load_balancer.id, compute_flavor=candidate)
-        self._loadbalancer_repo.update(db_apis.get_session(), load_balancer.id, server_group_id=candidate,
-                                       provisioning_status=constants.PENDING_CREATE)
 
     def revert(self, result, load_balancer: models.LoadBalancer, candidate: str, removal_host: str, **kwargs):
         """Handle a failure to force adding a loadbalancer."""

--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -108,9 +108,8 @@ class ControllerWorker(object):
 
     def as3worker(self):
         @lockutils.synchronized("f5sync", fair=True)
-        def f5sync(*args):
+        def f5sync(network_id, device, *args):
             self._metric_as3worker_queue.labels(octavia_host=CONF.host).set(self.queue.qsize())
-            network_id, device = self.queue.get()
             loadbalancers = self._get_all_loadbalancer(network_id)
             LOG.debug("AS3Worker after pop (queue_size=%d): Refresh tenant '%s' with loadbalancer %s",
                       self.queue.qsize(), network_id, [lb.id for lb in loadbalancers])
@@ -140,7 +139,8 @@ class ControllerWorker(object):
         """ AS3 Worker thread, pops tenant to refresh from thread-safe set queue"""
         while True:
             try:
-                f5sync()
+                network_id, device = self.queue.get()
+                f5sync(network_id, device)
             except Empty:
                 # Queue empty, pass
                 pass


### PR DESCRIPTION
This is a taskflow based rescheduling mechanism
* allows to reschedule a single load_balancer to any new agent
* supports revert in case something fails

Possible improvements:
* atomic delete/creation instead of parallelization (hard to realize since as3 could take seconds to minutes in rare cases)
* while migrating, there is currently nothing that protects the loadbalancer in migration to be updated by the sync_loop 
   * possible protection could be ensure by introducing a new provisioning_status, e.g. PENDING_MIGRATION, which is ignore by the sync loop