### PR TITLE
Fix rescheduling: SelfIPs and subnet routes not cleaned up before creation

### DIFF
--- a/octavia_f5/api/drivers/f5_driver/tasks/reschedule_tasks.py
+++ b/octavia_f5/api/drivers/f5_driver/tasks/reschedule_tasks.py
@@ -19,7 +19,6 @@ from oslo_log import log as logging
 from taskflow import task
 from taskflow.types import failure
 
-from octavia.common import constants
 from octavia.common import data_models as models
 from octavia.db import api as db_apis
 from octavia_f5.db import repositories as repo

--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -652,14 +652,18 @@ class ControllerWorker(object):
         if loadbalancers_remaining:
             # if there are still load balancers we only need to sync SelfIPs and subnet routes
 
-            # If the subnet of the LB to be removed is now empty, remove its SelfIPs by treating them as orphaned
-            selfips = list(chain.from_iterable(
-                self.network_driver.ensure_selfips(loadbalancers_remaining, CONF.host, cleanup_orphans=True)))
+            # If the subnet of the LB to be removed is now empty, remove the unneeded SelfIP ports. Since they are not
+            # considered orphaned (they aren't even considered by ensure_selfips because the subnet is gone) they need
+            # to be determined by comparing SelfIP ports for all LBs with those of the remaining LBs.
+            selfips_remaining = list(chain.from_iterable(
+                self.network_driver.ensure_selfips(loadbalancers_remaining, CONF.host, cleanup_orphans=False)))
+            selfips_to_delete = [sip for sip in selfips if sip not in selfips_remaining]
+            self.network_driver.cleanup_selfips(selfips_to_delete)
 
             # provision the rest to the device
-            self.l2sync.sync_l2_selfips_and_subnet_routes_flow(selfips, network_id)
+            self.l2sync.sync_l2_selfips_and_subnet_routes_flow(selfips_remaining, network_id)
             self.sync.tenant_update(
-                network_id, selfips=selfips, loadbalancers=loadbalancers_remaining).raise_for_status()
+                network_id, selfips=selfips_remaining, loadbalancers=loadbalancers_remaining).raise_for_status()
 
         else:
             # this was the last load balancer - delete everything

--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -641,7 +641,7 @@ class ControllerWorker(object):
         selfips = list(chain.from_iterable(
             self.network_driver.ensure_selfips(loadbalancers, CONF.host, cleanup_orphans=False)))
         if loadbalancers:
-            self.l2sync.ensure_l2_flow(selfips, network_id)
+            self.l2sync.sync_l2_selfips_and_subnet_routes_flow(selfips, network_id)
             self.sync.tenant_update(network_id, selfips=selfips, loadbalancers=loadbalancers).raise_for_status()
         else:
             self.sync.tenant_delete(network_id).raise_for_status()

--- a/octavia_f5/network/drivers/noop_driver_f5/driver.py
+++ b/octavia_f5/network/drivers/noop_driver_f5/driver.py
@@ -48,3 +48,6 @@ class NoopNetworkDriverF5(driver.NoopNetworkDriver):
 
     def create_vip(self, load_balancer, candidate):
         return self.driver.create_port(load_balancer.vip.network_id)
+
+    def invalidate_cache(self, hard=True):
+        pass

--- a/octavia_f5/tests/unit/controller/worker/test_controller_worker.py
+++ b/octavia_f5/tests/unit/controller/worker/test_controller_worker.py
@@ -49,6 +49,8 @@ class TestControllerWorker(base.TestCase):
         conf = self.useFixture(oslo_fixture.Config(cfg.CONF))
         conf.config(group="f5_agent", prometheus=False)
         conf.config(group="controller_worker", network_driver='network_noop_driver_f5')
+        # prevent ControllerWorker() from spawning threads
+        conf.config(group="f5_agent", sync_immediately=False)
 
     @mock.patch('octavia.db.repositories.AvailabilityZoneRepository')
     @mock.patch('octavia.db.repositories.AvailabilityZoneProfileRepository')
@@ -100,10 +102,7 @@ class TestControllerWorker(base.TestCase):
         cw = controller_worker.ControllerWorker()
         cw.remove_loadbalancer(LB_ID)
 
-        mock_lb_repo_get_all_by_network.assert_called_once_with(
-            _db_session, network_id=NETWORK_ID, show_deleted=False)
-        mock_lb_repo_get.assert_called_once_with(
-            _db_session, id=LB_ID)
-        mock_ensure_selfips.assert_called_with([LB_ID], CONF.host, cleanup_orphans=False)
+        mock_lb_repo_get_all_by_network.assert_called_once_with(_db_session, network_id=NETWORK_ID, show_deleted=False)
+        mock_lb_repo_get.assert_called_once_with(_db_session, id=LB_ID)
+        mock_ensure_selfips.assert_called_with([_load_balancer_mock], CONF.host, cleanup_orphans=False)
         mock_cleanup_selfips.assert_called_with([_selfip])
-

--- a/octavia_f5/tests/unit/controller/worker/test_controller_worker.py
+++ b/octavia_f5/tests/unit/controller/worker/test_controller_worker.py
@@ -24,19 +24,19 @@ from octavia_f5.controller.worker import controller_worker
 
 CONF = cfg.CONF
 
-_health_mon_mock = mock.MagicMock()
+LB_ID = uuidutils.generate_uuid()
+NETWORK_ID = uuidutils.generate_uuid()
 _status_manager = mock.MagicMock()
 _vip_mock = mock.MagicMock()
+_vip_mock.network_id = NETWORK_ID
 _listener_mock = mock.MagicMock()
 _load_balancer_mock = mock.MagicMock()
+_load_balancer_mock.id = LB_ID
 _load_balancer_mock.listeners = [_listener_mock]
+_load_balancer_mock.vip = _vip_mock
 _load_balancer_mock.flavor_id = None
 _load_balancer_mock.availability_zone = None
-_member_mock = mock.MagicMock()
-_pool_mock = mock.MagicMock()
-_l7policy_mock = mock.MagicMock()
-_l7rule_mock = mock.MagicMock()
-_az_mock = mock.MagicMock()
+_selfip = mock.MagicMock()
 _db_session = mock.MagicMock()
 
 
@@ -79,3 +79,31 @@ class TestControllerWorker(base.TestCase):
         cw.register_in_availability_zone(az)
         mock_az_repo.return_value.create.assert_called_once()
         mock_azp_repo.return_value.create.assert_called_once()
+
+    @mock.patch('octavia.db.repositories.LoadBalancerRepository.get',
+                return_value=_load_balancer_mock)
+    @mock.patch('octavia_f5.db.repositories.LoadBalancerRepository.get_all_by_network',
+                return_value=[_load_balancer_mock])
+    @mock.patch("octavia_f5.network.drivers.noop_driver_f5.driver.NoopNetworkDriverF5"
+                ".ensure_selfips",
+                return_value=([_selfip], []))
+    @mock.patch("octavia_f5.network.drivers.noop_driver_f5.driver.NoopNetworkDriverF5"
+                ".cleanup_selfips")
+    def test_remove_loadbalancer_last(self,
+                                      mock_cleanup_selfips,
+                                      mock_ensure_selfips,
+                                      mock_lb_repo_get_all_by_network,
+                                      mock_lb_repo_get,
+                                      mock_api_get_session,
+                                      mock_sync_manager,
+                                      mock_status_manager):
+        cw = controller_worker.ControllerWorker()
+        cw.remove_loadbalancer(LB_ID)
+
+        mock_lb_repo_get_all_by_network.assert_called_once_with(
+            _db_session, network_id=NETWORK_ID, show_deleted=False)
+        mock_lb_repo_get.assert_called_once_with(
+            _db_session, id=LB_ID)
+        mock_ensure_selfips.assert_called_with([LB_ID], CONF.host, cleanup_orphans=False)
+        mock_cleanup_selfips.assert_called_with([_selfip])
+


### PR DESCRIPTION
`ControllerWorker.add_loadbalancer` calls `ensure_l2_flow` unconditionally.
If a load balancer of the same network (but a different subnet) already exists on this device there will be a subnet route (the one for the subnet of the LB-to-add) that needs cleaning up before the SelfIP for the subnet of the LB-to-add can be created.
Also, the whole `ensure_l2_flow` isn't needed in this case. So execute only sync_l2_selfips_and_subnet_routes_flow in this case.
Same for `ControllerWorker.remove_loadbalancer`.

Closes #215 