### PR TITLE
Fix rescheduling: Legacy VIP ports mistaken for SelfIP ports

### DIFF
--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -664,6 +664,8 @@ class ControllerWorker(object):
             # considered orphaned (they aren't even considered by ensure_selfips because the subnet is gone) they need
             # to be determined by comparing SelfIP ports for all LBs with those of the remaining LBs.
             selfips_to_delete = [sip for sip in selfips if sip not in selfips_remaining]
+            for selfip in selfips_to_delete:
+                LOG.info(f"Deleting unneeded SelfIP {selfip.id} \"{selfip.name}\"")
             self.network_driver.cleanup_selfips(selfips_to_delete)
 
         else:

--- a/octavia_f5/network/drivers/neutron/neutron_client.py
+++ b/octavia_f5/network/drivers/neutron/neutron_client.py
@@ -411,6 +411,7 @@ class NeutronClient(neutron_base.BaseNeutronDriver,
             m = re.match('local-(.*)-([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})',
                          selfip.get('name', ''))
             if not m:
+                selfips.remove(selfip)
                 continue
 
             host, subnet = m.group(1, 2)


### PR DESCRIPTION
Legacy VIP ports are ignored by `ensure_selfips`, but not removed from the `selfips` list, so they're still returned by the function and then deleted by `ControllerWorker.remove_loadbalancer`
