### PR TITLE
Skip cache for failover status checks.

### DIFF
--- a/octavia_f5/restclient/bigip/bigip_restclient.py
+++ b/octavia_f5/restclient/bigip/bigip_restclient.py
@@ -59,8 +59,7 @@ class BigIPRestClient(requests.Session):
 
     @property
     def is_active(self):
-        if self._active is None:
-            return self.update_status()
+        self.update_status()
         return self._active
 
     def update_status(self):


### PR DESCRIPTION
This PR removes the cache from F5 status checking to have correct statuses during the failover check.

Related to https://github.com/sapcc/octavia-f5-provider-driver/issues/212