### PR TITLE
Add ESD support for stateless UDP

### DIFF
--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -91,6 +91,12 @@ def get_esd_entities(servicetype, esd):
         if compression:
             service_args['profileHTTPCompression'] = as3.BigIP(compression)
 
+    if servicetype == f5_const.SERVICE_UDP:
+        # UDP datagram profile - routes UDP traffic without a connection table
+        cudp = esd.get('lbaas_cudp', None)
+        if cudp:
+            service_args['profileUDP'] = as3.BigIP(cudp)
+
     return service_args
 
 

--- a/octavia_f5/utils/esd_repo.py
+++ b/octavia_f5/utils/esd_repo.py
@@ -155,6 +155,8 @@ class EsdRepository(EsdJSONValidation):
             'value_type': str},
         'lbaas_stcp': {
             'value_type': str},
+        'lbaas_cudp': {
+            'value_type': str},
         'lbaas_http': {
             'value_type': str},
         'lbaas_one_connect': {


### PR DESCRIPTION
That is, UDP traffic without using a connection table.
Usually UDP traffic (on a Service_UDP class listener) uses a connection table that associates a source IP/port combination with a pool member. Entries from this table aren't cleared (except after a timeout of 60s), even after the pool member is deleted, which causes a lot of UDP traffic to be sinkholed on load balancers that often switch/delete pool members, especially Gardener LBs.

The ESD has been added here: https://github.com/sapcc/helm-charts/pull/5224

Closes #233