### PR TITLE
[QuotasRepository] use baseRepository update method, optimize reset_quota

### DIFF
--- a/octavia_f5/db/repositories.py
+++ b/octavia_f5/db/repositories.py
@@ -159,3 +159,11 @@ class AmphoraRepository(repositories.AmphoraRepository):
             ).delete()
         except sqlalchemy.orm.exc.NoResultFound:
             pass
+
+class QuotasRepository(repositories.BaseRepository):
+    model_class = models.Quotas
+
+    def update(self, session, project_id, **model_kwargs):
+        with session.begin(subtransactions=True):
+            session.query(self.model_class).filter_by(
+                project_id=project_id).update(model_kwargs)


### PR DESCRIPTION
This PR forks the upstream QuotasRepository class to implement a faster update strategy for reseting quotas. Also, `reset_quota` is optimized running only once per project instead per load_balancer.

This should reduce the likelihood of deadlocks due to quota table row locks.