### PR TITLE
[repositorys] fix missing negation of query param

### DIFF
--- a/octavia_f5/db/repositories.py
+++ b/octavia_f5/db/repositories.py
@@ -142,9 +142,8 @@ class AmphoraRepository(repositories.AmphoraRepository):
     def get_devices_for_host(self, session, host):
 
         query = session.query(self.model_class.cached_zone)
-        # pylint: disable=singleton-comparison
         query = query.filter(self.model_class.compute_flavor == host,
-                             self.model_class.cached_zone.is_(None))
+                             self.model_class.cached_zone.is_not(None))
 
         return [model[0] for model in query.all()]
 


### PR DESCRIPTION
#210 introduced a regression bug that changed sql alchemy condition `self.model_class.cached_zone != None` to `self.model_class.cached_zone.is_(None)`. This is not equivalent.