### PR TITLE
Add TLS 1.3 support for Server and Client Side

### DIFF
--- a/octavia_f5/restclient/as3objects/tls.py
+++ b/octavia_f5/restclient/as3objects/tls.py
@@ -120,6 +120,7 @@ def get_tls_server(certificate_ids, listener, authentication_ca=None, allow_rene
     # Note: tls_1_1 is only supported in tmos version 14.0+
     service_args['tls1_1Enabled'] = lib_consts.TLS_VERSION_1_1 in tls_versions
     service_args['tls1_2Enabled'] = lib_consts.TLS_VERSION_1_2 in tls_versions
+    service_args['tls1_3Enabled'] = lib_consts.TLS_VERSION_1_3 in tls_versions
     # Control Renegotiation depends on HTTP2
     service_args['renegotiationEnabled'] = allow_renegotiation
 
@@ -170,6 +171,7 @@ def get_tls_client(pool, trust_ca=None, client_cert=None, crl_file=None, allow_r
     # Note: tls_1_1 is only supported in tmos version 14.0+
     service_args['tls1_1Enabled'] = lib_consts.TLS_VERSION_1_1 in tls_versions
     service_args['tls1_2Enabled'] = lib_consts.TLS_VERSION_1_2 in tls_versions
+    service_args['tls1_3Enabled'] = lib_consts.TLS_VERSION_1_3 in tls_versions
     # Control Renegotiation depends on HTTP2
     service_args['renegotiationEnabled'] = allow_renegotiation
 

--- a/octavia_f5/restclient/as3objects/tls.py
+++ b/octavia_f5/restclient/as3objects/tls.py
@@ -113,16 +113,8 @@ def get_tls_server(certificate_ids, listener, authentication_ca=None, allow_rene
     # LBs created before Ussuri may have TLS-enabled listeners with no tls_versions specified
     tls_versions = listener.tls_versions or CONF.api_settings.default_listener_tls_versions
 
-    # Set TLS versions
-    # Enable/Disable all SSL versions at once
-    service_args['sslEnabled'] = lib_consts.SSL_VERSION_3 in tls_versions
-    service_args['tls1_0Enabled'] = lib_consts.TLS_VERSION_1 in tls_versions
-    service_args['tls1_1Enabled'] = lib_consts.TLS_VERSION_1_1 in tls_versions
-    service_args['tls1_2Enabled'] = lib_consts.TLS_VERSION_1_2 in tls_versions
-    # Note: tls1_3Enabled is only supported in tmos version 14.0+
-    service_args['tls1_3Enabled'] = lib_consts.TLS_VERSION_1_3 in tls_versions
-    # Control Renegotiation depends on HTTP2
-    service_args['renegotiationEnabled'] = allow_renegotiation
+    # Add TLS version-specific args
+    service_args.update(get_tls_versions_args(tls_versions, allow_renegotiation))
 
     return TLS_Server(**service_args)
 
@@ -164,15 +156,28 @@ def get_tls_client(pool, trust_ca=None, client_cert=None, crl_file=None, allow_r
     # LBs created before Ussuri may have TLS-enabled pools with no tls_versions specified
     tls_versions = pool.tls_versions or CONF.api_settings.default_pool_tls_versions
 
-    # Set TLS versions
-    # Enable/Disable all SSL versions at once
-    service_args['sslEnabled'] = lib_consts.SSL_VERSION_3 in tls_versions
-    service_args['tls1_0Enabled'] = lib_consts.TLS_VERSION_1 in tls_versions
-    service_args['tls1_1Enabled'] = lib_consts.TLS_VERSION_1_1 in tls_versions
-    service_args['tls1_2Enabled'] = lib_consts.TLS_VERSION_1_2 in tls_versions
-    # Note: tls1_3Enabled is only supported in tmos version 14.0+
-    service_args['tls1_3Enabled'] = lib_consts.TLS_VERSION_1_3 in tls_versions
-    # Control Renegotiation depends on HTTP2
-    service_args['renegotiationEnabled'] = allow_renegotiation
+    # Add TLS version-specific args
+    service_args.update(get_tls_versions_args(tls_versions, allow_renegotiation))
 
     return TLS_Client(**service_args)
+
+
+def get_tls_versions_args(tls_versions, allow_renegotiation):
+    return {
+        # The following versions: SSLv3, TLSv1.0, TLSv1.1 are disabled and are not
+        # supported because of security issues. They are also not allowed on API
+        # level and our customers cannot configure them. But we have to set them to
+        # false because default values are true.
+        'sslEnabled': False,
+        'tls1_0Enabled': False,
+        'tls1_1Enabled': False,
+        # TLSv1.2 has to be enabled in any case because most of the ciphers require
+        # it and also it should be configured for HTTP2. Otherwise, we should have
+        # only TLSv1.3 ciphers. But this configuration is much more complicated for
+        # customers.
+        'tls1_2Enabled': True,
+        # Note: tls1_3Enabled is only supported in tmos version 14.0+
+        'tls1_3Enabled': lib_consts.TLS_VERSION_1_3 in tls_versions,
+        # Control Renegotiation depends on HTTP2
+        'renegotiationEnabled': allow_renegotiation,
+    }

--- a/octavia_f5/restclient/as3objects/tls.py
+++ b/octavia_f5/restclient/as3objects/tls.py
@@ -117,9 +117,9 @@ def get_tls_server(certificate_ids, listener, authentication_ca=None, allow_rene
     # Enable/Disable all SSL versions at once
     service_args['sslEnabled'] = lib_consts.SSL_VERSION_3 in tls_versions
     service_args['tls1_0Enabled'] = lib_consts.TLS_VERSION_1 in tls_versions
-    # Note: tls_1_1 is only supported in tmos version 14.0+
     service_args['tls1_1Enabled'] = lib_consts.TLS_VERSION_1_1 in tls_versions
     service_args['tls1_2Enabled'] = lib_consts.TLS_VERSION_1_2 in tls_versions
+    # Note: tls1_3Enabled is only supported in tmos version 14.0+
     service_args['tls1_3Enabled'] = lib_consts.TLS_VERSION_1_3 in tls_versions
     # Control Renegotiation depends on HTTP2
     service_args['renegotiationEnabled'] = allow_renegotiation
@@ -168,9 +168,9 @@ def get_tls_client(pool, trust_ca=None, client_cert=None, crl_file=None, allow_r
     # Enable/Disable all SSL versions at once
     service_args['sslEnabled'] = lib_consts.SSL_VERSION_3 in tls_versions
     service_args['tls1_0Enabled'] = lib_consts.TLS_VERSION_1 in tls_versions
-    # Note: tls_1_1 is only supported in tmos version 14.0+
     service_args['tls1_1Enabled'] = lib_consts.TLS_VERSION_1_1 in tls_versions
     service_args['tls1_2Enabled'] = lib_consts.TLS_VERSION_1_2 in tls_versions
+    # Note: tls1_3Enabled is only supported in tmos version 14.0+
     service_args['tls1_3Enabled'] = lib_consts.TLS_VERSION_1_3 in tls_versions
     # Control Renegotiation depends on HTTP2
     service_args['renegotiationEnabled'] = allow_renegotiation


### PR DESCRIPTION
This PR adds support for TLS 1.3 on Server and Client side. 3 new ciphers have to be added to the option: `tls_cipher_allow_list`:

- TLS13-AES128-GCM-SHA256
- TLS13-AES256-GCM-SHA384
 - TLS13-CHACHA20-POLY1305-SHA256

Documentation here: https://my.f5.com/manage/s/article/K10251520

Example of F5 declaration:
```
...
"tls_listener_f410ba56-2144-4b18-8eb4-4c61e423e962": {
    "certificates": [
        {
            "certificate": "cert_21d096e57a5d420cdc9cdd54ec97dbcb92952029"
        }
    ],
    "cipherGroup": {
        "use": "cipher_group_listener_f410ba56-2144-4b18-8eb4-4c61e423e962"
    },
    "class": "TLS_Server",
    "renegotiationEnabled": false,
    "sslEnabled": false,
    "tls1_0Enabled": false,
    "tls1_1Enabled": false,
    "tls1_2Enabled": true,
    "tls1_3Enabled": true
},
"cipher_rule_listener_f410ba56-2144-4b18-8eb4-4c61e423e962": {
    "cipherSuites": [
       ...
        "TLS13-AES128-GCM-SHA256",
        "TLS13-AES256-GCM-SHA384",
        "TLS13-CHACHA20-POLY1305-SHA256"
    ],
    "class": "Cipher_Rule"
},
...
``` 

Example of handshake (tested in QA):
```
# curl --http1.1 --tlsv1.3 --resolve example.com:4343:<IP> --cacert /test_ca.pem https://example.com:4343 -v
* Added example.com:4343:<IP> to DNS cache
* Hostname example.com was found in DNS cache
*   Trying 10.237.208.186:4343...
* Connected to example.com (10.237.208.186) port 4343
* ALPN: curl offers http/1.1
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
*  CAfile: /test_ca.pem
*  CApath: none
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=NGINX, Inc.; CN=nginx-manager.example.com
*  start date: Sep 22 14:43:50 2023 GMT
*  expire date: Sep 19 14:43:50 2033 GMT
*  subjectAltName: host "example.com" matched cert's "example.com"
*  issuer: C=US; ST=California; L=San Francisco; O=NGINX, Inc.; CN=nms-int-ca
*  SSL certificate verify ok.
* using HTTP/1.1
> GET / HTTP/1.1
> Host: example.com:4343
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Server: nginx
< Date: Mon, 20 Nov 2023 19:44:56 GMT
< Content-Type: text/html
< Content-Length: 157
< Last-Modified: Fri, 22 Sep 2023 11:57:42 GMT
< Connection: keep-alive
< ETag: "650d8136-9d"
< Accept-Ranges: bytes
<
<!DOCTYPE html>
<html>
<head>
<title>Answer from host test-lb-1</title>
</head>
<body>
<h1>Answer from host test-lb-1</h1>
</body>
</html>
* Connection #0 to host example.com left intact
```

OpenSSL check:
```
 $ openssl s_client -tls1_3 -connect <IP>:4343 -servername example.com -CAfile /test_ca.pem
CONNECTED(00000003)
depth=2 C = US, ST = California, L = San Francisco, O = "NGINX, Inc.", CN = nms-ca
verify return:1
depth=1 C = US, ST = California, L = San Francisco, O = "NGINX, Inc.", CN = nms-int-ca
verify return:1
depth=0 C = US, ST = California, L = San Francisco, O = "NGINX, Inc.", CN = nginx-manager.example.com
verify return:1
---
Certificate chain
 0 s:C = US, ST = California, L = San Francisco, O = "NGINX, Inc.", CN = nginx-manager.example.com
   i:C = US, ST = California, L = San Francisco, O = "NGINX, Inc.", CN = nms-int-ca
   a:PKEY: rsaEncryption, 4096 (bit); sigalg: RSA-SHA256
   v:NotBefore: Sep 22 14:43:50 2023 GMT; NotAfter: Sep 19 14:43:50 2033 GMT
---
Server certificate
-----BEGIN CERTIFICATE-----
...
-----END CERTIFICATE-----
subject=C = US, ST = California, L = San Francisco, O = "NGINX, Inc.", CN = nginx-manager.example.com
issuer=C = US, ST = California, L = San Francisco, O = "NGINX, Inc.", CN = nms-int-ca
---
No client certificate CA names sent
Peer signing digest: SHA256
Peer signature type: RSA-PSS
Server Temp Key: X25519, 253 bits
---
SSL handshake has read 2329 bytes and written 309 bytes
Verification: OK
---
New, TLSv1.3, Cipher is TLS_AES_128_GCM_SHA256
Server public key is 4096 bit
This TLS version forbids renegotiation.
Compression: NONE
Expansion: NONE
No ALPN negotiated
Early data was not sent
Verify return code: 0 (ok)
---
```

Also, this PR contains hardcoded disabling of SSLv3, TLSv1.0, and TLSv1.1 because, on the api level, they are not allowed, but we have to keep them in the code because we have to re-write default F5 values:
```
$ openstack loadbalancer listener set --tls-version "SSLv3" --tls-version "TLSv1.2" --tls-version "TLSv1.3" 6b8d4dc7-405c-4c7c-ab52-50a64fd42445
Validation failure: Requested TLS versions are less than the minimum: SSLv3 < TLSv1.2 (HTTP 400) (Request-ID: req-b1fa5d86-84b0-46ea-b1ca-2d1ab8309df0)

$ openstack loadbalancer listener set --tls-version "TLSv1.0" --tls-version "TLSv1.2" --tls-version "TLSv1.3" 6b8d4dc7-405c-4c7c-ab52-50a64fd42445
Validation failure: Invalid TLS versions: TLSv1.0 (HTTP 400) (Request-ID: req-cf6c8810-7e48-4e24-a5a5-b963b96aba00)

$ openstack loadbalancer listener set --tls-version "TLSv1.1" --tls-version "TLSv1.2" --tls-version "TLSv1.3" 6b8d4dc7-405c-4c7c-ab52-50a64fd42445
Validation failure: Requested TLS versions are less than the minimum: TLSv1.1 < TLSv1.2 (HTTP 400) (Request-ID: req-40b99e6a-c9b5-428b-88e1-151af8ad29da)
```