### PR TITLE
[tls] Remove possibility of enabling TLS1.3

### DIFF
--- a/octavia_f5/restclient/as3objects/tls.py
+++ b/octavia_f5/restclient/as3objects/tls.py
@@ -85,7 +85,6 @@ def get_tls_server(certificate_ids, listener, authentication_ca=None):
     # Note: tls_1_1 is only supported in tmos version 14.0+
     service_args['tls1_1Enabled'] = lib_consts.TLS_VERSION_1_1 in tls_versions
     service_args['tls1_2Enabled'] = lib_consts.TLS_VERSION_1_2 in tls_versions
-    service_args['tls1_3Enabled'] = lib_consts.TLS_VERSION_1_3 in tls_versions
 
     return TLS_Server(**service_args)
 
@@ -130,6 +129,5 @@ def get_tls_client(pool, trust_ca=None, client_cert=None, crl_file=None):
     # Note: tls_1_1 is only supported in tmos version 14.0+
     service_args['tls1_1Enabled'] = lib_consts.TLS_VERSION_1_1 in tls_versions
     service_args['tls1_2Enabled'] = lib_consts.TLS_VERSION_1_2 in tls_versions
-    service_args['tls1_3Enabled'] = lib_consts.TLS_VERSION_1_3 in tls_versions
 
     return TLS_Client(**service_args)


### PR DESCRIPTION
This is due to the fact that TLS1.3 does not work with cipherstrings on F5. It needs cipher groups, which we have not implemented yet.

Simply removing the possibility to enable TLS1.3 is the easiest solution, but may not be the most favorable. To be discussed.