### PR TITLE
Add settings to control number of threads for status_manager updates.

### DIFF
--- a/octavia_f5/common/config.py
+++ b/octavia_f5/common/config.py
@@ -221,6 +221,12 @@ f5_status_manager_opts = [
     cfg.IntOpt('failover_timeout',
                default=5,
                help=_("Time in seconds before a device is marked as offline.")),
+    cfg.IntOpt('health_update_threads',
+               default=10,
+               help=_('Number of threads for processing health update.')),
+    cfg.IntOpt('stats_update_threads',
+               default=10,
+               help=_('Number of threads for processing stats update.')),
 ]
 
 f5_util_opts = [

--- a/octavia_f5/controller/statusmanager/status_manager.py
+++ b/octavia_f5/controller/statusmanager/status_manager.py
@@ -79,9 +79,9 @@ class StatusManager(object):
         self.amp_health_repo = repo.AmphoraHealthRepository()
         self.lb_repo = repo.LoadBalancerRepository()
         self.health_executor = futurist.ThreadPoolExecutor(
-            max_workers=CONF.health_manager.health_update_threads)
+            max_workers=CONF.status_manager.health_update_threads)
         self.stats_executor = futurist.ThreadPoolExecutor(
-            max_workers=CONF.health_manager.stats_update_threads)
+            max_workers=CONF.status_manager.stats_update_threads)
         self.bigips = list(self.initialize_bigips())
         # Cache reachability of every bigip
         self.bigip_status = {bigip.hostname: False


### PR DESCRIPTION
This PR adds settings to limit the number of threads that will be spawned for executors. Now we have two executors: one for health updates and another for status updates. Each executor spawns 50 threads:
```
>>> len(fon("ThreadPoolExecutor")[0]._workers)
50
```
but really we need fewer numbers.