### PR TITLE
Remove initialization in each iteration.

### DIFF
--- a/octavia_f5/common/config.py
+++ b/octavia_f5/common/config.py
@@ -221,6 +221,12 @@ f5_status_manager_opts = [
     cfg.IntOpt('failover_timeout',
                default=5,
                help=_("Time in seconds before a device is marked as offline.")),
+    cfg.IntOpt('health_update_threads',
+               default=10,
+               help=_('Number of threads for processing health update.')),
+    cfg.IntOpt('stats_update_threads',
+               default=10,
+               help=_('Number of threads for processing stats update.')),
 ]
 
 f5_util_opts = [

--- a/octavia_f5/controller/statusmanager/legacy_healthmanager/health_drivers/update_db.py
+++ b/octavia_f5/controller/statusmanager/legacy_healthmanager/health_drivers/update_db.py
@@ -58,7 +58,8 @@ class UpdateHealthDb(update_base.HealthUpdateBase):
                 new_op_status = constants.ONLINE
             message.update({constants.OPERATING_STATUS: new_op_status})
 
-    def update_health(self, health, srcaddr):
+    def update_health(self, health, srcaddr='127.0.0.1'):
+        LOG.info("Updating health")
         # The executor will eat any exceptions from the update_health code
         # so we need to wrap it and log the unhandled exception
         start_time = timeit.default_timer()
@@ -474,7 +475,8 @@ class UpdateStatsDb(update_base.StatsUpdateBase, stats.StatsMixin):
         super(UpdateStatsDb, self).__init__()
         self.repo_listener = repo.ListenerRepository()
 
-    def update_stats(self, health_message, srcaddr):
+    def update_stats(self, health_message, srcaddr='127.0.0.1'):
+        LOG.info("Updating stats")
         # The executor will eat any exceptions from the update_stats code
         # so we need to wrap it and log the unhandled exception
         try:

--- a/octavia_f5/controller/statusmanager/status_manager.py
+++ b/octavia_f5/controller/statusmanager/status_manager.py
@@ -79,9 +79,9 @@ class StatusManager(object):
         self.amp_health_repo = repo.AmphoraHealthRepository()
         self.lb_repo = repo.LoadBalancerRepository()
         self.health_executor = futurist.ThreadPoolExecutor(
-            max_workers=CONF.health_manager.health_update_threads)
+            max_workers=CONF.status_manager.health_update_threads)
         self.stats_executor = futurist.ThreadPoolExecutor(
-            max_workers=CONF.health_manager.stats_update_threads)
+            max_workers=CONF.status_manager.stats_update_threads)
         self.bigips = list(self.initialize_bigips())
         # Cache reachability of every bigip
         self.bigip_status = {bigip.hostname: False

--- a/octavia_f5/controller/statusmanager/status_manager.py
+++ b/octavia_f5/controller/statusmanager/status_manager.py
@@ -62,13 +62,6 @@ class DatabaseLockSession(object):
                 with excutils.save_and_reraise_exception():
                     self._lock_session.rollback()
 
-def update_health(msg):
-    LOG.info("Updating health")
-    update_db.UpdateHealthDb().update_health(msg, '127.0.0.1')
-
-def update_stats(msg):
-    LOG.info("Updating stats")
-    update_db.UpdateStatsDb().update_stats(msg, '127.0.0.1')
 
 class StatusManager(object):
     def __init__(self):
@@ -82,6 +75,8 @@ class StatusManager(object):
             max_workers=CONF.status_manager.health_update_threads)
         self.stats_executor = futurist.ThreadPoolExecutor(
             max_workers=CONF.status_manager.stats_update_threads)
+        self.health_updater = update_db.UpdateHealthDb()
+        self.stats_updater = update_db.UpdateStatsDb()
         self.bigips = list(self.initialize_bigips())
         # Cache reachability of every bigip
         self.bigip_status = {bigip.hostname: False
@@ -312,8 +307,8 @@ class StatusManager(object):
 
         for msg in amphora_messages.values():
             msg['recv_time'] = time.time()
-            self.health_executor.submit(update_health, msg)
-            self.stats_executor.submit(update_stats, msg)
+            self.health_executor.submit(self.health_updater.update_health, msg)
+            self.stats_executor.submit(self.stats_updater.update_stats, msg)
 
     def update_listener_count(self, num_listeners):
         """ updates listener count of bigip device (vrrp_priority column in amphora table)


### PR DESCRIPTION
This PR removes class initialization in each iteration of updates. This can be a reason of memory leak because I see lots of objects in memory like:
```
>>> count_object_types()
Counter({<class 'function'>: 35083, <class 'dict'>: 25719, <class 'tuple'>: 23720, <class 'weakref'>: 11032, <class 'list'>: 9375, <class 'cell'>: 6336, <class 'type'>: 4823, <class 'builtin_function_or_method'>: 4353, <class 'getset_descriptor'>: 4053, <class 'set'>: 3742, <class 'member_descriptor'>: 2280, <class 'property'>: 1790, <class 'wrapper_descriptor'>: 1758, <class 'module'>: 1617, <class '_frozen_importlib.ModuleSpec'>: 1604, <class 'method_descriptor'>: 1572, <class '_frozen_importlib_external.SourceFileLoader'>: 1502, <class 'frozenset'>: 1117, <class 'classmethod'>: 1053, <class 'method'>: 967, <class 'sqlalchemy.orm.attributes.AttributeEvent'>: 845, ....
``` 
Have no idea why it was like this because in upstream this class initialization [inside StatusManager](https://github.com/openstack/octavia/blob/8ac5aa7cbec259d79b63e8777ee26bd8391c33b5/octavia/amphorae/drivers/health/heartbeat_udp.py#L60).

How stats inside container looks like:
```
USER   PID %CPU  %MEM        VSZ       RSS TT       STAT     STARTED                     TIME       COMMAND
root     7  3.2   0.6     6.07GB  407.32MB ?        Ssl      Thu Dec  1 09:58:32 2022    00:07:34   octavia-f5-stat
root   173  0.0   0.0     4.58MB    3.99MB pts/0    Ss       Thu Dec  1 10:22:09 2022    00:00:00   bash
root   678  0.0   0.0     5.81MB    2.88MB pts/0    R+       Thu Dec  1 13:52:39 2022    00:00:00   ps
root   679  0.0   0.0     4.02MB    1.08MB pts/0    S+       Thu Dec  1 13:52:39 2022    00:00:00   awk
root   680  0.0   0.0     2.51MB     580kB pts/0    S+       Thu Dec  1 13:52:39 2022    00:00:00   head
root   681  0.0   0.0     2.51MB     580kB pts/0    S+       Thu Dec  1 13:52:39 2022    00:00:00   cut
root     1  0.0   0.0     2.35MB     572kB ?        Ss       Thu Dec  1 09:58:32 2022    00:00:00   dumb-init
```

At the same time heap really small:
```
>>> import guppy
from guppy import hpy
heap = hpy()
stats = heap.heapu()
>>> stats
Partition of a set of 5764 objects. Total size = 763213 bytes.
 Index  Count   %     Size   % Cumulative  % Type
     0    243   4   197896  26    197896  26 set
     1   2271  39   163512  21    361408  47 builtins.weakref
     2    144   2   146832  19    508240  67 dict
     3   1978  34   142416  19    650656  85 types.BuiltinMethodType
     4     71   1    30184   4    680840  89 type
     5    200   3    24211   3    705051  92 _cffi_backend.CType
     6    208   4    13312   2    718363  94 types.MethodType
     7    180   3    12960   2    731323  96 types.WrapperDescriptorType
     8    196   3    11104   1    742427  97 tuple
     9     98   2     7056   1    749483  98 types.MethodDescriptorType
```