### PR TITLE
[tls] Set ssl3Enabled AS3 parameter

### DIFF
--- a/octavia_f5/restclient/as3objects/tls.py
+++ b/octavia_f5/restclient/as3objects/tls.py
@@ -112,6 +112,7 @@ def get_tls_server(certificate_ids, listener, authentication_ca=None):
     tls_versions = listener.tls_versions or CONF.api_settings.default_listener_tls_versions
 
     # Set TLS version
+    service_args['ssl3Enabled'] = lib_consts.SSL_VERSION_3 in tls_versions
     service_args['tls1_0Enabled'] = lib_consts.TLS_VERSION_1 in tls_versions
     # Note: tls_1_1 is only supported in tmos version 14.0+
     service_args['tls1_1Enabled'] = lib_consts.TLS_VERSION_1_1 in tls_versions
@@ -157,6 +158,7 @@ def get_tls_client(pool, trust_ca=None, client_cert=None, crl_file=None):
     tls_versions = pool.tls_versions or CONF.api_settings.default_pool_tls_versions
 
     # Set TLS version
+    service_args['ssl3Enabled'] = lib_consts.SSL_VERSION_3 in tls_versions
     service_args['tls1_0Enabled'] = lib_consts.TLS_VERSION_1 in tls_versions
     # Note: tls_1_1 is only supported in tmos version 14.0+
     service_args['tls1_1Enabled'] = lib_consts.TLS_VERSION_1_1 in tls_versions


### PR DESCRIPTION
This reverts 889efba4b53bd3f107507530826fb891f1451b3c. That commit was made because there were still AS3 versions in prod that don't support the ssl3Enabled parameter.

Those AS3 instances are currently being upgraded. As soon as they are done, this PR will be merged.

Reintroducing the ssl3Enabled AS3 parameter is necessary, because its default is True, which led to SSL3 ciphers being active on F5 BigIPs. A possible mitigation would have been to add ':!SSL3' to the cipher string unconditionally, but upgrading AS3 and reintroducing the ssl3Enabled parameter suffices and is cleaner.