### PR TITLE
Fix NoneType error in ALPN protocols check.

### DIFF
--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -116,7 +116,8 @@ def get_service(listener, cert_manager, esd_repository):
         HTTP2 profile acts like normal HTTP when HTTP2 isn't explicitely requested via ALPN. However,
         having a listener be able to speak HTTP2 without it being declared that way is unexpected behavior.
         """
-        return hasattr(listener, 'alpn_protocols') and lib_consts.ALPN_PROTOCOL_HTTP_2 in listener.alpn_protocols
+        return (hasattr(listener, 'alpn_protocols') and listener.alpn_protocols and
+                lib_consts.ALPN_PROTOCOL_HTTP_2 in listener.alpn_protocols)
 
     # Custom virtual address settings
     if CONF.f5_agent.service_address_icmp_echo:

--- a/octavia_f5/restclient/as3objects/tls.py
+++ b/octavia_f5/restclient/as3objects/tls.py
@@ -12,11 +12,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from octavia.common import validate
-from octavia_lib.common import constants as lib_consts
 from oslo_config import cfg
 from oslo_log import log as logging
 
+from octavia_lib.common import constants as lib_consts
+from octavia.common import validate
 from octavia_f5.common import constants
 from octavia_f5.restclient.as3classes import TLS_Server, TLS_Client, Pointer
 


### PR DESCRIPTION
This MR fixes a logical error when `alpn_protocols` value exists but is empty:
```
ERROR octavia_f5.controller.worker.controller_worker     if CONF.f5_agent.profile_http2 and service_args['_servicetype'] in f5_const.SERVICE_HTTPS and is_http2(listener):
ERROR octavia_f5.controller.worker.controller_worker   File "/var/lib/openstack/src/octavia-f5-provider-driver/octavia_f5/restclient/as3objects/service.py", line 119, in is_http2
ERROR octavia_f5.controller.worker.controller_worker     return hasattr(listener, 'alpn_protocols') and lib_consts.ALPN_PROTOCOL_HTTP_2 in listener.alpn_protocols
ERROR octavia_f5.controller.worker.controller_worker TypeError: argument of type 'NoneType' is not iterable
```