### PR TITLE
Fix static subnet routes

### DIFF
--- a/octavia_f5/common/config.py
+++ b/octavia_f5/common/config.py
@@ -202,7 +202,7 @@ f5_networking_opts = [
                 default=[],
                 help=_('List of vcmp guest names to use for identifying the '
                        'correct vcmp guest - defaults to the bigip hostname.')),
-    cfg.BoolOpt('route_on_active',
+    cfg.BoolOpt('route_only_on_active',
                 default=True,
                 help=_("Sync routes only to active bigip device, this option"
                        "is useful if automatic full-sync is activated.")),

--- a/octavia_f5/controller/worker/tasks/f5_tasks.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks.py
@@ -301,7 +301,7 @@ class SyncStaticRoutes(task.Task):
         device_response = bigip.get(
             path=f"/mgmt/tm/net/route?$filter=partition+eq+{tenant.get_name(network.id)}")
         device_response = device_response.json()
-        device_routes = device_response['items']
+        device_routes = device_response.get('items', [])
 
         # Remove superfluous subnet routes, provision only missing subnet routes
         for device_route in device_routes:

--- a/octavia_f5/controller/worker/tasks/f5_tasks.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks.py
@@ -236,8 +236,8 @@ class EnsureDefaultRoute(task.Task):
                 subnet_id: str,
                 network: f5_network_models.Network):
 
-        if CONF.networking.route_on_active and not bigip.is_active:
-            # Skip passive device if route_on_active is enabled
+        # Skip passive device if route_only_on_active is enabled
+        if CONF.networking.route_only_on_active and not bigip.is_active:
             return None
 
         name = f"vlan-{network.vlan_id}"
@@ -281,16 +281,16 @@ class SyncStaticRoutes(task.Task):
                 selfips: [network_models.Port],
                 network: f5_network_models.Network):
 
+        # Skip passive device if route_only_on_active is enabled
+        if CONF.networking.route_only_on_active and not bigip.is_active:
+            return None
+
         def subnet_in_selfips(subnet, selfips):
             for selfip in selfips:
                 for fixed_ip in selfip.fixed_ips:
                     if fixed_ip.subnet_id == subnet:
                         return True
             return False
-
-        if CONF.networking.route_on_active and not bigip.is_active:
-            # Skip passive device if route_on_active is enabled
-            return None
 
         network_driver = driver_utils.get_network_driver()
 


### PR DESCRIPTION
This adds onto and fixes #196

- Rename option `route_on_active` to `route_only_on_active`
  `route_on_active` implies that this option is for turning on and off provisioning of routes to active devices. It's the opposite however - turning on and off provisioning to passive devices.
- Subnet route provisioning: Invert if-else statement
  It's better to leave out negation (`if ... not in ...`) where possible. Also: Get items from `device_response` before checking on them.
- Fix `SyncStaticRoutes`: Fails when no static routes present.