### PR TITLE
Set priority group only for pools with multiple members.

### DIFF
--- a/octavia_f5/restclient/as3objects/pool.py
+++ b/octavia_f5/restclient/as3objects/pool.py
@@ -57,7 +57,11 @@ def get_pool(pool, ips_to_skip, status):
         'members': [],
     }
 
-    enable_priority_group = any([member.backup for member in pool.members])
+    # Never set priority group if there is only one member, even if it's a backup member
+    enable_priority_group = False
+    if len(pool.members) > 1:
+        enable_priority_group = any([member.backup for member in pool.members])
+
     for member in pool.members:
         if not utils.pending_delete(member):
             if member.ip_address in ips_to_skip:


### PR DESCRIPTION
This PR fixes `priorityGroup` set for a single member. This is related to a bug in F5 which we detected with Octavia Tempest. The fix was already tested and the number of fails decreased by 40%.