### PR TITLE
Status Manager: Raise exception when no BigIPs configured

### DIFF
--- a/octavia_f5/controller/statusmanager/status_manager.py
+++ b/octavia_f5/controller/statusmanager/status_manager.py
@@ -32,6 +32,7 @@ from octavia_f5.common import constants
 from octavia_f5.controller.statusmanager.legacy_healthmanager.health_drivers import update_db
 from octavia_f5.db import repositories as f5_repo
 from octavia_f5.restclient.bigip import bigip_restclient, bigip_auth
+from octavia_f5.utils import exceptions
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
@@ -107,6 +108,10 @@ class StatusManager(object):
         'octavia_status_failover', 'Number of failovers')
 
     def initialize_bigips(self):
+
+        if not CONF.f5_agent.bigip_urls:
+            raise exceptions.ProviderDriverException("No BigIPs configured")
+
         for bigip_url in CONF.f5_agent.bigip_urls:
             # Create REST client for every bigip
 

--- a/octavia_f5/utils/exceptions.py
+++ b/octavia_f5/utils/exceptions.py
@@ -13,19 +13,23 @@
 # under the License.
 
 
-class AS3Exception(Exception):
+class ProviderDriverException(Exception):
     pass
 
 
-class RetryException(Exception):
+class AS3Exception(ProviderDriverException):
     pass
 
 
-class FailoverException(Exception):
+class RetryException(ProviderDriverException):
     pass
 
 
-class IControlRestException(Exception):
+class FailoverException(ProviderDriverException):
+    pass
+
+
+class IControlRestException(ProviderDriverException):
     pass
 
 
@@ -57,7 +61,7 @@ class MonitorDeletionException(AS3Exception):
         self.monitor = monitor
 
 
-class DeleteAllTenantsException(Exception):
+class DeleteAllTenantsException(AS3Exception):
     def __init__(self):
         super(DeleteAllTenantsException).__init__()
         self.message = 'Delete called without tenant, would wipe all AS3 Declaration, ignoring.'


### PR DESCRIPTION
This change makes the status manager fail early when there are no BigIP URLs configured. This should not happen in production (and probably never did/will), but it happened to me by accident during offline testing. It only resulted in an error later in the code when `self.bigips` could not be iterated over, but I wanted it to fail earlier. That's all. This is not really connected to the WIP failover fix.