### PR TITLE
[as3restclient] Add fastL4 profile support to ESDs

### DIFF
--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -64,9 +64,11 @@ def get_esd_entities(servicetype, esd):
     if irules:
         service_args['iRules'] = [as3.BigIP(rule) for rule in irules]
 
-    # client / server tcp profiles
+    # TCP/FastL4 profiles
     if servicetype in [f5_const.SERVICE_HTTP, f5_const.SERVICE_HTTPS,
                        f5_const.SERVICE_TCP, f5_const.SERVICE_L4]:
+
+        # client/server TCP profiles
         ctcp = esd.get('lbaas_ctcp', None)
         stcp = esd.get('lbaas_stcp', None)
         if stcp and ctcp:
@@ -80,6 +82,12 @@ def get_esd_entities(servicetype, esd):
         else:
             service_args['profileTCP'] = 'normal'
 
+        # FastL4 profiles
+        profilel4 = esd.get('lbaas_fastl4', None)
+        if profilel4 and servicetype == f5_const.SERVICE_L4:
+            service_args['profilel4'] = as3.BigIP(profilel4)
+
+    # HTTP profiles
     if servicetype in [f5_const.SERVICE_HTTP, f5_const.SERVICE_HTTPS]:
         # OneConnect (Multiplex) Profile
         oneconnect = esd.get('lbaas_one_connect', None)
@@ -91,6 +99,7 @@ def get_esd_entities(servicetype, esd):
         if compression:
             service_args['profileHTTPCompression'] = as3.BigIP(compression)
 
+    # UDP profiles
     if servicetype == f5_const.SERVICE_UDP:
         # UDP datagram profile - routes UDP traffic without a connection table
         cudp = esd.get('lbaas_cudp', None)

--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -361,6 +361,9 @@ def get_service(listener, cert_manager, esd_repository):
             service_args['iRules'] or 'profileTCP' in service_args):
         service_args['_servicetype'] = f5_const.SERVICE_TCP
 
+        # profilel4 is only used on ServiceL4, so remove it
+        service_args.pop('profilel4', None)
+
     # add default profiles to supported listeners
     if CONF.f5_agent.profile_http and service_args['_servicetype'] in f5_const.SERVICE_HTTP_TYPES:
         if 'profileHTTP' not in service_args:

--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -79,13 +79,11 @@ def get_esd_entities(servicetype, esd):
             )
         elif ctcp:
             service_args['profileTCP'] = as3.BigIP(ctcp)
-        else:
-            service_args['profileTCP'] = 'normal'
 
         # FastL4 profiles
         profilel4 = esd.get('lbaas_fastl4', None)
         if profilel4 and servicetype == f5_const.SERVICE_L4:
-            service_args['profilel4'] = as3.BigIP(profilel4)
+            service_args['profileL4'] = as3.BigIP(profilel4)
 
     # HTTP profiles
     if servicetype in [f5_const.SERVICE_HTTP, f5_const.SERVICE_HTTPS]:
@@ -362,7 +360,7 @@ def get_service(listener, cert_manager, esd_repository):
         service_args['_servicetype'] = f5_const.SERVICE_TCP
 
         # profilel4 is only used on ServiceL4, so remove it
-        service_args.pop('profilel4', None)
+        service_args.pop('profileL4', None)
 
     # add default profiles to supported listeners
     if CONF.f5_agent.profile_http and service_args['_servicetype'] in f5_const.SERVICE_HTTP_TYPES:

--- a/octavia_f5/tests/unit/restclient/as3objects/test_service.py
+++ b/octavia_f5/tests/unit/restclient/as3objects/test_service.py
@@ -1,0 +1,58 @@
+# Copyright 2023 SAP SE
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from unittest import mock
+
+from oslo_config import cfg
+from oslo_config import fixture as oslo_fixture
+
+from octavia.db import models
+from octavia.tests.unit import base
+from octavia_f5.common import config  # noqa
+from octavia_f5.restclient.as3objects import service
+
+CONF = None
+
+
+class TestService(base.TestCase):
+    def setUp(self):
+        self.conf = self.useFixture(oslo_fixture.Config(cfg.CONF))
+        self.conf.config(group='f5_agent',
+                         tcp_service_type='Service_L4')
+        super(TestService, self).setUp()
+
+
+    @mock.patch("octavia_f5.utils.esd_repo.EsdRepository")
+    @mock.patch("octavia_f5.utils.cert_manager.CertManagerWrapper")
+    def test_get_service_l4(self, cert_manager, esd_repo):
+        mock_listener = mock.Mock(spec=models.Listener)
+        mock_listener.id = "test_listener_id"
+        mock_listener.name = "test_listener"
+        mock_listener.allowed_cidrs = []
+        mock_listener.connection_limit = 0
+        mock_listener.protocol = "TCP"
+        mock_listener.l7policies = []
+        mock_listener.tags = ["test_l4_tag"]
+
+        test_profile_name = "test_f5_fastl4_profile"
+        esd_repo.get_esd.return_value = {
+            "lbaas_fastl4" : test_profile_name,
+        }
+
+        svc = service.get_service(mock_listener, cert_manager, esd_repo)
+        self.assertEqual(1, len(svc))
+        svc_name, svc_as3 = svc[0]
+        self.assertEqual(f"listener_{mock_listener.id}", svc_name)
+        self.assertEqual("Service_L4", getattr(svc_as3, "class"))
+        self.assertEqual(f"/Common/{test_profile_name}", svc_as3.profileL4.bigip)


### PR DESCRIPTION
https://github.com/sapcc/helm-charts/pull/5305 introduces a fastL4 profile ESD that uses `lbaas_fastl4` key, which is [treated as valid by F5PD](https://github.com/sapcc/octavia-f5-provider-driver/blob/stable/yoga-m3/octavia_f5/utils/esd_repo.py#L152-L153), but not interpreted yet. This PR extends the `get_esd_entities` function to include translation of the `lbaas_fastl4` parameter into the AS3 `profilel4` parameter (for `ServiceL4` class).