### PR TITLE
Fix amphora cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Instead, otherwise unused tables are used in a specific way:
 - The **amphora** table is used in two ways:
   - For each load balancer an amphora entry is created. This is done [to prevent problems with Octavias health manager](./octavia_f5/controller/worker/controller_worker.py#L249-L251), which makes assumptions about amphora entries.
     - `compute_flavor` holds the name of the device the load balancer is scheduled to. This can be used to query the device via `openstack loadbalancer amphora show $LB_ID`.
+    - Since an amphora table entry is never updated as long as its respective load balancer lives, the `updated_at` field will always be `null` until the load balancer is being deleted, [which will update the amphora entry status to `DELETED` as well](octavia_f5/controller/worker/status_manager.py#L158).
   - For each F5 device that is managed by a provider driver worker a special entry is created in the `amphora` table.
     - `compute_flavor` holds the name of the managed F5 device
     - `cached_zone` holds the hostname

--- a/octavia_f5/db/repositories.py
+++ b/octavia_f5/db/repositories.py
@@ -67,6 +67,7 @@ class LoadBalancerRepository(repositories.LoadBalancerRepository):
 
         return [model.to_data_model() for model in query.all()]
 
+
 class PoolRepository(repositories.PoolRepository):
     def get_pending_from_host(self, session, host=None):
         """Get a list of pending pools from specific host
@@ -143,7 +144,7 @@ class AmphoraRepository(repositories.AmphoraRepository):
         query = session.query(self.model_class.cached_zone)
         # pylint: disable=singleton-comparison
         query = query.filter(self.model_class.compute_flavor == host,
-                             self.model_class.cached_zone != None)
+                             self.model_class.cached_zone.is_(None))
 
         return [model[0] for model in query.all()]
 
@@ -153,8 +154,8 @@ class AmphoraRepository(repositories.AmphoraRepository):
         """
         try:
             session.query(self.model_class).filter(
-                self.model_class.load_balancer_id == None,
-                self.model_class.cached_zone == None,
+                self.model_class.load_balancer_id.is_(None),
+                self.model_class.cached_zone.is_(None),
                 self.model_class.compute_flavor == CONF.host,
             ).delete()
         except sqlalchemy.orm.exc.NoResultFound:


### PR DESCRIPTION
`amp_repo.delete()` expects the supplied filters to only return one result (it calls .one() on the query), but since we want to delete several amphora entries at once it failed every time. Since `InvalidRequestError` is catched and pass'ed, this failed silently.

- Move cleanup function to `octavia_f5.db.repositories.AmphoraRepository`
- Instead of delete or `delete_batch` (it can only delete one entry at a time), use sqlalchemy directly to delete all old amphora entries at once.
- Fix: Don't `pass` on `InvalidRequestError`
- `pass` on `NoResultFound`

Closes #199 