### PR TITLE
Interface route for subnets without self-ip

### DIFF
--- a/octavia_f5/controller/worker/flows/f5_flows.py
+++ b/octavia_f5/controller/worker/flows/f5_flows.py
@@ -29,14 +29,16 @@ class F5Flows(object):
             ensure_selfip_subflow.add(ensure_selfip)
 
         ensure_routedomain = f5_tasks.EnsureRouteDomain()
-        ensure_route = f5_tasks.EnsureRoute()
+        ensure_default_route = f5_tasks.EnsureDefaultRoute()
+        ensure_static_routes = f5_tasks.SyncStaticRoutes(inject={'selfips': selfips})
         ensure_vlan = f5_tasks.EnsureVLAN()
 
         ensure_l2_flow = linear_flow.Flow('ensure-l2-flow')
         ensure_l2_flow.add(ensure_vlan,
                            ensure_routedomain,
                            ensure_selfip_subflow,
-                           ensure_route)
+                           ensure_default_route,
+                           ensure_static_routes)
         return ensure_l2_flow
 
     def remove_l2(self, selfips: [str]) -> flow.Flow:
@@ -47,12 +49,14 @@ class F5Flows(object):
                                                    inject={'port': selfip})
             cleanup_selfip_subflow.add(cleanup_selfip)
 
+        cleanup_static_routes = f5_tasks.SyncStaticRoutes(inject={'selfips': []})
         cleanup_route = f5_tasks.CleanupRoute()
         cleanup_routedomain = f5_tasks.CleanupRouteDomain()
         cleanup_vlan = f5_tasks.CleanupVLAN()
 
         cleanup_l2_flow = linear_flow.Flow('cleanup-l2-flow')
-        cleanup_l2_flow.add(cleanup_route,
+        cleanup_l2_flow.add(cleanup_static_routes,
+                            cleanup_route,
                             cleanup_selfip_subflow,
                             cleanup_routedomain,
                             cleanup_vlan)

--- a/octavia_f5/controller/worker/l2_sync_manager.py
+++ b/octavia_f5/controller/worker/l2_sync_manager.py
@@ -26,6 +26,7 @@ from octavia.common.base_taskflow import BaseTaskFlowEngine
 from octavia.network import base
 from octavia.network import data_models as network_models
 from octavia_f5.controller.worker.flows import f5_flows
+from octavia_f5.controller.worker.tasks import f5_tasks
 from octavia_f5.restclient.bigip import bigip_auth
 from octavia_f5.restclient.bigip.bigip_restclient import BigIPRestClient
 from octavia_f5.utils import driver_utils, decorators
@@ -118,6 +119,12 @@ class L2SyncManager(BaseTaskFlowEngine):
                                                                  'remove': [p.id for p in selfips['remove']]})
 
         e = self.taskflow_load(self._f5flows.sync_l2_selfips(selfips), store=store)
+        with tf_logging.LoggingListener(e, log=LOG):
+            e.run()
+
+    def _do_sync_l2_static_routes_flow(self, selfips: [network_models.Port], store: dict):
+        ensure_static_routes = f5_tasks.SyncStaticRoutes(inject={'selfips': selfips})
+        e = self.taskflow_load(ensure_static_routes, store=store)
         with tf_logging.LoggingListener(e, log=LOG):
             e.run()
 
@@ -245,6 +252,8 @@ class L2SyncManager(BaseTaskFlowEngine):
             fs[self.executor.submit(self._do_sync_l2_selfips_flow,
                                     expected_selfips=selfips_for_host,
                                     store=store)] = bigip
+            fs[self.executor.submit(self._do_sync_l2_static_routes_flow,
+                                    selfips=selfips_for_host, store=store)] = bigip
 
         done, not_done = futures.wait(fs, timeout=10)
         for f in done | not_done:

--- a/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
+++ b/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
@@ -81,7 +81,10 @@ class TestF5Flows(base.TestCase):
         )
 
         mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
-        mock_bigip.get.side_effect = empty_response
+        mock_bigip.get.side_effect = [empty_response(), empty_response(),
+                                      empty_response(), empty_response(),
+                                      empty_response(), empty_response(),
+                                      MockResponse({'items':[]}, status_code=200)]
         f5flows = f5_flows.F5Flows()
 
         engines.run(f5flows.ensure_l2([selfip_port]),
@@ -156,7 +159,8 @@ class TestF5Flows(base.TestCase):
         mock_bigip.get.side_effect = [mock_vlan_response,
                                       mock_routedomain_response,
                                       mock_selfip_response,
-                                      mock_route_response]
+                                      mock_route_response,
+                                      MockResponse({'items':[]}, status_code=200)]
         f5flows = f5_flows.F5Flows()
 
         engines.run(f5flows.ensure_l2([selfip_port]),

--- a/octavia_f5/tests/unit/controller/worker/tasks/test_f5_tasks.py
+++ b/octavia_f5/tests/unit/controller/worker/tasks/test_f5_tasks.py
@@ -17,6 +17,7 @@ from unittest import mock
 from oslo_config import cfg
 from oslo_config import fixture as oslo_fixture
 from oslo_log import log as logging
+from oslo_utils import uuidutils
 from taskflow import engines
 
 import octavia.tests.unit.base as base
@@ -62,7 +63,7 @@ class TestF5Tasks(base.TestCase):
         mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
         mock_bigip.get.return_value = mock_route_response
 
-        engines.run(f5_tasks.EnsureRoute(),
+        engines.run(f5_tasks.EnsureDefaultRoute(),
                     store={'network': mock_network,
                            'bigip': mock_bigip,
                            'subnet_id': 'test-subnet-id'})
@@ -96,7 +97,7 @@ class TestF5Tasks(base.TestCase):
         mock_bigip.get.side_effect = [test_f5_flows.MockResponse({}, 404),
                                       mock_route_response]
 
-        engines.run(f5_tasks.EnsureRoute(),
+        engines.run(f5_tasks.EnsureDefaultRoute(),
                     store={'network': mock_network,
                            'bigip': mock_bigip,
                            'subnet_id': 'test-subnet-id'})
@@ -134,7 +135,7 @@ class TestF5Tasks(base.TestCase):
         # Patch should fail
         mock_bigip.patch.side_effect = test_f5_flows.empty_response
 
-        engines.run(f5_tasks.EnsureRoute(),
+        engines.run(f5_tasks.EnsureDefaultRoute(),
                     store={'network': mock_network,
                            'bigip': mock_bigip,
                            'subnet_id': 'test-subnet-id'})
@@ -150,3 +151,72 @@ class TestF5Tasks(base.TestCase):
         mock_bigip.post.assert_called_with(json={
             'name': 'vlan-1234', 'gw': '8.8.8.8%1234', 'network': 'default%1234'},
             path='/mgmt/tm/net/route')
+
+    @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
+                ".get_subnet")
+    def test_SyncStaticRoutes(self, mock_get_subnet):
+        mock_subnets = [
+            network_models.Subnet(
+                id=uuidutils.generate_uuid(), gateway_ip='2.3.4.5',
+                cidr='2.3.4.0/24', network_id='test-network-id'),
+            network_models.Subnet(
+                id=uuidutils.generate_uuid(), gateway_ip='10.0.0.1',
+                cidr='10.0.0.0/24', network_id='test-network-id'),
+        ]
+        mock_get_subnet.side_effect = mock_subnets
+        mock_network = f5_network_models.Network(
+            mtu=9000, id=uuidutils.generate_uuid(),
+            subnets=[subnet.id for subnet in mock_subnets],
+            segments=[{'provider:physical_network': 'physnet',
+                       'provider:segmentation_id': 1234}]
+        )
+
+        mock_route_response = test_f5_flows.MockResponse({
+            'items': [
+                {
+                    'name': f"subnet-{mock_subnets[1].id}",
+                    'tmInterface': 'vlan-1234',
+                    'network': '10.0.0.2%1234/24'
+                }
+            ]
+        }, status_code=200)
+
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip.get.return_value = mock_route_response
+        mock_selfip = network_models.Port(
+            name=f"local-bigipmockhost-test-subnet-id",
+            fixed_ips=[network_models.FixedIP(
+                ip_address='2.3.4.255',
+                subnet_id=mock_subnets[0].id)
+            ]
+        )
+
+        engines.run(f5_tasks.SyncStaticRoutes(),
+                    store={'network': mock_network,
+                           'bigip': mock_bigip,
+                           'selfips': [mock_selfip]})
+
+        mock_bigip.get.assert_called_with(
+            path=f"/mgmt/tm/net/route?$filter=partition+eq+net_{mock_network.id.replace('-','_')}")
+        mock_bigip.post.assert_not_called()
+        mock_bigip.delete.assert_not_called()
+
+        # Check creating new route
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_route_response = test_f5_flows.MockResponse({'items': []}, status_code=200)
+        mock_bigip.get.return_value = mock_route_response
+        engines.run(f5_tasks.SyncStaticRoutes(),
+                    store={'network': mock_network,
+                           'bigip': mock_bigip,
+                           'selfips': [mock_selfip]})
+
+        mock_bigip.get.assert_called_with(
+            path=f"/mgmt/tm/net/route?$filter=partition+eq+net_{mock_network.id.replace('-','_')}")
+        mock_bigip.delete.assert_not_called()
+        mock_bigip.post.assert_called_with(
+            path='/mgmt/tm/net/route', json={
+                'name': f"subnet-{mock_subnets[1].id}",
+                'tmInterface': '/Common/vlan-1234',
+                'network': '2.3.4.0%1234/24',
+                'partition': f"net_{mock_network.id.replace('-','_')}"}
+        )


### PR DESCRIPTION
This PR introduces l2 generation and update for interface routes for subnets of a network that have no self-ip.
This allows having pool members from foreign subnets without the need to route via default gw and allow setups like no-snat.