### PR TITLE
[as3restclient] Logging: Truncate certificate private keys

### DIFF
--- a/octavia_f5/restclient/as3logging.py
+++ b/octavia_f5/restclient/as3logging.py
@@ -13,15 +13,39 @@
 # under the License.
 
 from urllib import parse
-
 import json
+
+from octavia_f5.common import constants
+
+
+def truncate_as3_secrets(as3_json_decl):
+    """ Remove or truncate sensitive material from an AS3 declaration.
+    Changes are made in-place.
+
+    :param as3_json_decl: A parsed JSON object constructed with json.load or json.loads
+    """
+
+    for net in as3_json_decl:
+        net_obj = as3_json_decl.get(net)
+        for lb in net_obj:
+            lb_obj = net_obj.get(lb)
+            for lb_key in lb_obj:
+                # remove private keys from certificate declarations
+                if not lb_key.startswith(constants.PREFIX_CERTIFICATE):
+                    continue
+                cert_obj = lb_obj.get(lb_key)
+                for cert_key in cert_obj:
+                    if cert_key == 'privateKey':
+                        cert_priv = cert_obj.get(cert_key)
+                        # keep the first line so that the type of key is still
+                        # recognizable
+                        cert_obj[cert_key] = cert_priv.split("\n")[0] + "\n(...)"
 
 
 def get_response_log(response):
     """ Formats AS3 requests response and prints them pretty
 
     :param response: requests response
-    :param error: boolean, true if log to error, else debug
     """
 
     request = response.request
@@ -36,6 +60,7 @@ def get_response_log(response):
     if request.body:
         try:
             parsed = json.loads(request.body)
+            truncate_as3_secrets(parsed)
             msg += json.dumps(parsed, sort_keys=True, indent=4)
         except ValueError:
             # No json, just dump


### PR DESCRIPTION
We don't want/need certificate private keys to show up fully in logs, so truncate them.
Don't omit them fully, just print their first line (e.g. "-----BEGIN RSA PRIVATE KEY-----") so that their type is still clear.

I thought that someone already made an issue for this in the past, but I can't find it. It was probably just a Slack thread.