### PR TITLE
Add support for allowed_cidrs value in listener.

### DIFF
--- a/octavia_f5/common/config.py
+++ b/octavia_f5/common/config.py
@@ -126,8 +126,6 @@ f5_agent_opts = [
                 help=_("Use unsafe mode for posting AS3 declarations.")),
     cfg.StrOpt('availability_zone', default=None,
                 help=_("Name of the availability zone the F5 device of this worker is assigned to.")),
-    cfg.StrOpt('irule_allowed_cidrs', default='cc_allowed_cidrs',
-               help=_("Name of iRule used for allowed_cidrs filtering.")),
 ]
 
 f5_tls_shared = {

--- a/octavia_f5/common/config.py
+++ b/octavia_f5/common/config.py
@@ -126,6 +126,8 @@ f5_agent_opts = [
                 help=_("Use unsafe mode for posting AS3 declarations.")),
     cfg.StrOpt('availability_zone', default=None,
                 help=_("Name of the availability zone the F5 device of this worker is assigned to.")),
+    cfg.StrOpt('irule_allowed_cidrs', default='cc_allowed_cidrs',
+               help=_("Name of iRule used for allowed_cidrs filtering.")),
 ]
 
 f5_tls_shared = {

--- a/octavia_f5/common/constants.py
+++ b/octavia_f5/common/constants.py
@@ -32,6 +32,7 @@ PREFIX_SUBNET = 'sub_'
 PREFIX_IRULE = 'irule_'
 PREFIX_MEMBER = 'member_'
 PREFIX_SECRET = 'secret_'
+SUFFIX_ALLOWED_CIDRS = '_allowed_cidrs'
 
 APPLICATION_TCP = 'tcp'
 APPLICATION_UDP = 'udp'

--- a/octavia_f5/restclient/as3classes.py
+++ b/octavia_f5/restclient/as3classes.py
@@ -305,3 +305,11 @@ class HTTP_Profile(BaseDescription):
     def __init__(self, **kwargs):
         super(HTTP_Profile, self).__init__(locals())
         setattr(self, 'class', 'HTTP_Profile')
+
+
+class Data_Group(BaseDescription):
+    def __init__(self, _records, keyDataType='ip', **kwargs):
+        super(Data_Group, self).__init__(locals())
+        setattr(self, 'class', 'Data_Group')
+        self.require('keyDataType')
+        setattr(self, 'records', [{"key": r} for r in _records])

--- a/octavia_f5/restclient/as3objects/irule.py
+++ b/octavia_f5/restclient/as3objects/irule.py
@@ -136,13 +136,6 @@ when HTTP_RESPONSE {{
         persist add uie [HTTP::cookie "{_cookie}"] 3600
     }}
 }}"""
-ALLOWED_CIDRS = """when CLIENT_ACCEPTED priority 200 {{
-    if {{ not [class match -- [getfield [IP::client_addr] "%" 1] equals [virtual name]{_suffix}] }}
-    {{
-        reject
-        event disable all
-    }}
-}}"""
 
 def get_proxy_irule():
     """
@@ -233,14 +226,3 @@ def get_header_irules(insert_headers):
         entities.append(('irule_x_ssl_client_not_after', irule))
 
     return entities
-
-
-def get_allowed_cidrs_irule():
-    """
-    Returns iRule for allowed cidrs filtering.
-    :return: iRule entity (tuple with iRule name and definition)
-    """
-    irule = IRule(ALLOWED_CIDRS.format(_suffix=constants.SUFFIX_ALLOWED_CIDRS),
-                  remark="allowed cidr filtering")
-    name = '{}allowed_cidr'.format(constants.PREFIX_IRULE)
-    return name, irule

--- a/octavia_f5/restclient/as3objects/irule.py
+++ b/octavia_f5/restclient/as3objects/irule.py
@@ -136,13 +136,13 @@ when HTTP_RESPONSE {{
         persist add uie [HTTP::cookie "{_cookie}"] 3600
     }}
 }}"""
-ALLOWED_CIDRS = """when CLIENT_ACCEPTED priority 200 {
-    if { not [class match -- [getfield [IP::client_addr] "%" 1] equals [virtual name]_allowed_cidrs] }
-    {
+ALLOWED_CIDRS = """when CLIENT_ACCEPTED priority 200 {{
+    if {{ not [class match -- [getfield [IP::client_addr] "%" 1] equals [virtual name]{_suffix}] }}
+    {{
         reject
         event disable all
-    }
-}"""
+    }}
+}}"""
 
 def get_proxy_irule():
     """
@@ -240,7 +240,7 @@ def get_allowed_cidrs_irule():
     Returns iRule for allowed cidrs filtering.
     :return: iRule entity (tuple with iRule name and definition)
     """
-    irule = IRule(ALLOWED_CIDRS,
+    irule = IRule(ALLOWED_CIDRS.format(_suffix=constants.SUFFIX_ALLOWED_CIDRS),
                   remark="allowed cidr filtering")
     name = '{}allowed_cidr'.format(constants.PREFIX_IRULE)
     return name, irule

--- a/octavia_f5/restclient/as3objects/irule.py
+++ b/octavia_f5/restclient/as3objects/irule.py
@@ -136,7 +136,13 @@ when HTTP_RESPONSE {{
         persist add uie [HTTP::cookie "{_cookie}"] 3600
     }}
 }}"""
-
+ALLOWED_CIDRS = """when CLIENT_ACCEPTED priority 200 {
+    if { not [class match -- [getfield [IP::client_addr] "%" 1] equals [virtual name]_allowed_cidrs] }
+    {
+        reject
+        event disable all
+    }
+}"""
 
 def get_proxy_irule():
     """
@@ -227,3 +233,14 @@ def get_header_irules(insert_headers):
         entities.append(('irule_x_ssl_client_not_after', irule))
 
     return entities
+
+
+def get_allowed_cidrs_irule():
+    """
+    Returns iRule for allowed cidrs filtering.
+    :return: iRule entity (tuple with iRule name and definition)
+    """
+    irule = IRule(ALLOWED_CIDRS,
+                  remark="allowed cidr filtering")
+    name = '{}allowed_cidr'.format(constants.PREFIX_IRULE)
+    return name, irule

--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -42,6 +42,15 @@ def get_name(listener_id):
     return "{}{}".format(f5_const.PREFIX_LISTENER, listener_id)
 
 
+def get_data_group_name(listener_id):
+    """Return AS3 object name for type data group
+
+    :param listener_id: listener id
+    :return: AS3 object name
+    """
+    return "{}{}{}".format(f5_const.PREFIX_LISTENER, listener_id, f5_const.SUFFIX_ALLOWED_CIDRS)
+
+
 def get_esd_entities(servicetype, esd):
     """
     Map F5 ESD (Enhanced Service Definition) to service components.
@@ -174,6 +183,14 @@ def get_service(listener, cert_manager, esd_repository):
         name, irule = m_irule.get_proxy_irule()
         service_args['iRules'].append(name)
         entities.append((name, irule))
+
+    # Set allowed cidrs
+    if hasattr(listener, 'allowed_cidrs') and listener.allowed_cidrs:
+        cidrs = [c.cidr for c in listener.allowed_cidrs]
+        entities.append((get_data_group_name(listener.id), as3.Data_Group(cidrs)))
+        irule_name, irule = m_irule.get_allowed_cidrs_irule()
+        entities.append((irule_name, irule))
+        service_args['iRules'].append(irule_name)
 
     # maximum number of connections
     if listener.connection_limit > 0:

--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -48,7 +48,7 @@ def get_data_group_name(listener_id):
     :param listener_id: listener id
     :return: AS3 object name
     """
-    return "{}{}{}".format(f5_const.PREFIX_LISTENER, listener_id, f5_const.SUFFIX_ALLOWED_CIDRS)
+    return "{}{}".format(get_name(listener_id), f5_const.SUFFIX_ALLOWED_CIDRS)
 
 
 def get_esd_entities(servicetype, esd):

--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -188,9 +188,7 @@ def get_service(listener, cert_manager, esd_repository):
     if hasattr(listener, 'allowed_cidrs') and listener.allowed_cidrs:
         cidrs = [c.cidr for c in listener.allowed_cidrs]
         entities.append((get_data_group_name(listener.id), as3.Data_Group(cidrs)))
-        irule_name, irule = m_irule.get_allowed_cidrs_irule()
-        entities.append((irule_name, irule))
-        service_args['iRules'].append(irule_name)
+        service_args['iRules'].append(as3.BigIP(CONF.f5_agent.irule_allowed_cidrs))
 
     # maximum number of connections
     if listener.connection_limit > 0:

--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -187,8 +187,10 @@ def get_service(listener, cert_manager, esd_repository):
     # Set allowed cidrs
     if hasattr(listener, 'allowed_cidrs') and listener.allowed_cidrs:
         cidrs = [c.cidr for c in listener.allowed_cidrs]
-        entities.append((get_data_group_name(listener.id), as3.Data_Group(cidrs)))
-        service_args['iRules'].append(as3.BigIP(CONF.f5_agent.irule_allowed_cidrs))
+        if '0.0.0.0/0' not in cidrs:
+            # 0.0.0.0/0 - means not restrictions
+            entities.append((get_data_group_name(listener.id), as3.Data_Group(cidrs)))
+            service_args['iRules'].append(as3.BigIP(CONF.f5_agent.irule_allowed_cidrs))
 
     # maximum number of connections
     if listener.connection_limit > 0:

--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -188,7 +188,7 @@ def get_service(listener, cert_manager, esd_repository):
     if hasattr(listener, 'allowed_cidrs') and listener.allowed_cidrs:
         cidrs = [c.cidr for c in listener.allowed_cidrs]
         if '0.0.0.0/0' not in cidrs:
-            # 0.0.0.0/0 - means not restrictions
+            # 0.0.0.0/0 - means all sources are allowed, no filtering needed
             entities.append((get_data_group_name(listener.id), as3.Data_Group(cidrs)))
             service_args['iRules'].append(as3.BigIP(CONF.f5_agent.irule_allowed_cidrs))
 


### PR DESCRIPTION
Example of declaration that has to be sent to F5 from Octavia via AS3:
```
{
    "class": "AS3",
    "action": "deploy",
    "persist": false,
    "declaration": {
        "net_370b0255_eb12_41c4_bd39_587fa7012219": {
            "label": "project_bba86def92f64c10bd5a091ce5d2efa6",
            "defaultRouteDomain": 2065,
            "class": "Tenant",
            "lb_487e7950-d600-483c-9493-89206f2f338b": {
                "template": "generic",
                "label": "487e7950-d600-483c-9493-89206f2f338b",
                "class": "Application",
                "listener_d7212e7d-0e6f-4f04-b352-52801aac7c02": {
                    "virtualAddresses": [
                        "10.180.88.99"
                    ],
                    "virtualPort": 80,
                    "persistenceMethods": [],
                    "iRules": [
                        {
                             "bigip": "/Common/cc_allowed_cidrs"
                        }
                    ],
                    "policyEndpoint": [],
                    "label": "test-listener-2",
                    "pool": "pool_50fb3f12-aae9-44dd-9840-594b96d8fdbf",
                    "profileTCP": {
                        "bigip": "/Common/cc_tcp_profile"
                    },
                    "snat": "self",
                    "class": "Service_TCP"
                },
                "pool_50fb3f12-aae9-44dd-9840-594b96d8fdbf": {
                    "label": "test-pool-3",
                    "remark": "http pool",
                    "loadBalancingMode": "ratio-member",
                    "members": [
                        {
                            "enable": true,
                            "servicePort": 8000,
                            "serverAddresses": [
                                "10.180.88.186"
                            ],
                            "adminState": "enable",
                            "ratio": 1,
                            "remark": "7e8eea42-bb9c-488b-9c58-33835fd01ae4"
                        }
                    ],
                    "monitors": [],
                    "class": "Pool"
                },
                "listener_d7212e7d-0e6f-4f04-b352-52801aac7c02_allowed_cidrs": {
                    "class": "Data_Group",
                    "keyDataType": "ip",
                    "records": [
                        {
                            "key": "192.168.0.0/24"
                        },
                        {
                            "key": "192.168.1.0/24"
                        }
                    ]
                }
            }
        },
        "schemaVersion": "3.32.0",
        "updateMode": "selective",
        "id": "urn:uuid:1af024a9-92b6-4fc3-aafc-1605bb248703",
        "label": "F5 BigIP Octavia Provider",
        "class": "ADC"
    }
}
```
`Data_Group` object has to be created for each listener. Template for declaration:
```
"listener_<UUID>_allowed_cidrs": {
    "class": "Data_Group",
    "keyDataType": "ip",
    "records": [
        {
            "key": "<CIDR>"
        }
    ]
}
```
After that data group should be used with pre-created iRule, like:
```
"iRules": [
    {
        "bigip": "/Common/cc_allowed_cidrs"
    }
],
```