### PR TITLE
Add L2 rollback

### DIFF
--- a/octavia_f5/controller/worker/flows/f5_flows.py
+++ b/octavia_f5/controller/worker/flows/f5_flows.py
@@ -23,98 +23,201 @@ LOG = logging.getLogger(__name__)
 
 
 class F5Flows(object):
-    def ensure_l2(self, selfips: [network_models.Port]) -> flow.Flow:
-        # We can parallelize selfip creation
-        ensure_selfip_subflow = unordered_flow.Flow('ensure-selfip-subflow')
-        for selfip in selfips:
-            ensure_selfip = f5_tasks.EnsureSelfIP(name=f"ensure-selfip-{selfip.id}",
-                                                  inject={'port': selfip})
-            ensure_selfip_subflow.add(ensure_selfip)
+    def make_ensure_l2_flow(self, selfips: [network_models.Port], store: dict) -> flow.Flow:
+        """
+        Construct and return a flow to ensure complete L2 configuration for a new partition.
+        The flow assumes that no L2 objects exist yet for the network so nothing is cleaned up.
+        """
 
-        ensure_routedomain = f5_tasks.EnsureRouteDomain()
+        # make SelfIP creation subflow
+        ensure_selfips_subflow = unordered_flow.Flow('ensure-selfips-subflow')
+        for selfip in selfips:
+            ensure_selfip_task = f5_tasks.EnsureSelfIP(name=f"ensure-selfip-{selfip.id}", inject={'port': selfip})
+            ensure_selfips_subflow.add(ensure_selfip_task)
+
+        # create subnet routes for all subnets that don't have a SelfIP
+        network = store['network']
+        subnets_to_create_routes_for = [subnet for subnet in network.subnets
+                                        if not f5_tasks.selfip_for_subnet_exists(subnet, selfips)]
+        ensure_subnet_routes_subflow = unordered_flow.Flow('ensure-subnet-routes-subflow')
+
+        # make subnet route creation subflow
+        for subnet_id in subnets_to_create_routes_for:
+            subnet_route_name = f5_tasks.get_subnet_route_name(network.id, subnet_id)
+            ensure_subnet_route_task = f5_tasks.EnsureSubnetRoute(name=f"ensure-subnet-route-{subnet_route_name}",
+                                                                  inject={'subnet_id': subnet_id})
+            ensure_subnet_routes_subflow.add(ensure_subnet_route_task)
+
+        ensure_route_domain = f5_tasks.EnsureRouteDomain()
         ensure_default_route = f5_tasks.EnsureDefaultRoute()
-        ensure_static_routes = f5_tasks.EnsureSubnetRoutes(inject={'selfips': selfips})
         ensure_vlan = f5_tasks.EnsureVLAN()
 
         ensure_l2_flow = linear_flow.Flow('ensure-l2-flow')
         ensure_l2_flow.add(ensure_vlan,
-                           ensure_routedomain,
-                           ensure_selfip_subflow,
+                           ensure_route_domain,
+                           # SelfIPs must be present for routes to work
+                           ensure_selfips_subflow,
                            ensure_default_route,
-                           ensure_static_routes)
+                           ensure_subnet_routes_subflow)
         return ensure_l2_flow
 
-    def remove_l2(self, selfips: [str]) -> flow.Flow:
-        # We can parallelize selfip deletion
-        cleanup_selfip_subflow = unordered_flow.Flow('cleanup-selfip-subflow')
-        for selfip in selfips:
-            cleanup_selfip = f5_tasks.RemoveSelfIP(name=f"cleanup-selfip-{selfip.id}",
-                                                   inject={'port': selfip})
-            cleanup_selfip_subflow.add(cleanup_selfip)
+    def make_remove_l2_flow(self, store: dict) -> flow.Flow:
+        """Construct and return a flow to remove complete L2 configuration of a partition."""
+        existing_selfips = store['existing_selfips']
+        existing_subnet_routes = store['existing_subnet_routes']
 
-        cleanup_subnet_routes = f5_tasks.CleanupSubnetRoutes(inject={'selfips': selfips,
-                                                                     'delete_all': True})
-        cleanup_route = f5_tasks.CleanupDefaultRoute()
-        cleanup_routedomain = f5_tasks.CleanupRouteDomain()
-        cleanup_vlan = f5_tasks.CleanupVLAN()
+        # remove subnet routes
+        remove_subnet_routes_subflow = unordered_flow.Flow('remove-subnet-routes-subflow')
+        for subnet_route in existing_subnet_routes:
+            remove_subnet_route_task = f5_tasks.RemoveSubnetRoute(name=f"remove-subnet-route-{subnet_route['name']}",
+                                                                  inject={'subnet_route': subnet_route})
+            remove_subnet_routes_subflow.add(remove_subnet_route_task)
 
-        cleanup_l2_flow = linear_flow.Flow('cleanup-l2-flow')
-        cleanup_l2_flow.add(cleanup_subnet_routes,
-                            cleanup_route,
-                            cleanup_selfip_subflow,
-                            cleanup_routedomain,
-                            cleanup_vlan)
-        return cleanup_l2_flow
+        # remove SelfIPs
+        remove_selfips_subflow = unordered_flow.Flow('remove-selfips-subflow')
+        for selfip in existing_selfips:
+            remove_selfip_task = f5_tasks.RemoveSelfIP(name=f"remove-selfip-{selfip.id}", inject={'port': selfip})
+            remove_selfips_subflow.add(remove_selfip_task)
 
-    def cleanup_selfips_and_subnet_routes(self, expected_selfips, device_selfips, store: dict) -> flow.Flow:
+        # remove other L2 objects
+        remove_default_route_task = f5_tasks.RemoveDefaultRoute()
+        remove_route_domain_task = f5_tasks.RemoveRouteDomain()
+        remove_vlan_task = f5_tasks.RemoveVLAN()
+
+        remove_l2_flow = linear_flow.Flow('remove-l2-flow')
+        remove_l2_flow.add(remove_subnet_routes_subflow,
+                           remove_default_route_task,
+                           # SelfIPs must be deleted after routes, otherwise a route would be unreachable
+                           remove_selfips_subflow,
+                           remove_route_domain_task,
+                           remove_vlan_task)
+        return remove_l2_flow
+
+    def make_sync_selfips_and_subnet_routes_flow(self, needed_selfips, subnets_that_need_routes,
+                                                 store: dict) -> flow.Flow:
+        """ Construct and return a flow that syncs SelfIPs and static subnet routes.
+        Since SelfIPs and subnet routes are mutually exclusive (per subnet), first remove unneeded SelfIPs/subnet
+        routes, then add missing SelfIPs/subnet routes. Put the two stages into one single (linear) flow, so that they
+        can both be rolled back together.
+
+        :param needed_selfips: SelfIPs that must exist
+        :param subnets_that_need_routes: Subnets for which subnet routes must exist
+        """
+
+        # create subflow to remove unneeded SelfIPs and subnet routes
+        remove_selfips_and_subnet_routes_flow = self.make_remove_selfips_and_subnet_routes_flow(
+            needed_selfips, subnets_that_need_routes, store)
+
+        # create subflow to ensure needed SelfIPs and subnet routes
+        ensure_selfips_and_subnet_routes_flow = self.make_ensure_selfips_and_subnet_routes_flow(
+            needed_selfips, subnets_that_need_routes, store)
+
+        # return linear flow
+        sync_flow = linear_flow.Flow('sync-selfips-and-subnet-routes-flow')
+        sync_flow.add(remove_selfips_and_subnet_routes_flow)
+        sync_flow.add(ensure_selfips_and_subnet_routes_flow)
+        return sync_flow
+
+    def make_remove_selfips_and_subnet_routes_flow(self, needed_selfips, subnets_that_need_routes,
+                                                   store: dict) -> flow.Flow:
         """ Remove unneeded SelfIPs and subnet routes of a specific network
 
-        :param expected_selfips: SelfIPs that must exist
-        :param device_selfips: SelfIPs that currently exist
+        :param needed_selfips: SelfIPs that must exist
+        :param subnets_that_need_routes: Subnets for which subnet routes must exist
         """
+        host = store['bigip'].hostname
+        network = store['network']
+        existing_selfips = store['existing_selfips']
+        existing_subnet_routes = store['existing_subnet_routes']
 
-        cleanup_selfips_and_subnet_routes_flow = unordered_flow.Flow('cleanup-selfips-and-subnet-routes-flow')
+        # remove subnet routes that are existing but don't belong to one of the subnets that need routes
+        subnet_route_network_part = f5_tasks.get_subnet_route_name(network.id, '')
+        subnet_routes_to_remove = [r['name'] for r in existing_subnet_routes
+                                   if r['name'].startswith(subnet_route_network_part)
+                                   and r['name'][len(subnet_route_network_part):] not in subnets_that_need_routes]
+        LOG.debug(f"{host}: Subnet routes to remove for network {network.id} (subnet IDs): {subnet_routes_to_remove}")
 
-        # removal of SelfIPs
-        selfips_to_remove = [port for port in device_selfips if port.id not in [p.id for p in expected_selfips]]
-        LOG.debug("%s: SelfIPs to remove for network %s: %s",
-                  store['bigip'].hostname, store['network'].id, [p.id for p in selfips_to_remove])
-        for selfip in selfips_to_remove:
-            cleanup_selfip = f5_tasks.RemoveSelfIP(name=f"cleanup-selfip-{selfip.id}", inject={'port': selfip})
-            cleanup_selfips_and_subnet_routes_flow.add(cleanup_selfip)
+        # make subnet routes removal subflow
+        remove_subnet_routes_subflow = unordered_flow.Flow('remove-subnet-routes-subflow')
+        for subnet_route_name in subnet_routes_to_remove:
+            remove_subnet_route_task = f5_tasks.RemoveSubnetRoute(name=f"remove-subnet-route-{subnet_route_name}",
+                                                                  inject={'subnet_route': subnet_route_name})
+            remove_subnet_routes_subflow.add(remove_subnet_route_task)
 
-        # removal of subnet routes
-        cleanup_selfips_and_subnet_routes_flow.add(
-            f5_tasks.CleanupSubnetRoutes(inject={'selfips': expected_selfips}))
+        # remove SelfIPs that are existing but not needed
+        selfips_to_remove = [port for port in existing_selfips if port.id not in [p.id for p in needed_selfips]]
+        LOG.debug(f"{host}: SelfIPs to remove for network {network.id}: {[p.id for p in selfips_to_remove]}")
 
-        return cleanup_selfips_and_subnet_routes_flow
+        # make SelfIPs removal subflow
+        remove_selfips_subflow = unordered_flow.Flow('remove-selfips-subflow')
+        for selfip_port in selfips_to_remove:
+            remove_selfip = f5_tasks.RemoveSelfIP(name=f"remove-selfip-{selfip_port.id}",
+                                                  inject={'port': selfip_port})
+            remove_selfips_subflow.add(remove_selfip)
 
-    def ensure_selfips_and_subnet_routes(self, expected_selfips, device_selfips, store: dict) -> flow.Flow:
+        # make and return flow
+        remove_selfips_and_subnet_routes_flow = linear_flow.Flow('remove-selfips-and-subnet-routes-flow')
+        remove_selfips_and_subnet_routes_flow.add(remove_subnet_routes_subflow,
+                                                  remove_selfips_subflow)
+        return remove_selfips_and_subnet_routes_flow
+
+    def make_ensure_selfips_and_subnet_routes_flow(self, needed_selfips, subnets_that_need_routes,
+                                                   store: dict) -> flow.Flow:
         """ Add needed SelfIPs and subnet routes of a specific network
 
-        :param expected_selfips: SelfIPs that must exist
-        :param device_selfips: SelfIPs that currently exist
+        :param needed_selfips: SelfIPs that must exist
+        :param subnets_that_need_routes: Subnets for which subnet routes must exist
         """
+        host = store['bigip'].hostname
+        network = store['network'].id
+        preexisting_selfips = store['existing_selfips']
+        preexisting_subnet_routes = store['existing_subnet_routes']
 
-        ensure_selfips_and_subnet_routes_flow = unordered_flow.Flow('ensure-selfips-and-subnet-routes-flow')
+        # find SelfIPs that are expected but not existing
+        selfips_to_create = [port for port in needed_selfips if port.id not in [p.id for p in preexisting_selfips]]
+        LOG.debug(f"{host}: SelfIPs to add for network {network.id}: {[p.id for p in selfips_to_create]}")
 
-        # adding SelfIPs
-        selfips_to_add = [port for port in expected_selfips if port.id not in [p.id for p in device_selfips]]
-        LOG.debug("%s: SelfIPs to add for network %s: %s",
-                  store['bigip'].hostname, store['network'].id, [p.id for p in selfips_to_add])
+        # make SelfIP creation subflow
+        ensure_selfips_subflow = unordered_flow.Flow('ensure-selfips-subflow')
+        for selfip in selfips_to_create:
+            ensure_selfip_task = f5_tasks.EnsureSelfIP(name=f"ensure-selfip-{selfip.id}", inject={'port': selfip})
+            ensure_selfips_subflow.add(ensure_selfip_task)
 
-        for selfip in selfips_to_add:
-            ensure_selfip = f5_tasks.EnsureSelfIP(name=f"ensure-selfip-{selfip.id}", inject={'port': selfip})
-            ensure_selfips_and_subnet_routes_flow.add(ensure_selfip)
+        # find subnet routes for subnets that need them but don't have any yet
+        subnet_route_network_part = f5_tasks.get_subnet_route_name(network.id, '')
+        subnets_of_preexisting_subnet_routes = [
+            r['name'][len(subnet_route_network_part):] for r in preexisting_subnet_routes
+            if r['name'].startswith(subnet_route_network_part)
+        ]
+        subnets_to_create_routes_for = [s for s in subnets_that_need_routes
+                                        if s not in subnets_of_preexisting_subnet_routes]
 
-        # removal of subnet routes
-        ensure_selfips_and_subnet_routes_flow.add(
-            f5_tasks.EnsureSubnetRoutes(inject={'selfips': expected_selfips}))
+        # make subnet route creation subflow
+        ensure_subnet_routes_subflow = unordered_flow.Flow('ensure-subnet-routes-subflow')
+        for subnet_id in subnets_to_create_routes_for:
+            subnet_route_name = f5_tasks.get_subnet_route_name(network.id, subnet_id)
+            ensure_subnet_route_task = f5_tasks.EnsureSubnetRoute(name=f"ensure-subnet-route-{subnet_route_name}",
+                                                                  inject={'subnet_id': subnet_id})
+            ensure_subnet_routes_subflow.add(ensure_subnet_route_task)
 
+        # make and return flow
+        ensure_selfips_and_subnet_routes_flow = linear_flow.Flow('ensure-selfips-and-subnet-routes-flow')
+        ensure_selfips_and_subnet_routes_flow.add(ensure_selfips_subflow,
+                                                  ensure_subnet_routes_subflow)
         return ensure_selfips_and_subnet_routes_flow
 
-    def get_selfips_from_device_for_vlan(self) -> [network_models.Port]:
-        return f5_tasks.GetAllSelfIPsForVLAN(name='all-selfips')
+    def make_get_existing_selfips_and_subnet_routes_flow(self) -> flow.Flow:
+        """Return a flow that gets all SelfIPs and subnet routes that currently
+        exist on a particular device for a particular network."""
+
+        get_selfips_task = f5_tasks.GetExistingSelfIPsForVLAN(name='get-existing-selfips')
+        get_subnet_routes_task = f5_tasks.GetExistingSubnetRoutesForNetwork(name='get-existing-subnet-routes')
+
+        get_existing_sip_sr_flow = unordered_flow.Flow('get-existing-selfips-and-subnet-routes-flow')
+        get_existing_sip_sr_flow.add(get_selfips_task)
+        get_existing_sip_sr_flow.add(get_subnet_routes_task)
+
+        return get_existing_sip_sr_flow
 
     def ensure_vcmp_l2(self) -> flow.Flow:
         ensure_vlan = f5_tasks.EnsureVLAN()
@@ -129,11 +232,11 @@ class F5Flows(object):
 
     def remove_vcmp_l2(self) -> flow.Flow:
         get_vcmp_guests = f5_tasks.GetVCMPGuests()
-        cleanup_guest_vlan = f5_tasks.CleanupGuestVLAN()
-        cleanup_vlan_if_not_owned_by_guest = f5_tasks.CleanupVLANIfNotOwnedByGuest()
+        remove_guest_vlan = f5_tasks.RemoveGuestVLAN()
+        remove_vlan_if_not_owned_by_guest = f5_tasks.RemoveVLANIfNotOwnedByGuest()
 
-        cleanup_vcmp_l2_flow = linear_flow.Flow('cleanup-vcmp-l2-flow')
-        cleanup_vcmp_l2_flow.add(get_vcmp_guests,
-                                 cleanup_guest_vlan,
-                                 cleanup_vlan_if_not_owned_by_guest)
-        return cleanup_vcmp_l2_flow
+        remove_vcmp_l2_flow = linear_flow.Flow('remove-vcmp-l2-flow')
+        remove_vcmp_l2_flow.add(get_vcmp_guests,
+                                remove_guest_vlan,
+                                remove_vlan_if_not_owned_by_guest)
+        return remove_vcmp_l2_flow

--- a/octavia_f5/controller/worker/flows/f5_flows.py
+++ b/octavia_f5/controller/worker/flows/f5_flows.py
@@ -68,9 +68,9 @@ class F5Flows(object):
 
         # remove subnet routes
         remove_subnet_routes_subflow = unordered_flow.Flow('remove-subnet-routes-subflow')
-        for subnet_route in existing_subnet_routes:
-            remove_subnet_route_task = f5_tasks.RemoveSubnetRoute(name=f"remove-subnet-route-{subnet_route['name']}",
-                                                                  inject={'subnet_route': subnet_route})
+        for subnet_route_name in existing_subnet_routes:
+            remove_subnet_route_task = f5_tasks.RemoveSubnetRoute(name=f"remove-subnet-route-{subnet_route_name}",
+                                                                  inject={'subnet_route_name': subnet_route_name})
             remove_subnet_routes_subflow.add(remove_subnet_route_task)
 
         # remove SelfIPs
@@ -141,7 +141,7 @@ class F5Flows(object):
         remove_subnet_routes_subflow = unordered_flow.Flow('remove-subnet-routes-subflow')
         for subnet_route_name in subnet_routes_to_remove:
             remove_subnet_route_task = f5_tasks.RemoveSubnetRoute(name=f"remove-subnet-route-{subnet_route_name}",
-                                                                  inject={'subnet_route': subnet_route_name})
+                                                                  inject={'subnet_route_name': subnet_route_name})
             remove_subnet_routes_subflow.add(remove_subnet_route_task)
 
         # remove SelfIPs that are existing but not needed
@@ -169,7 +169,7 @@ class F5Flows(object):
         :param subnets_that_need_routes: Subnets for which subnet routes must exist
         """
         host = store['bigip'].hostname
-        network = store['network'].id
+        network = store['network']
         preexisting_selfips = store['existing_selfips']
         preexisting_subnet_routes = store['existing_subnet_routes']
 
@@ -191,6 +191,7 @@ class F5Flows(object):
         ]
         subnets_to_create_routes_for = [s for s in subnets_that_need_routes
                                         if s not in subnets_of_preexisting_subnet_routes]
+        LOG.debug(f"{host}: Subnet of network {network.id} for which routes will be created: {subnets_to_create_routes_for}")
 
         # make subnet route creation subflow
         ensure_subnet_routes_subflow = unordered_flow.Flow('ensure-subnet-routes-subflow')

--- a/octavia_f5/controller/worker/flows/f5_flows.py
+++ b/octavia_f5/controller/worker/flows/f5_flows.py
@@ -220,7 +220,7 @@ class F5Flows(object):
 
         return get_existing_sip_sr_flow
 
-    def ensure_vcmp_l2(self) -> flow.Flow:
+    def make_ensure_vcmp_l2_flow(self) -> flow.Flow:
         ensure_vlan = f5_tasks.EnsureVLAN()
         ensure_vlan_interface = f5_tasks.EnsureVLANInterface()
         ensure_guest_vlan = f5_tasks.EnsureGuestVLAN()
@@ -231,7 +231,7 @@ class F5Flows(object):
                                 ensure_guest_vlan)
         return ensure_vcmp_l2_flow
 
-    def remove_vcmp_l2(self) -> flow.Flow:
+    def make_remove_vcmp_l2_flow(self) -> flow.Flow:
         get_vcmp_guests = f5_tasks.GetVCMPGuests()
         remove_guest_vlan = f5_tasks.RemoveGuestVLAN()
         remove_vlan_if_not_owned_by_guest = f5_tasks.RemoveVLANIfNotOwnedByGuest()

--- a/octavia_f5/controller/worker/flows/f5_flows.py
+++ b/octavia_f5/controller/worker/flows/f5_flows.py
@@ -69,9 +69,9 @@ class F5Flows(object):
 
         # remove subnet routes
         remove_subnet_routes_subflow = unordered_flow.Flow('remove-subnet-routes-subflow')
-        for subnet_route_name in existing_subnet_routes:
-            remove_subnet_route_task = f5_tasks.RemoveSubnetRoute(name=f"remove-subnet-route-{subnet_route_name}",
-                                                                  inject={'subnet_route_name': subnet_route_name})
+        for subnet_route in existing_subnet_routes:
+            remove_subnet_route_task = f5_tasks.RemoveSubnetRoute(name=f"remove-subnet-route-{subnet_route['name']}",
+                                                                  inject={'subnet_route': subnet_route})
             remove_subnet_routes_subflow.add(remove_subnet_route_task)
 
         # remove SelfIPs
@@ -134,16 +134,16 @@ class F5Flows(object):
 
         # remove subnet routes that are existing but don't belong to one of the subnets that need routes
         subnet_route_network_part = f5_tasks.get_subnet_route_name(network.id, '')
-        subnet_routes_to_remove = [r['name'] for r in existing_subnet_routes
+        subnet_routes_to_remove = [r for r in existing_subnet_routes
                                    if r['name'].startswith(subnet_route_network_part)
                                    and r['name'][len(subnet_route_network_part):] not in subnets_that_need_routes]
-        LOG.debug(f"{host}: Subnet routes to remove for network {network.id} (subnet IDs): {subnet_routes_to_remove}")
+        LOG.debug(f"{host}: Subnet routes to remove for network {network.id} (subnet IDs): {[r['name'] for r in subnet_routes_to_remove]}")
 
         # make subnet routes removal subflow
         remove_subnet_routes_subflow = unordered_flow.Flow('remove-subnet-routes-subflow')
-        for subnet_route_name in subnet_routes_to_remove:
-            remove_subnet_route_task = f5_tasks.RemoveSubnetRoute(name=f"remove-subnet-route-{subnet_route_name}",
-                                                                  inject={'subnet_route_name': subnet_route_name})
+        for subnet_route in subnet_routes_to_remove:
+            remove_subnet_route_task = f5_tasks.RemoveSubnetRoute(name=f"remove-subnet-route-{subnet_route['name']}",
+                                                                  inject={'subnet_route': subnet_route})
             remove_subnet_routes_subflow.add(remove_subnet_route_task)
 
         # remove SelfIPs that are existing but not needed

--- a/octavia_f5/controller/worker/flows/f5_flows.py
+++ b/octavia_f5/controller/worker/flows/f5_flows.py
@@ -31,8 +31,9 @@ class F5Flows(object):
 
         # make SelfIP creation subflow
         ensure_selfips_subflow = unordered_flow.Flow('ensure-selfips-subflow')
-        for selfip in selfips:
-            ensure_selfip_task = f5_tasks.EnsureSelfIP(name=f"ensure-selfip-{selfip.id}", inject={'port': selfip})
+        for selfip_port in selfips:
+            ensure_selfip_task = f5_tasks.EnsureSelfIP(
+                name=f"ensure-selfip-{selfip_port.id}", inject={'port': selfip_port})
             ensure_selfips_subflow.add(ensure_selfip_task)
 
         # create subnet routes for all subnets that don't have a SelfIP
@@ -76,7 +77,8 @@ class F5Flows(object):
         # remove SelfIPs
         remove_selfips_subflow = unordered_flow.Flow('remove-selfips-subflow')
         for selfip in existing_selfips:
-            remove_selfip_task = f5_tasks.RemoveSelfIP(name=f"remove-selfip-{selfip.id}", inject={'port': selfip})
+            remove_selfip_task = f5_tasks.RemoveSelfIP(name=f"remove-selfip-{selfip['port_id']}",
+                                                       inject={'selfip': selfip})
             remove_selfips_subflow.add(remove_selfip_task)
 
         # remove other L2 objects
@@ -122,7 +124,7 @@ class F5Flows(object):
                                                    store: dict) -> flow.Flow:
         """ Remove unneeded SelfIPs and subnet routes of a specific network
 
-        :param needed_selfips: SelfIPs that must exist
+        :param needed_selfips: Ports for SelfIPs that must exist
         :param subnets_that_need_routes: Subnets for which subnet routes must exist
         """
         host = store['bigip'].hostname
@@ -145,14 +147,14 @@ class F5Flows(object):
             remove_subnet_routes_subflow.add(remove_subnet_route_task)
 
         # remove SelfIPs that are existing but not needed
-        selfips_to_remove = [port for port in existing_selfips if port.id not in [p.id for p in needed_selfips]]
-        LOG.debug(f"{host}: SelfIPs to remove for network {network.id}: {[p.id for p in selfips_to_remove]}")
+        selfips_to_remove = [sip for sip in existing_selfips if sip['port_id'] not in [p.id for p in needed_selfips]]
+        LOG.debug(f"{host}: SelfIPs to remove for network {network.id}: {[sip['port_id'] for sip in selfips_to_remove]}")
 
         # make SelfIPs removal subflow
         remove_selfips_subflow = unordered_flow.Flow('remove-selfips-subflow')
-        for selfip_port in selfips_to_remove:
-            remove_selfip = f5_tasks.RemoveSelfIP(name=f"remove-selfip-{selfip_port.id}",
-                                                  inject={'port': selfip_port})
+        for selfip in selfips_to_remove:
+            remove_selfip = f5_tasks.RemoveSelfIP(name=f"remove-selfip-{selfip['port_id']}",
+                                                  inject={'selfip': selfip})
             remove_selfips_subflow.add(remove_selfip)
 
         # make and return flow
@@ -174,13 +176,15 @@ class F5Flows(object):
         preexisting_subnet_routes = store['existing_subnet_routes']
 
         # find SelfIPs that are expected but not existing
-        selfips_to_create = [port for port in needed_selfips if port.id not in [p.id for p in preexisting_selfips]]
+        selfips_to_create = [port for port in needed_selfips
+                             if port.id not in [sip['port_id'] for sip in preexisting_selfips]]
         LOG.debug(f"{host}: SelfIPs to add for network {network.id}: {[p.id for p in selfips_to_create]}")
 
         # make SelfIP creation subflow
         ensure_selfips_subflow = unordered_flow.Flow('ensure-selfips-subflow')
-        for selfip in selfips_to_create:
-            ensure_selfip_task = f5_tasks.EnsureSelfIP(name=f"ensure-selfip-{selfip.id}", inject={'port': selfip})
+        for selfip_port in selfips_to_create:
+            ensure_selfip_task = f5_tasks.EnsureSelfIP(
+                name=f"ensure-selfip-{selfip_port.id}", inject={'port': selfip_port})
             ensure_selfips_subflow.add(ensure_selfip_task)
 
         # find subnet routes for subnets that need them but don't have any yet
@@ -191,7 +195,8 @@ class F5Flows(object):
         ]
         subnets_to_create_routes_for = [s for s in subnets_that_need_routes
                                         if s not in subnets_of_preexisting_subnet_routes]
-        LOG.debug(f"{host}: Subnet of network {network.id} for which routes will be created: {subnets_to_create_routes_for}")
+        LOG.debug(f"{host}: Subnet of network {network.id} for which routes will be created: "
+                  f"{subnets_to_create_routes_for}")
 
         # make subnet route creation subflow
         ensure_subnet_routes_subflow = unordered_flow.Flow('ensure-subnet-routes-subflow')

--- a/octavia_f5/controller/worker/l2_sync_manager.py
+++ b/octavia_f5/controller/worker/l2_sync_manager.py
@@ -102,7 +102,7 @@ class L2SyncManager(BaseTaskFlowEngine):
             e.run()
 
     def _do_ensure_vcmp_l2_flow(self, store: dict):
-        e = self.taskflow_load(self._f5flows.ensure_vcmp_l2(), store=store)
+        e = self.taskflow_load(self._f5flows.make_ensure_vcmp_l2_flow(), store=store)
         with tf_logging.DynamicLoggingListener(e, log=LOG):
             e.run()
 
@@ -159,7 +159,7 @@ class L2SyncManager(BaseTaskFlowEngine):
             e.run()
 
     def _do_remove_vcmp_l2_flow(self, store: dict):
-        e = self.taskflow_load(self._f5flows.remove_vcmp_l2(), store=store)
+        e = self.taskflow_load(self._f5flows.make_remove_vcmp_l2_flow(), store=store)
         with tf_logging.DynamicLoggingListener(e, log=LOG):
             e.run()
 

--- a/octavia_f5/controller/worker/l2_sync_manager.py
+++ b/octavia_f5/controller/worker/l2_sync_manager.py
@@ -84,7 +84,20 @@ class L2SyncManager(BaseTaskFlowEngine):
             bigip.update_status()
 
     def _do_ensure_l2_flow(self, selfips: [network_models.Port], store: dict):
-        e = self.taskflow_load(self._f5flows.ensure_l2(selfips), store=store)
+
+        # get existing SelfIPs and subnet routes - they are needed to determine,
+        # which ones have to be created and which already exist
+        e = self.taskflow_load(self._f5flows.make_get_existing_selfips_and_subnet_routes_flow(), store=store)
+        with tf_logging.LoggingListener(e, log=LOG):
+            e.run()
+
+        # info about existing SelfIPs and subnet routes could be needed for either
+        # flow construction or in the tasks themselves, or both
+        store['existing_selfips'] = e.storage.get('get-existing-selfips')
+        store['existing_subnet_routes'] = e.storage.get('get-existing-subnet-routes')
+
+        ensure_l2_flow = self._f5flows.make_ensure_l2_flow(selfips, store=store)
+        e = self.taskflow_load(ensure_l2_flow, store=store)
         with tf_logging.DynamicLoggingListener(e, log=LOG):
             e.run()
 
@@ -94,41 +107,54 @@ class L2SyncManager(BaseTaskFlowEngine):
             e.run()
 
     def _do_remove_l2_flow(self, store: dict):
-        e = self.taskflow_load(self._f5flows.get_selfips_from_device_for_vlan(), store=store)
+
+        # get existing SelfIPs and subnet routes
+        e = self.taskflow_load(self._f5flows.make_get_existing_selfips_and_subnet_routes_flow(), store=store)
         with tf_logging.LoggingListener(e, log=LOG):
             e.run()
 
-        selfips = e.storage.get('all-selfips')
+        # info about existing SelfIPs and subnet routes could be needed for either
+        # flow construction or in the tasks themselves, or both
+        store['existing_selfips'] = e.storage.get('get-existing-selfips')
+        store['existing_subnet_routes'] = e.storage.get('get-existing-subnet-routes')
 
-        e = self.taskflow_load(self._f5flows.remove_l2(selfips), store=store)
+        remove_l2_flow = self._f5flows.make_remove_l2_flow(store=store)
+        e = self.taskflow_load(remove_l2_flow, store=store)
         with tf_logging.LoggingListener(e, log=LOG):
             e.run()
 
-    def _do_sync_l2_selfips_and_subnet_routes_flow(self, expected_selfips: [network_models.Port], store: dict):
+    def _do_sync_l2_selfips_and_subnet_routes_flow(self, needed_selfips: [network_models.Port], store: dict):
         """Remove unneeded SelfIPs and subnet routes, then add missing SelfIPs and subnet routes.
 
         If in another subnet of this network a load balancer is created or deleted, either a subnet route has to be
         replaced with a SelfIP or vice versa. Since SelfIPs and subnet routes conflict, deletion must always happen
         before creation."""
 
-        e = self.taskflow_load(self._f5flows.get_selfips_from_device_for_vlan(), store=store)
+        # get existing SelfIPs and subnet routes
+        e = self.taskflow_load(self._f5flows.make_get_existing_selfips_and_subnet_routes_flow(), store=store)
         with tf_logging.LoggingListener(e, log=LOG):
             e.run()
+        existing_selfips = e.storage.get('get-existing-selfips')
+        existing_subnet_routes = e.storage.get('get-existing-subnet-routes')
 
-        LOG.debug("%s: The expected SelfIPs for network %s are: %s",
-                  store['bigip'].hostname, store['network'].id, [sip.id for sip in expected_selfips])
+        # subnet routes that must exist (subnets with SelfIPs already have routes)
+        network = store['network']
+        subnets_that_need_routes = [subnet for subnet in network.subnets if
+                                    not f5_tasks.selfip_for_subnet_exists(subnet, needed_selfips)]
 
-        device_selfips = e.storage.get('all-selfips')
+        # log the current and desired state
+        hostname = store['bigip'].hostname
+        LOG.debug(f"{hostname}: The preexisting SelfIPs for network {network.id} are: {[sip.id for sip in existing_selfips]}")
+        LOG.debug(f"{hostname}: The expected SelfIPs for network {network.id} are: {[sip.id for sip in needed_selfips]}")
+        LOG.debug(f"{hostname}: The preexisting subnet routes for network {network.id} are: {[r['name'] for r in existing_subnet_routes]}")
+        LOG.debug(f"{hostname}: The expected subnet routes for network {network.id} are for these subnets: {subnets_that_need_routes}")
 
-        # remove unneeded SelfIPs/subnet routes
-        e = self.taskflow_load(self._f5flows.cleanup_selfips_and_subnet_routes(
-            expected_selfips, device_selfips, store=store), store=store)
-        with tf_logging.LoggingListener(e, log=LOG):
-            e.run()
-
-        # add missing SelfIPs/subnet routes
-        e = self.taskflow_load(self._f5flows.ensure_selfips_and_subnet_routes(
-            expected_selfips, device_selfips, store=store), store=store)
+        # get and run the sync flow
+        store['existing_selfips'] = existing_selfips
+        store['existing_subnet_routes'] = existing_subnet_routes
+        sync_flow = self._f5flows.make_sync_selfips_and_subnet_routes_flow(
+            needed_selfips, subnets_that_need_routes, store)
+        e = self.taskflow_load(sync_flow, store=store)
         with tf_logging.LoggingListener(e, log=LOG):
             e.run()
 
@@ -255,7 +281,7 @@ class L2SyncManager(BaseTaskFlowEngine):
             store = {'bigip': bigip, 'network': network}
             selfips_for_host = [selfip for selfip in selfips if bigip.hostname in selfip.name]
             fs[self.executor.submit(self._do_sync_l2_selfips_and_subnet_routes_flow,
-                                    expected_selfips=selfips_for_host, store=store)] = bigip
+                                    needed_selfips=selfips_for_host, store=store)] = bigip
 
         done, not_done = futures.wait(fs, timeout=10)
         for f in done | not_done:

--- a/octavia_f5/controller/worker/l2_sync_manager.py
+++ b/octavia_f5/controller/worker/l2_sync_manager.py
@@ -144,7 +144,7 @@ class L2SyncManager(BaseTaskFlowEngine):
 
         # log the current and desired state
         hostname = store['bigip'].hostname
-        LOG.debug(f"{hostname}: The preexisting SelfIPs for network {network.id} are: {[sip.id for sip in existing_selfips]}")
+        LOG.debug(f"{hostname}: The preexisting SelfIPs for network {network.id} are: {[sip['port_id'] for sip in existing_selfips]}")
         LOG.debug(f"{hostname}: The expected SelfIPs for network {network.id} are: {[sip.id for sip in needed_selfips]}")
         LOG.debug(f"{hostname}: The preexisting subnet routes for network {network.id} are: {[r['name'] for r in existing_subnet_routes]}")
         LOG.debug(f"{hostname}: The expected subnet routes for network {network.id} are for these subnets: {subnets_that_need_routes}")

--- a/octavia_f5/controller/worker/tasks/f5_tasks.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks.py
@@ -213,6 +213,26 @@ class EnsureSelfIP(task.Task):
         # No Changes needed
         return device_selfip
 
+    @decorators.RaisesIControlRestError()
+    def revert(self, port: network_models.Port,
+               bigip: bigip_restclient.BigIPRestClient,
+               existing_selfips, *args, **kwargs):
+        selfip_port_name = f"port-{port.id}"
+
+        # don't remove the SelfIP if it existed before this task was executed
+        if port.id in [p.id for p in existing_selfips]:
+            LOG.warning("Reverting EnsureSelfIP: Not deleting SelfIP, since it existed before the task was run: "
+                        f"{selfip_port_name}")
+            return
+
+        # delete SelfIP, ignoring 404
+        LOG.warning(f"Reverting EnsureSelfIP: Deleting SelfIP: {selfip_port_name}")
+        device_response = bigip.delete(path=f"/mgmt/tm/net/self/{selfip_port_name}")
+        if device_response.status_code == 404:
+            LOG.warning(f"Reverting EnsureSelfIP: SelfIP {selfip_port_name} was already removed")
+        else:
+            device_response.raise_for_status()
+
 
 class GetExistingSelfIPsForVLAN(task.Task):
     default_provides = 'existing_selfips'
@@ -335,6 +355,27 @@ class EnsureSubnetRoute(task.Task):
         # No changes needed
         return device_subnet_route
 
+    @decorators.RaisesIControlRestError()
+    def revert(self, bigip: bigip_restclient.BigIPRestClient,
+               network: f5_network_models.Network,
+               subnet_id, existing_subnet_routes,
+               *args, **kwargs):
+        subnet_route_name = get_subnet_route_name(network.id, subnet_id)
+
+        # Don't remove the route if it existed before this task was executed
+        if subnet_route_name in [r['name'] for r in existing_subnet_routes]:
+            LOG.warning("Reverting EnsureSubnetRoute: Not deleting route, since it existed before the task was run: "
+                        f"{subnet_route_name}")
+            return
+
+        # delete subnet route, ignoring 404
+        LOG.warning(f"Reverting EnsureSubnetRoute: Deleting subnet route: {subnet_route_name}")
+        device_response = bigip.delete(path=f"/mgmt/tm/net/route/~Common~{subnet_route_name}")
+        if device_response.status_code == 404:
+            LOG.warning(f"Reverting EnsureSubnetRoute: Subnet route {subnet_route_name} was already removed")
+        else:
+            device_response.raise_for_status()
+
 
 """ Removal Tasks """
 
@@ -377,6 +418,22 @@ class RemoveSubnetRoute(task.Task):
         else:
             res.raise_for_status()
 
+    @decorators.RaisesIControlRestError()
+    def revert(self, bigip: bigip_restclient.BigIPRestClient,
+               subnet_route, existing_subnet_routes,
+               *args, **kwargs):
+
+        # don't restore subnet route if it didn't exist before this task was executed
+        subnet_route_name = subnet_route['name']
+        if subnet_route_name not in [r['name'] for r in existing_subnet_routes]:
+            LOG.warning("Reverting RemoveSubnetRoute: Not restoring subnet route since it existed before the task "
+                        f"was run: {subnet_route_name}")
+            return
+
+        LOG.warning(f"Reverting RemoveSubnetRoute: Restoring subnet route: {subnet_route_name}")
+        res = bigip.post(path='/mgmt/tm/net/route', json=subnet_route)
+        res.raise_for_status()
+
 
 class RemoveSelfIP(task.Task):
 
@@ -390,6 +447,30 @@ class RemoveSelfIP(task.Task):
             LOG.warning(f"SelfIP port-{port.id} was already removed")
         else:
             res.raise_for_status()
+
+    @decorators.RaisesIControlRestError()
+    def revert(self, port: network_models.Port,
+               bigip: bigip_restclient.BigIPRestClient,
+               existing_selfips: [network_models.Port],
+               network, *args, **kwargs):
+
+        # don't restore SelfIP if it didn't exist before this task was executed
+        if port.id not in [p.id for p in existing_selfips]:
+            LOG.warning("Reverting RemoveSelfIP: Not restoring SelfIP since it existed before the task "
+                        f"was run: port-{port.id}")
+            return
+
+        network_driver = driver_utils.get_network_driver()
+        name = f"port-{port.id}"
+        vlan = f"/Common/vlan-{network.vlan_id}"
+        subnet = network_driver.get_subnet(port.fixed_ips[0].subnet_id)
+        ipnetwork = IPNetwork(subnet.cidr)
+        address = f"{port.fixed_ips[0].ip_address}%{network.vlan_id}/{ipnetwork.prefixlen}"
+        selfip = {'name': name, 'vlan': vlan, 'address': address}
+
+        LOG.warning(f"Reverting RemoveSelfIP: Restoring SelfIP: port-{port.id}")
+        res = bigip.post(path=f"/mgmt/tm/net/self/", json=selfip)
+        res.raise_for_status()
 
 
 class RemoveRouteDomain(task.Task):

--- a/octavia_f5/controller/worker/tasks/f5_tasks.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks.py
@@ -417,7 +417,8 @@ class RemoveSubnetRoute(task.Task):
 
     @decorators.RaisesIControlRestError()
     def execute(self, bigip: bigip_restclient.BigIPRestClient,
-                subnet_route_name):
+                subnet_route):
+        subnet_route_name = subnet_route['name']
         res = bigip.delete(path=f"/mgmt/tm/net/route/~Common~{subnet_route_name}")
 
         if res.status_code == 404:
@@ -427,8 +428,9 @@ class RemoveSubnetRoute(task.Task):
 
     @decorators.RaisesIControlRestError()
     def revert(self, bigip: bigip_restclient.BigIPRestClient,
-               subnet_route_name, existing_subnet_routes, network,
+               subnet_route, existing_subnet_routes, network,
                *args, **kwargs):
+        subnet_route_name = subnet_route['name']
 
         # don't restore subnet route if it didn't exist before this task was executed
         if subnet_route_name not in [r['name'] for r in existing_subnet_routes]:
@@ -436,18 +438,12 @@ class RemoveSubnetRoute(task.Task):
                         f"was run: {subnet_route_name}")
             return
 
-        # payload
-        network_driver = driver_utils.get_network_driver()
-        subnet_id = subnet_route_name.split('_')[-1]
-        subnet = network_driver.get_subnet(subnet_id)
-        subnet_cidr = IPNetwork(subnet.cidr)
-        vlan = f"/Common/vlan-{network.vlan_id}"
-        net = f"{subnet_cidr.ip}%{network.vlan_id}/{subnet_cidr.prefixlen}"
-        subnet_route = {'name': subnet_route_name, 'tmInterface': vlan, 'network': net}
-
         # restore subnet route
+        payload = {'name': subnet_route_name,
+                   'tmInterface': subnet_route['tmInterface'],
+                   'network': subnet_route['network']}
         LOG.warning(f"Reverting RemoveSubnetRoute: Restoring subnet route: {subnet_route_name}")
-        res = bigip.post(path='/mgmt/tm/net/route', json=subnet_route)
+        res = bigip.post(path='/mgmt/tm/net/route', json=payload)
         res.raise_for_status()
 
 

--- a/octavia_f5/controller/worker/tasks/f5_tasks.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks.py
@@ -438,6 +438,12 @@ class RemoveSubnetRoute(task.Task):
                         f"was run: {subnet_route_name}")
             return
 
+        # don't restore subnet route if it wasn't removed
+        res = bigip.get(path=f"/mgmt/tm/net/route/~Common~{subnet_route_name}")
+        if res.status_code != 404:
+            LOG.warning(f"Reverting RemoveSubnetRoute: Subnet route {subnet_route_name} was not removed, no need to restore")
+            return
+
         # restore subnet route
         payload = {'name': subnet_route_name,
                    'tmInterface': subnet_route['tmInterface'],
@@ -466,6 +472,12 @@ class RemoveSelfIP(task.Task):
         if selfip['name'] not in [sip['name'] for sip in existing_selfips]:
             LOG.warning("Reverting RemoveSelfIP: Not restoring SelfIP since it didn't exist before the task "
                         f"was run: {selfip['name']}")
+            return
+
+        # don't restore SelfIP if it wasn't removed
+        res = bigip.get(path=f"/mgmt/tm/net/self/{selfip['port_id']}")
+        if res.status_code != 404:
+            LOG.warning(f"Reverting RemoveSelfIP: SelfIP {selfip['name']} was not removed, no need to restore")
             return
 
         # restore SelfIP

--- a/octavia_f5/controller/worker/tasks/f5_tasks.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks.py
@@ -419,16 +419,25 @@ class RemoveSubnetRoute(task.Task):
 
     @decorators.RaisesIControlRestError()
     def revert(self, bigip: bigip_restclient.BigIPRestClient,
-               subnet_route, existing_subnet_routes,
+               subnet_route_name, existing_subnet_routes, network,
                *args, **kwargs):
 
         # don't restore subnet route if it didn't exist before this task was executed
-        subnet_route_name = subnet_route['name']
         if subnet_route_name not in [r['name'] for r in existing_subnet_routes]:
             LOG.warning("Reverting RemoveSubnetRoute: Not restoring subnet route since it existed before the task "
                         f"was run: {subnet_route_name}")
             return
 
+        # payload
+        network_driver = driver_utils.get_network_driver()
+        subnet_id = subnet_route_name.split('_')[-1]
+        subnet = network_driver.get_subnet(subnet_id)
+        subnet_cidr = IPNetwork(subnet.cidr)
+        vlan = f"/Common/vlan-{network.vlan_id}"
+        net = f"{subnet_cidr.ip}%{network.vlan_id}/{subnet_cidr.prefixlen}"
+        subnet_route = {'name': subnet_route_name, 'tmInterface': vlan, 'network': net}
+
+        # restore subnet route
         LOG.warning(f"Reverting RemoveSubnetRoute: Restoring subnet route: {subnet_route_name}")
         res = bigip.post(path='/mgmt/tm/net/route', json=subnet_route)
         res.raise_for_status()

--- a/octavia_f5/controller/worker/tasks/f5_tasks.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks.py
@@ -244,7 +244,7 @@ class GetExistingSelfIPsForVLAN(task.Task):
                 network: f5_network_models.Network):
 
         # get items
-        device_response = bigip.get(path='/mgmt/tm/net/self?$select=vlan,name')
+        device_response = bigip.get(path='/mgmt/tm/net/self?$select=vlan,name,address')
         device_response.raise_for_status()
         items = device_response.json().get('items', [])
 

--- a/octavia_f5/controller/worker/tasks/f5_tasks.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks.py
@@ -186,14 +186,16 @@ class EnsureSelfIP(task.Task):
                 port: network_models.Port,
                 bigip: bigip_restclient.BigIPRestClient):
 
-        network_driver = driver_utils.get_network_driver()
+        # payload
         name = f"port-{port.id}"
         vlan = f"/Common/vlan-{network.vlan_id}"
+        network_driver = driver_utils.get_network_driver()
         subnet = network_driver.get_subnet(port.fixed_ips[0].subnet_id)
-        ipnetwork = IPNetwork(subnet.cidr)
-        address = f"{port.fixed_ips[0].ip_address}%{network.vlan_id}/{ipnetwork.prefixlen}"
+        subnet_cidr = IPNetwork(subnet.cidr)
+        address = f"{port.fixed_ips[0].ip_address}%{network.vlan_id}/{subnet_cidr.prefixlen}"
         selfip = {'name': name, 'vlan': vlan, 'address': address}
 
+        # Check whether SelfIP already exists
         device_response = bigip.get(path=f"/mgmt/tm/net/self/{name}")
 
         # Create selfip if not existing
@@ -329,26 +331,29 @@ class EnsureSubnetRoute(task.Task):
         if CONF.networking.route_on_active and not bigip.is_active:
             return
 
-        # common prefix for subnet routes of this network
+        # payload
+        route_name = get_subnet_route_name(network.id, subnet_id)
         network_driver = driver_utils.get_network_driver()
-        cidr = IPNetwork(network_driver.get_subnet(subnet_id).cidr)
-        name = get_subnet_route_name(network.id, subnet_id)
+        subnet = network_driver.get_subnet(subnet_id)
+        subnet_cidr = IPNetwork(subnet.cidr)
         vlan = f"/Common/vlan-{network.vlan_id}"
-        net = f"{cidr.ip}%{network.vlan_id}/{cidr.prefixlen}"
-        route = {'name': name, 'tmInterface': vlan, 'network': net}
+        net = f"{subnet_cidr.ip}%{network.vlan_id}/{subnet_cidr.prefixlen}"
+        subnet_route = {'name': route_name, 'tmInterface': vlan, 'network': net}
 
-        device_response = bigip.get(path=f"/mgmt/tm/net/route/~Common~{name}")
+        # Check whether subnet route already exists
+        device_response = bigip.get(path=f"/mgmt/tm/net/route/~Common~{route_name}")
 
         # Create subnet route if not existing
         if device_response.status_code == 404:
-            res = bigip.post(path='/mgmt/tm/net/route', json=route)
+            res = bigip.post(path='/mgmt/tm/net/route', json=subnet_route)
             res.raise_for_status()
             return res.json()
 
         # Otherwise update existing subnet route (if our route isn't a subset)
         device_subnet_route = device_response.json()
-        if not route.items() <= device_subnet_route.items():
-            res = bigip.patch(path=f"/mgmt/tm/net/route/~Common~{name}", json=route)
+        if not subnet_route.items() <= device_subnet_route.items():
+            res = bigip.patch(path=f"/mgmt/tm/net/route/~Common~{route_name}",
+                              json=subnet_route)
             res.raise_for_status()
             return res.json()
 
@@ -468,14 +473,16 @@ class RemoveSelfIP(task.Task):
                         f"was run: port-{port.id}")
             return
 
+        # payload
         network_driver = driver_utils.get_network_driver()
         name = f"port-{port.id}"
         vlan = f"/Common/vlan-{network.vlan_id}"
         subnet = network_driver.get_subnet(port.fixed_ips[0].subnet_id)
-        ipnetwork = IPNetwork(subnet.cidr)
-        address = f"{port.fixed_ips[0].ip_address}%{network.vlan_id}/{ipnetwork.prefixlen}"
+        subnet_cidr = IPNetwork(subnet.cidr)
+        address = f"{port.fixed_ips[0].ip_address}%{network.vlan_id}/{subnet_cidr.prefixlen}"
         selfip = {'name': name, 'vlan': vlan, 'address': address}
 
+        # restore SelfIP
         LOG.warning(f"Reverting RemoveSelfIP: Restoring SelfIP: port-{port.id}")
         res = bigip.post(path=f"/mgmt/tm/net/self/", json=selfip)
         res.raise_for_status()

--- a/octavia_f5/controller/worker/tasks/f5_tasks.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks.py
@@ -28,10 +28,10 @@ LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
 
 
-def subnet_in_selfips(subnet, selfips):
+def selfip_for_subnet_exists(subnet_id, selfips):
     for selfip in selfips:
         for fixed_ip in selfip.fixed_ips:
-            if fixed_ip.subnet_id == subnet:
+            if fixed_ip.subnet_id == subnet_id:
                 return True
     return False
 
@@ -53,8 +53,7 @@ class EnsureVLAN(task.Task):
     )
     def execute(self,
                 bigip: bigip_restclient.BigIPRestClient,
-                network: f5_network_models.Network,
-                *args, **kwargs):
+                network: f5_network_models.Network):
 
         vlan = {
             'name': f'vlan-{network.vlan_id}',
@@ -89,8 +88,7 @@ class EnsureVLANInterface(task.Task):
     @decorators.RaisesIControlRestError()
     def execute(self,
                 bigip: bigip_restclient.BigIPRestClient,
-                device_vlan: dict,
-                *args, **kwargs):
+                device_vlan: dict):
         network_driver = driver_utils.get_network_driver()
         interface = {
             'name': device_vlan['name'],
@@ -122,8 +120,7 @@ class EnsureGuestVLAN(task.Task):
     def execute(self,
                 bigip: bigip_restclient.BigIPRestClient,
                 bigip_guest_names: [str],
-                device_vlan: dict,
-                *args, **kwargs):
+                device_vlan: dict):
 
         device_guest = None
         device_response = bigip.get(path='/mgmt/tm/vcmp/guest')
@@ -187,8 +184,7 @@ class EnsureSelfIP(task.Task):
     @decorators.RaisesIControlRestError()
     def execute(self, network: f5_network_models.Network,
                 port: network_models.Port,
-                bigip: bigip_restclient.BigIPRestClient,
-                *args, **kwargs):
+                bigip: bigip_restclient.BigIPRestClient):
 
         network_driver = driver_utils.get_network_driver()
         name = f"port-{port.id}"
@@ -206,7 +202,7 @@ class EnsureSelfIP(task.Task):
             res.raise_for_status()
             return res.json()
 
-        # Update if dict differs from on-device state
+        # Otherwise update existing subnet route (if our route isn't a subset)
         device_selfip = device_response.json()
         if not selfip.items() <= device_selfip.items():
             res = bigip.patch(path='/mgmt/tm/net/self/{}'.format(device_selfip['name']),
@@ -218,8 +214,8 @@ class EnsureSelfIP(task.Task):
         return device_selfip
 
 
-class GetAllSelfIPsForVLAN(task.Task):
-    default_provides = 'selfips'
+class GetExistingSelfIPsForVLAN(task.Task):
+    default_provides = 'existing_selfips'
 
     @staticmethod
     def _remove_port_prefix(name: str):
@@ -236,6 +232,22 @@ class GetAllSelfIPsForVLAN(task.Task):
                 for item in items
                 if item['vlan'] == vlan
                 and item['name'].startswith('port-')]
+
+
+class GetExistingSubnetRoutesForNetwork(task.Task):
+    default_provides = 'existing_subnet_routes'
+
+    @decorators.RaisesIControlRestError()
+    def execute(self, bigip: bigip_restclient.BigIPRestClient,
+                network: f5_network_models.Network):
+
+        # get all routes
+        response = bigip.get(path=f"/mgmt/tm/net/route").json()
+        routes = response.get('items', [])
+
+        # filter for only the subnet routes belonging to this network
+        subnet_route_network_part = get_subnet_route_name(network.id, '')
+        return [r for r in routes if r['name'].startswith(subnet_route_network_part)]
 
 
 class EnsureDefaultRoute(task.Task):
@@ -285,59 +297,49 @@ class EnsureDefaultRoute(task.Task):
         return device_route
 
 
-class EnsureSubnetRoutes(task.Task):
-    """ Task to create missing needed static subnet routes"""
+class EnsureSubnetRoute(task.Task):
+    """ Task to make sure a subnet route exists. """
 
     @decorators.RaisesIControlRestError()
     def execute(self, bigip: bigip_restclient.BigIPRestClient,
-                selfips: [network_models.Port],
-                network: f5_network_models.Network):
+                network: f5_network_models.Network,
+                subnet_id):
 
         # Skip passive device if route_on_active is enabled
         if CONF.networking.route_on_active and not bigip.is_active:
-            return None
-
-        # Fetch existing routes
-        response = bigip.get(path=f"/mgmt/tm/net/route?$filter=partition+eq+Common").json()
-        existing_routes = response.get('items', [])
-
-        # subnet routes that must exist (routes already exist for SelfIPs)
-        subnets_that_need_routes = [subnet for subnet in network.subnets if not subnet_in_selfips(subnet, selfips)]
+            return
 
         # common prefix for subnet routes of this network
-        subnet_route_network_part = get_subnet_route_name(network.id, '')
-
-        # delete existing subnet routes that aren't needed anymore - we'll only provision the missing ones
-        for existing_route in existing_routes:
-            existing_route_name = existing_route['name']
-
-            # ignore routes that are not subnet routes of this network
-            if not existing_route_name.startswith(subnet_route_network_part):
-                continue
-
-            existing_route_subnet = existing_route_name[len(subnet_route_network_part):]
-            if existing_route_subnet in subnets_that_need_routes:
-                # if the subnet route is a needed one there's no need to provision it again
-                subnets_that_need_routes.remove(existing_route_subnet)
-
-        # Add missing subnet routes
         network_driver = driver_utils.get_network_driver()
-        for subnet_id in subnets_that_need_routes:
-            cidr = IPNetwork(network_driver.get_subnet(subnet_id).cidr)
+        cidr = IPNetwork(network_driver.get_subnet(subnet_id).cidr)
+        name = get_subnet_route_name(network.id, subnet_id)
+        vlan = f"/Common/vlan-{network.vlan_id}"
+        net = f"{cidr.ip}%{network.vlan_id}/{cidr.prefixlen}"
+        route = {'name': name, 'tmInterface': vlan, 'network': net}
 
-            name = get_subnet_route_name(network.id, subnet_id)
-            vlan = f"/Common/vlan-{network.vlan_id}"
-            net = f"{cidr.ip}%{network.vlan_id}/{cidr.prefixlen}"
-            route = {'name': name, 'tmInterface': vlan, 'network': net}
+        device_response = bigip.get(path=f"/mgmt/tm/net/route/~Common~{name}")
 
+        # Create subnet route if not existing
+        if device_response.status_code == 404:
             res = bigip.post(path='/mgmt/tm/net/route', json=route)
             res.raise_for_status()
+            return res.json()
+
+        # Otherwise update existing subnet route (if our route isn't a subset)
+        device_subnet_route = device_response.json()
+        if not route.items() <= device_subnet_route.items():
+            res = bigip.patch(path=f"/mgmt/tm/net/route/~Common~{name}", json=route)
+            res.raise_for_status()
+            return res.json()
+
+        # No changes needed
+        return device_subnet_route
 
 
-""" Cleanup Tasks """
+""" Removal Tasks """
 
 
-class CleanupDefaultRoute(task.Task):
+class RemoveDefaultRoute(task.Task):
 
     @decorators.RaisesIControlRestError()
     def execute(self, network: f5_network_models.Network,
@@ -356,58 +358,41 @@ class CleanupDefaultRoute(task.Task):
                 break
 
         if res and not res.ok:
-            LOG.warning("%s: Failed cleanup Route for network_id=%s vlan=%s "
+            LOG.warning("%s: Failed removing route for network_id=%s vlan=%s "
                         "(could be already done by autosync): %s",
                         bigip.hostname, network.id, network.vlan_id, res.content)
 
 
-class CleanupSubnetRoutes(task.Task):
-    """Task to clean up static subnet routes. If the network is to be deleted, set delete_all=True.
-    Else only the unneeded subnet routes of this network are deleted."""
+class RemoveSubnetRoute(task.Task):
+    """Task to remove a static subnet route."""
 
     @decorators.RaisesIControlRestError()
     def execute(self, bigip: bigip_restclient.BigIPRestClient,
-                selfips: [network_models.Port],
-                network: f5_network_models.Network,
-                delete_all=False):
+                subnet_route, existing_subnet_routes):
+        route_name_name = subnet_route['name']
+        res = bigip.delete(path=f"/mgmt/tm/net/route/~Common~{route_name_name}")
 
-        subnets_that_need_routes = []
-        if not delete_all:
-            subnets_that_need_routes = [subnet for subnet in network.subnets if not subnet_in_selfips(subnet, selfips)]
-
-        # prefix of subnet routes that belong to this network
-        subnet_route_network_part = get_subnet_route_name(network.id, '')
-
-        # Fetch existing routes in the partition
-        response = bigip.get(path=f"/mgmt/tm/net/route").json()
-        existing_routes = response.get('items', [])
-
-        # delete routes from this network
-        for existing_route in existing_routes:
-            existing_route_name = existing_route['name']
-
-            # ignore routes that are not subnet routes of this network
-            if not existing_route_name.startswith(subnet_route_network_part):
-                continue
-
-            # delete subnet route if it's not needed
-            existing_route_subnet = existing_route_name[len(subnet_route_network_part):]
-            if existing_route_subnet not in subnets_that_need_routes:
-                res = bigip.delete(path=f"/mgmt/tm/net/route/~Common~{existing_route_name}")
-                res.raise_for_status()
+        if res.status_code == 404:
+            LOG.warning(f"Subnet route {route_name_name} was already removed")
+        else:
+            res.raise_for_status()
 
 
 class RemoveSelfIP(task.Task):
+
+    @decorators.RaisesIControlRestError()
     def execute(self, port: network_models.Port,
-                bigip: bigip_restclient.BigIPRestClient):
-        """ Task to delete SelfIP """
+                bigip: bigip_restclient.BigIPRestClient,
+                existing_selfips: [network_models.Port]):
         res = bigip.delete(path=f"/mgmt/tm/net/self/port-{port.id}")
-        if not res.ok:
-            LOG.warning("%s: Failed cleanup SelfIP %s: %s",
-                        port.id, bigip.hostname, res.content)
+
+        if res.status_code == 404:
+            LOG.warning(f"SelfIP port-{port.id} was already removed")
+        else:
+            res.raise_for_status()
 
 
-class CleanupRouteDomain(task.Task):
+class RemoveRouteDomain(task.Task):
     def execute(self, network: f5_network_models.Network,
                 bigip: bigip_restclient.BigIPRestClient):
 
@@ -424,18 +409,18 @@ class CleanupRouteDomain(task.Task):
                 break
 
         if res and not res.ok:
-            LOG.warning("%s: Failed cleanup RouteDomain for network_id=%s vlan_id=%s: %s",
+            LOG.warning("%s: Failed removing route domain for network_id=%s vlan_id=%s: %s",
                         bigip.hostname, network.id, network.vlan_id, res.content)
 
 
-class CleanupVLAN(task.Task):
+class RemoveVLAN(task.Task):
     def execute(self, network: f5_network_models.Network,
                 bigip: bigip_restclient.BigIPRestClient):
         """ Task to delete VLAN """
         name = f'vlan-{network.vlan_id}'
         res = bigip.delete(path=f"/mgmt/tm/net/vlan/~Common~{name}")
         if not res.ok:
-            LOG.warning("%s: Failed CleanupVLAN for vlan_id=%s: %s",
+            LOG.warning("%s: Failed removing VLAN for vlan_id=%s: %s",
                         bigip.hostname, network.vlan_id, res.content)
 
 
@@ -452,7 +437,7 @@ class GetVCMPGuests(task.Task):
         return device_response.json()['items']
 
 
-class CleanupVLANIfNotOwnedByGuest(task.Task):
+class RemoveVLANIfNotOwnedByGuest(task.Task):
     def execute(self, network: f5_network_models.Network,
                 bigip: bigip_restclient.BigIPRestClient,
                 bigip_guest_names: [str],
@@ -471,11 +456,11 @@ class CleanupVLANIfNotOwnedByGuest(task.Task):
 
         res = bigip.delete(path=f"/mgmt/tm/net/vlan/{name}")
         if not res.ok:
-            LOG.warning("%s: Failed CleanupVLANIfNotOwnedByGuest for vlan_id=%s: %s",
+            LOG.warning("%s: Failed RemoveVLANIfNotOwnedByGuest for vlan_id=%s: %s",
                         bigip.hostname, network.vlan_id, res.content)
 
 
-class CleanupGuestVLAN(task.Task):
+class RemoveGuestVLAN(task.Task):
     """ Removes vlan assignment of a VCMP Guest """
     @decorators.RaisesIControlRestError()
     def execute(self, network: f5_network_models.Network,
@@ -501,5 +486,5 @@ class CleanupGuestVLAN(task.Task):
                 path=f"/mgmt/tm/vcmp/guest/{guest['name']}",
                 json={'vlans': vlans})
             if not res.ok:
-                LOG.warning("%s: Failed CleanupGuestVLAN for vlan_id=%s: %s",
+                LOG.warning("%s: Failed removing guest VLAN for vlan_id=%s: %s",
                             bigip.hostname, network.vlan_id, res.content)

--- a/octavia_f5/controller/worker/tasks/f5_tasks.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks.py
@@ -182,9 +182,9 @@ class EnsureSelfIP(task.Task):
     """ Task to create or update Self-IP if needed """
 
     @decorators.RaisesIControlRestError()
-    def execute(self, network: f5_network_models.Network,
-                port: network_models.Port,
-                bigip: bigip_restclient.BigIPRestClient):
+    def execute(self, bigip: bigip_restclient.BigIPRestClient,
+                network: f5_network_models.Network,
+                port: network_models.Port):
 
         # payload
         name = f"port-{port.id}"
@@ -219,19 +219,19 @@ class EnsureSelfIP(task.Task):
     def revert(self, port: network_models.Port,
                bigip: bigip_restclient.BigIPRestClient,
                existing_selfips, *args, **kwargs):
-        selfip_port_name = f"port-{port.id}"
+        selfip_name = f"port-{port.id}"
 
         # don't remove the SelfIP if it existed before this task was executed
         if port.id in [p.id for p in existing_selfips]:
             LOG.warning("Reverting EnsureSelfIP: Not deleting SelfIP, since it existed before the task was run: "
-                        f"{selfip_port_name}")
+                        f"{selfip_name}")
             return
 
         # delete SelfIP, ignoring 404
-        LOG.warning(f"Reverting EnsureSelfIP: Deleting SelfIP: {selfip_port_name}")
-        device_response = bigip.delete(path=f"/mgmt/tm/net/self/{selfip_port_name}")
+        LOG.warning(f"Reverting EnsureSelfIP: Deleting SelfIP: {selfip_name}")
+        device_response = bigip.delete(path=f"/mgmt/tm/net/self/{selfip_name}")
         if device_response.status_code == 404:
-            LOG.warning(f"Reverting EnsureSelfIP: SelfIP {selfip_port_name} was already removed")
+            LOG.warning(f"Reverting EnsureSelfIP: SelfIP {selfip_name} was already removed")
         else:
             device_response.raise_for_status()
 
@@ -332,16 +332,16 @@ class EnsureSubnetRoute(task.Task):
             return
 
         # payload
-        route_name = get_subnet_route_name(network.id, subnet_id)
+        subnet_route_name = get_subnet_route_name(network.id, subnet_id)
         network_driver = driver_utils.get_network_driver()
         subnet = network_driver.get_subnet(subnet_id)
         subnet_cidr = IPNetwork(subnet.cidr)
         vlan = f"/Common/vlan-{network.vlan_id}"
         net = f"{subnet_cidr.ip}%{network.vlan_id}/{subnet_cidr.prefixlen}"
-        subnet_route = {'name': route_name, 'tmInterface': vlan, 'network': net}
+        subnet_route = {'name': subnet_route_name, 'tmInterface': vlan, 'network': net}
 
         # Check whether subnet route already exists
-        device_response = bigip.get(path=f"/mgmt/tm/net/route/~Common~{route_name}")
+        device_response = bigip.get(path=f"/mgmt/tm/net/route/~Common~{subnet_route_name}")
 
         # Create subnet route if not existing
         if device_response.status_code == 404:
@@ -352,7 +352,7 @@ class EnsureSubnetRoute(task.Task):
         # Otherwise update existing subnet route (if our route isn't a subset)
         device_subnet_route = device_response.json()
         if not subnet_route.items() <= device_subnet_route.items():
-            res = bigip.patch(path=f"/mgmt/tm/net/route/~Common~{route_name}",
+            res = bigip.patch(path=f"/mgmt/tm/net/route/~Common~{subnet_route_name}",
                               json=subnet_route)
             res.raise_for_status()
             return res.json()
@@ -414,7 +414,7 @@ class RemoveSubnetRoute(task.Task):
 
     @decorators.RaisesIControlRestError()
     def execute(self, bigip: bigip_restclient.BigIPRestClient,
-                subnet_route_name, existing_subnet_routes):
+                subnet_route_name):
         res = bigip.delete(path=f"/mgmt/tm/net/route/~Common~{subnet_route_name}")
 
         if res.status_code == 404:
@@ -429,7 +429,7 @@ class RemoveSubnetRoute(task.Task):
 
         # don't restore subnet route if it didn't exist before this task was executed
         if subnet_route_name not in [r['name'] for r in existing_subnet_routes]:
-            LOG.warning("Reverting RemoveSubnetRoute: Not restoring subnet route since it existed before the task "
+            LOG.warning("Reverting RemoveSubnetRoute: Not restoring subnet route since it didn't exist before the task "
                         f"was run: {subnet_route_name}")
             return
 
@@ -451,9 +451,8 @@ class RemoveSubnetRoute(task.Task):
 class RemoveSelfIP(task.Task):
 
     @decorators.RaisesIControlRestError()
-    def execute(self, port: network_models.Port,
-                bigip: bigip_restclient.BigIPRestClient,
-                existing_selfips: [network_models.Port]):
+    def execute(self, bigip: bigip_restclient.BigIPRestClient,
+                port: network_models.Port):
         res = bigip.delete(path=f"/mgmt/tm/net/self/port-{port.id}")
 
         if res.status_code == 404:
@@ -469,7 +468,7 @@ class RemoveSelfIP(task.Task):
 
         # don't restore SelfIP if it didn't exist before this task was executed
         if port.id not in [p.id for p in existing_selfips]:
-            LOG.warning("Reverting RemoveSelfIP: Not restoring SelfIP since it existed before the task "
+            LOG.warning("Reverting RemoveSelfIP: Not restoring SelfIP since it didn't exist before the task "
                         f"was run: port-{port.id}")
             return
 

--- a/octavia_f5/controller/worker/tasks/f5_tasks.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks.py
@@ -409,12 +409,11 @@ class RemoveSubnetRoute(task.Task):
 
     @decorators.RaisesIControlRestError()
     def execute(self, bigip: bigip_restclient.BigIPRestClient,
-                subnet_route, existing_subnet_routes):
-        route_name_name = subnet_route['name']
-        res = bigip.delete(path=f"/mgmt/tm/net/route/~Common~{route_name_name}")
+                subnet_route_name, existing_subnet_routes):
+        res = bigip.delete(path=f"/mgmt/tm/net/route/~Common~{subnet_route_name}")
 
         if res.status_code == 404:
-            LOG.warning(f"Subnet route {route_name_name} was already removed")
+            LOG.warning(f"Subnet route {subnet_route_name} was already removed")
         else:
             res.raise_for_status()
 

--- a/octavia_f5/controller/worker/tasks/f5_tasks.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks.py
@@ -204,7 +204,7 @@ class EnsureSelfIP(task.Task):
             res.raise_for_status()
             return res.json()
 
-        # Otherwise update existing subnet route (if our route isn't a subset)
+        # Otherwise update existing selfip (if our selfip isn't a subset)
         device_selfip = device_response.json()
         if not selfip.items() <= device_selfip.items():
             res = bigip.patch(path='/mgmt/tm/net/self/{}'.format(device_selfip['name']),

--- a/octavia_f5/controller/worker/tasks/f5_tasks.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks.py
@@ -222,7 +222,7 @@ class EnsureSelfIP(task.Task):
         selfip_name = f"port-{port.id}"
 
         # don't remove the SelfIP if it existed before this task was executed
-        if port.id in [p.id for p in existing_selfips]:
+        if port.id in [p['port_id'] for p in existing_selfips]:
             LOG.warning("Reverting EnsureSelfIP: Not deleting SelfIP, since it existed before the task was run: "
                         f"{selfip_name}")
             return
@@ -239,21 +239,24 @@ class EnsureSelfIP(task.Task):
 class GetExistingSelfIPsForVLAN(task.Task):
     default_provides = 'existing_selfips'
 
-    @staticmethod
-    def _remove_port_prefix(name: str):
-        return name[len('port-'):]
-
     @decorators.RaisesIControlRestError()
     def execute(self, bigip: bigip_restclient.BigIPRestClient,
                 network: f5_network_models.Network):
-        vlan = f"/Common/vlan-{network.vlan_id}"
+
+        # get items
         device_response = bigip.get(path='/mgmt/tm/net/self?$select=vlan,name')
         device_response.raise_for_status()
         items = device_response.json().get('items', [])
-        return [network_models.Port(id=self._remove_port_prefix(item['name']))
-                for item in items
-                if item['vlan'] == vlan
-                and item['name'].startswith('port-')]
+
+        # filter for VLAN
+        vlan = f"/Common/vlan-{network.vlan_id}"
+        items = [i for i in items if i['vlan'] == vlan and i['name'].startswith('port-')]
+
+        # we have to get the port ID oftentimes, so inject it for ease of use
+        for i in items:
+            i['port_id'] = i['name'][len('port-'):]
+
+        return items
 
 
 class GetExistingSubnetRoutesForNetwork(task.Task):
@@ -451,39 +454,28 @@ class RemoveSubnetRoute(task.Task):
 class RemoveSelfIP(task.Task):
 
     @decorators.RaisesIControlRestError()
-    def execute(self, bigip: bigip_restclient.BigIPRestClient,
-                port: network_models.Port):
-        res = bigip.delete(path=f"/mgmt/tm/net/self/port-{port.id}")
+    def execute(self, bigip: bigip_restclient.BigIPRestClient, selfip: dict):
+        res = bigip.delete(path=f"/mgmt/tm/net/self/port-{selfip['port_id']}")
 
         if res.status_code == 404:
-            LOG.warning(f"SelfIP port-{port.id} was already removed")
+            LOG.warning(f"SelfIP port-{selfip['port_id']} was already removed")
         else:
             res.raise_for_status()
 
     @decorators.RaisesIControlRestError()
-    def revert(self, port: network_models.Port,
-               bigip: bigip_restclient.BigIPRestClient,
-               existing_selfips: [network_models.Port],
-               network, *args, **kwargs):
+    def revert(self, bigip: bigip_restclient.BigIPRestClient,
+               selfip: dict, existing_selfips: [dict], *args, **kwargs):
 
         # don't restore SelfIP if it didn't exist before this task was executed
-        if port.id not in [p.id for p in existing_selfips]:
+        if selfip['name'] not in [sip['name'] for sip in existing_selfips]:
             LOG.warning("Reverting RemoveSelfIP: Not restoring SelfIP since it didn't exist before the task "
-                        f"was run: port-{port.id}")
+                        f"was run: {selfip['name']}")
             return
 
-        # payload
-        network_driver = driver_utils.get_network_driver()
-        name = f"port-{port.id}"
-        vlan = f"/Common/vlan-{network.vlan_id}"
-        subnet = network_driver.get_subnet(port.fixed_ips[0].subnet_id)
-        subnet_cidr = IPNetwork(subnet.cidr)
-        address = f"{port.fixed_ips[0].ip_address}%{network.vlan_id}/{subnet_cidr.prefixlen}"
-        selfip = {'name': name, 'vlan': vlan, 'address': address}
-
         # restore SelfIP
-        LOG.warning(f"Reverting RemoveSelfIP: Restoring SelfIP: port-{port.id}")
-        res = bigip.post(path=f"/mgmt/tm/net/self/", json=selfip)
+        payload = {'name': selfip['name'], 'vlan': selfip['vlan'], 'address': selfip['address']}
+        LOG.warning(f"Reverting RemoveSelfIP: Restoring SelfIP: {selfip['name']}")
+        res = bigip.post(path=f"/mgmt/tm/net/self/", json=payload)
         res.raise_for_status()
 
 

--- a/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
+++ b/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
@@ -341,6 +341,62 @@ class TestF5Flows(base.TestCase):
             path=f"/mgmt/tm/net/route/~Common~{subnet_route['name']}"
         )
 
+    @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
+                ".get_subnet")
+    def test_replace_selfip_with_subnet_route(self, mock_get_subnet):
+        """Test the flow returned by make_sync_selfips_and_subnet_routes_flow
+        to replace SelfIP with subnet route"""
+
+        # network with one subnet without LB, but a SelfIP, and no routes
+        mock_network_id = 'test-network-id'
+        mock_subnet_id = 'test-subnet-id'
+        mock_get_subnet.return_value = network_models.Subnet(
+            id=mock_subnet_id, gateway_ip='1.2.3.1',
+            cidr='1.2.3.0/24', network_id=mock_network_id)
+        mock_network = f5_network_models.Network(
+            mtu=9000, id=mock_network_id, subnets=[mock_subnet_id],
+            segments=[{'provider:physical_network': 'physnet',
+                       'provider:segmentation_id': 1234}]
+        )
+
+        # SelfIP port
+        selfip_fixed_ip = network_models.FixedIP(
+            ip_address='1.2.3.2', subnet_id=mock_subnet_id)
+        selfip_port = network_models.Port(
+            id='test-selfip-port-id', fixed_ips=[selfip_fixed_ip],
+        )
+
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip.get.return_value = empty_response()
+
+        store = {'network': mock_network,
+                 'bigip': mock_bigip,
+                 'existing_selfips': [selfip_port],
+                 'existing_subnet_routes': []}
+        needed_selfips = []
+        subnets_that_need_routes = [mock_subnet_id]
+        f5flows = f5_flows.F5Flows()
+        sync_selfips_and_subnet_routes_flow = f5flows.make_sync_selfips_and_subnet_routes_flow(
+            needed_selfips, subnets_that_need_routes, store=store)
+        engines.run(sync_selfips_and_subnet_routes_flow, store=store)
+
+        # Check that SelfIP got deleted
+        mock_bigip.delete.assert_called_with(
+            path=f"/mgmt/tm/net/self/port-{selfip_port.id}"
+        )
+
+        # Check that subnet route got created
+        mock_bigip.get.assert_called_with(
+            path=f"/mgmt/tm/net/route/~Common~net_{mock_network_id}_sub_{mock_subnet_id}"
+        )
+        mock_bigip.post.assert_called_with(
+            path=f"/mgmt/tm/net/route",
+            json={'name': f'net_{mock_network_id}_sub_{mock_subnet_id}',
+                  'tmInterface': '/Common/vlan-1234',
+                  'network': '1.2.3.0%1234/24'}
+        )
+        mock_bigip.patch.assert_not_called()
+
     def test_ensure_vcmp_l2_flow(self):
         """Check that the ensure_vcmp_l2_flow flow correctly configures the VLAN"""
 

--- a/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
+++ b/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
@@ -89,8 +89,10 @@ class TestF5Flows(base.TestCase):
 
         store = {'network': mock_network,
                  'bigip': mock_bigip,
-                 'subnet_id': selfip_fixed_ip.subnet_id}
-        ensure_l2_flow = f5flows.make_ensure_l2_flow([selfip_port], store=store)
+                 'subnet_id': selfip_fixed_ip.subnet_id,
+                 'existing_selfips': []}
+        needed_selfips = [selfip_port]
+        ensure_l2_flow = f5flows.make_ensure_l2_flow(needed_selfips, store=store)
         engines.run(ensure_l2_flow, store=store)
 
         # check that VLAN, RD, SelfIP, and default route have been created
@@ -167,8 +169,10 @@ class TestF5Flows(base.TestCase):
 
         store = {'network': mock_network,
                  'bigip': mock_bigip,
-                 'subnet_id': selfip_fixed_ip.subnet_id}
-        ensure_l2_flow = f5flows.make_ensure_l2_flow([selfip_port], store=store)
+                 'subnet_id': selfip_fixed_ip.subnet_id,
+                 'existing_selfips': []}
+        needed_selfips = [selfip_port]
+        ensure_l2_flow = f5flows.make_ensure_l2_flow(needed_selfips, store=store)
         engines.run(ensure_l2_flow, store=store)
 
         mock_bigip.get.assert_called()

--- a/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
+++ b/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
@@ -66,16 +66,21 @@ class TestF5Flows(base.TestCase):
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")
     def test_ensure_l2_flow(self, mock_get_subnet):
+        """Check that the ensure_l2 flow creates VLAN, RD, SelfIP, and default route"""
+
+        # mock network with one subnet
+        mock_network_id = 'test-network-id'
+        mock_subnet_id = 'test-subnet-id'
         mock_get_subnet.return_value = network_models.Subnet(
-            id='test-subnet-id', gateway_ip='1.2.3.1',
-            cidr='1.2.3.0/24', network_id='test-network-id')
+            id=mock_subnet_id, gateway_ip='1.2.3.1',
+            cidr='1.2.3.0/24', network_id=mock_network_id)
         mock_network = f5_network_models.Network(
-            mtu=9000, id='test-network-id', subnets=['test-subnet-id'],
+            mtu=9000, id=mock_network_id, subnets=[mock_subnet_id],
             segments=[{'provider:physical_network': 'physnet',
                        'provider:segmentation_id': 1234}]
         )
         selfip_fixed_ip = network_models.FixedIP(
-            ip_address='1.2.3.2', subnet_id='test-subnet-id')
+            ip_address='1.2.3.2', subnet_id=mock_subnet_id)
         selfip_port = network_models.Port(
             id='test-selfip-port-id', fixed_ips=[selfip_fixed_ip],
         )
@@ -84,12 +89,12 @@ class TestF5Flows(base.TestCase):
         mock_bigip.get.side_effect = [empty_response(), empty_response(),
                                       empty_response(), empty_response(),
                                       empty_response(), empty_response(),
-                                      MockResponse({'items':[]}, status_code=200)]
+                                      MockResponse({'items': []}, status_code=200)]
         f5flows = f5_flows.F5Flows()
 
         store = {'network': mock_network,
                  'bigip': mock_bigip,
-                 'subnet_id': selfip_fixed_ip.subnet_id,
+                 'subnet_id': mock_subnet_id,
                  'existing_selfips': []}
         needed_selfips = [selfip_port]
         ensure_l2_flow = f5flows.make_ensure_l2_flow(needed_selfips, store=store)
@@ -120,16 +125,20 @@ class TestF5Flows(base.TestCase):
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")
     def test_ensure_l2_flow_existing_l2(self, mock_get_subnet):
+        """Check that the ensure_l2 flow works when VLAN, RD, and default route already exist"""
+
+        mock_network_id = 'test-network-id'
+        mock_subnet_id = 'test-subnet-id'
         mock_get_subnet.return_value = network_models.Subnet(
-            id='test-subnet-id', gateway_ip='1.2.3.1',
-            cidr='1.2.3.0/24', network_id='test-network-id')
+            id=mock_subnet_id, gateway_ip='1.2.3.1',
+            cidr='1.2.3.0/24', network_id=mock_network_id)
         mock_network = f5_network_models.Network(
-            mtu=9000, id='test-network-id', subnets=['test-subnet-id'],
+            mtu=9000, id=mock_network_id, subnets=[mock_subnet_id],
             segments=[{'provider:physical_network': 'physnet',
                        'provider:segmentation_id': 1234}]
         )
         selfip_fixed_ip = network_models.FixedIP(
-            ip_address='1.2.3.2', subnet_id='test-subnet-id')
+            ip_address='1.2.3.2', subnet_id=mock_subnet_id)
         selfip_port = network_models.Port(
             id='test-selfip-port-id', fixed_ips=[selfip_fixed_ip],
         )
@@ -164,12 +173,12 @@ class TestF5Flows(base.TestCase):
                                       mock_routedomain_response,
                                       mock_selfip_response,
                                       mock_route_response,
-                                      MockResponse({'items':[]}, status_code=200)]
+                                      MockResponse({'items': []}, status_code=200)]
         f5flows = f5_flows.F5Flows()
 
         store = {'network': mock_network,
                  'bigip': mock_bigip,
-                 'subnet_id': selfip_fixed_ip.subnet_id,
+                 'subnet_id': mock_subnet_id,
                  'existing_selfips': []}
         needed_selfips = [selfip_port]
         ensure_l2_flow = f5flows.make_ensure_l2_flow(needed_selfips, store=store)
@@ -180,8 +189,12 @@ class TestF5Flows(base.TestCase):
         mock_bigip.post.assert_not_called()
 
     def test_ensure_vcmp_l2_flow(self):
+        """Check that the ensure_vcmp_l2_flow flow correctly configures the VLAN"""
+
+        mock_network_id = 'test-network-id'
+        mock_subnet_id = 'test-subnet-id'
         mock_network = f5_network_models.Network(
-            mtu=9000, id='test-network-id', subnets=['test-subnet-id'],
+            mtu=9000, id=mock_network_id, subnets=[mock_subnet_id],
             segments=[{'provider:physical_network': 'physnet',
                        'provider:segmentation_id': 1234}]
         )
@@ -204,10 +217,11 @@ class TestF5Flows(base.TestCase):
         mock_vcmp.patch.side_effect = empty_response
         f5flows = f5_flows.F5Flows()
 
-        engines.run(f5flows.make_ensure_vcmp_l2_flow(),
-                    store={'network': mock_network,
-                           'bigip': mock_vcmp,
-                           'bigip_guest_names': ['test-host-1']})
+        store = {'network': mock_network,
+                 'bigip': mock_vcmp,
+                 'bigip_guest_names': ['test-host-1']}
+        ensure_vcmp_l2_flow = f5flows.make_ensure_vcmp_l2_flow()
+        engines.run(ensure_vcmp_l2_flow, store=store)
 
         get_calls = [
             mock.call(path='/mgmt/tm/net/vlan/~Common~vlan-1234?expandSubcollections=true'),
@@ -232,8 +246,12 @@ class TestF5Flows(base.TestCase):
         )
 
     def test_remove_vcmp_l2_flow(self):
+        """Check correct L2 configuration on L2 removal"""
+
+        mock_network_id = 'test-network-id'
+        mock_subnet_id = 'test-subnet-id'
         mock_network = f5_network_models.Network(
-            mtu=9000, id='test-network-id', subnets=['test-subnet-id'],
+            mtu=9000, id=mock_network_id, subnets=[mock_subnet_id],
             segments=[{'provider:physical_network': 'physnet',
                        'provider:segmentation_id': 1234}]
         )
@@ -250,10 +268,11 @@ class TestF5Flows(base.TestCase):
         mock_vcmp.get.side_effect = [mock_guests_response]
         f5flows = f5_flows.F5Flows()
 
-        engines.run(f5flows.make_remove_vcmp_l2_flow(),
-                    store={'network': mock_network,
-                           'bigip': mock_vcmp,
-                           'bigip_guest_names': ['test-host-1']})
+        store = {'network': mock_network,
+                 'bigip': mock_vcmp,
+                 'bigip_guest_names': ['test-host-1']}
+        remove_vcmp_l2_flow = f5flows.make_remove_vcmp_l2_flow()
+        engines.run(remove_vcmp_l2_flow, store=store)
 
         mock_vcmp.get.assert_called_with(path='/mgmt/tm/vcmp/guest')
         mock_vcmp.delete.assert_called_with(path='/mgmt/tm/net/vlan/vlan-1234')
@@ -261,8 +280,12 @@ class TestF5Flows(base.TestCase):
                                            path='/mgmt/tm/vcmp/guest/test-host-1')
 
     def test_remove_vcmp_l2_flow_vlan_in_use(self):
+        """Check that the remove_vcmp_l2_flow does not delete a VLAN in use by another guest"""
+
+        mock_network_id = 'test-network-id'
+        mock_subnet_id = 'test-subnet-id'
         mock_network = f5_network_models.Network(
-            mtu=9000, id='test-network-id', subnets=['test-subnet-id'],
+            mtu=9000, id=mock_network_id, subnets=[mock_subnet_id],
             segments=[{'provider:physical_network': 'physnet',
                        'provider:segmentation_id': 1234}]
         )
@@ -277,10 +300,11 @@ class TestF5Flows(base.TestCase):
         mock_vcmp.get.side_effect = [mock_guests_response]
         f5flows = f5_flows.F5Flows()
 
-        engines.run(f5flows.make_remove_vcmp_l2_flow(),
-                    store={'network': mock_network,
-                           'bigip': mock_vcmp,
-                           'bigip_guest_names': ['test-host-1']})
+        remove_vcmp_l2_flow = f5flows.make_remove_vcmp_l2_flow()
+        store = {'network': mock_network,
+                 'bigip': mock_vcmp,
+                 'bigip_guest_names': ['test-host-1']}
+        engines.run(remove_vcmp_l2_flow, store=store)
 
         mock_vcmp.get.assert_called_with(path='/mgmt/tm/vcmp/guest')
         mock_vcmp.delete.assert_not_called()

--- a/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
+++ b/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
@@ -397,6 +397,65 @@ class TestF5Flows(base.TestCase):
         )
         mock_bigip.patch.assert_not_called()
 
+    @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
+                ".get_subnet")
+    def test_replace_subnet_route_with_selfip(self, mock_get_subnet):
+        """Test the flow returned by make_sync_selfips_and_subnet_routes_flow
+        to replace subnet route with SelfIP"""
+
+        # network with one subnet with LB, but no SelfIP, and a route
+        mock_network_id = 'test-network-id'
+        mock_subnet_id = 'test-subnet-id'
+        mock_get_subnet.return_value = network_models.Subnet(
+            id=mock_subnet_id, gateway_ip='1.2.3.1',
+            cidr='1.2.3.0/24', network_id=mock_network_id)
+        mock_network = f5_network_models.Network(
+            mtu=9000, id=mock_network_id, subnets=[mock_subnet_id],
+            segments=[{'provider:physical_network': 'physnet',
+                       'provider:segmentation_id': 1234}]
+        )
+
+        # SelfIP port
+        selfip_fixed_ip = network_models.FixedIP(
+            ip_address='1.2.3.2', subnet_id=mock_subnet_id)
+        selfip_port = network_models.Port(
+            id='test-selfip-port-id', fixed_ips=[selfip_fixed_ip],
+        )
+
+        # subnet route
+        subnet_route = {'name': f'net_{mock_network_id}_sub_{mock_subnet_id}'}
+
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip.get.return_value = empty_response()
+
+        store = {'network': mock_network,
+                 'bigip': mock_bigip,
+                 'existing_selfips': [],
+                 'existing_subnet_routes': [subnet_route]}
+        needed_selfips = [selfip_port]
+        subnets_that_need_routes = []
+        f5flows = f5_flows.F5Flows()
+        sync_selfips_and_subnet_routes_flow = f5flows.make_sync_selfips_and_subnet_routes_flow(
+            needed_selfips, subnets_that_need_routes, store=store)
+        engines.run(sync_selfips_and_subnet_routes_flow, store=store)
+
+        # Check that subnet route got deleted
+        mock_bigip.delete.assert_called_with(
+            path=f"/mgmt/tm/net/route/~Common~net_{mock_network_id}_sub_{mock_subnet_id}"
+        )
+
+        # Check that SelfIP got created
+        mock_bigip.get.assert_called_with(
+            path=f"/mgmt/tm/net/self/port-{selfip_port.id}"
+        )
+        mock_bigip.post.assert_called_with(
+            path=f"/mgmt/tm/net/self",
+            json={'name': f'port-{selfip_port.id}',
+                  'vlan': '/Common/vlan-1234',
+                  'address': '1.2.3.2%1234/24'}
+        )
+        mock_bigip.patch.assert_not_called()
+
     def test_ensure_vcmp_l2_flow(self):
         """Check that the ensure_vcmp_l2_flow flow correctly configures the VLAN"""
 

--- a/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
+++ b/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
@@ -65,7 +65,7 @@ class TestF5Flows(base.TestCase):
 
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")
-    def test_f5_flow_ensure_l2(self, mock_get_subnet):
+    def test_ensure_l2_flow(self, mock_get_subnet):
         mock_get_subnet.return_value = network_models.Subnet(
             id='test-subnet-id', gateway_ip='1.2.3.1',
             cidr='1.2.3.0/24', network_id='test-network-id')
@@ -119,7 +119,7 @@ class TestF5Flows(base.TestCase):
 
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")
-    def test_f5_flow_ensure_existing_l2(self, mock_get_subnet):
+    def test_ensure_l2_flow_existing_l2(self, mock_get_subnet):
         mock_get_subnet.return_value = network_models.Subnet(
             id='test-subnet-id', gateway_ip='1.2.3.1',
             cidr='1.2.3.0/24', network_id='test-network-id')
@@ -179,7 +179,7 @@ class TestF5Flows(base.TestCase):
         mock_bigip.patch.assert_not_called()
         mock_bigip.post.assert_not_called()
 
-    def test_f5_flow_ensure_vcmp_l2(self):
+    def test_ensure_vcmp_l2_flow(self):
         mock_network = f5_network_models.Network(
             mtu=9000, id='test-network-id', subnets=['test-subnet-id'],
             segments=[{'provider:physical_network': 'physnet',
@@ -204,7 +204,7 @@ class TestF5Flows(base.TestCase):
         mock_vcmp.patch.side_effect = empty_response
         f5flows = f5_flows.F5Flows()
 
-        engines.run(f5flows.ensure_vcmp_l2(),
+        engines.run(f5flows.make_ensure_vcmp_l2_flow(),
                     store={'network': mock_network,
                            'bigip': mock_vcmp,
                            'bigip_guest_names': ['test-host-1']})
@@ -231,7 +231,7 @@ class TestF5Flows(base.TestCase):
             path='/mgmt/tm/net/vlan'
         )
 
-    def test_f5_flow_remove_vcmp_l2(self):
+    def test_remove_vcmp_l2_flow(self):
         mock_network = f5_network_models.Network(
             mtu=9000, id='test-network-id', subnets=['test-subnet-id'],
             segments=[{'provider:physical_network': 'physnet',
@@ -250,7 +250,7 @@ class TestF5Flows(base.TestCase):
         mock_vcmp.get.side_effect = [mock_guests_response]
         f5flows = f5_flows.F5Flows()
 
-        engines.run(f5flows.remove_vcmp_l2(),
+        engines.run(f5flows.make_remove_vcmp_l2_flow(),
                     store={'network': mock_network,
                            'bigip': mock_vcmp,
                            'bigip_guest_names': ['test-host-1']})
@@ -260,7 +260,7 @@ class TestF5Flows(base.TestCase):
         mock_vcmp.patch.assert_called_with(json={'vlans': []},
                                            path='/mgmt/tm/vcmp/guest/test-host-1')
 
-    def test_f5_flow_remove_vcmp_l2_vlan_in_use(self):
+    def test_remove_vcmp_l2_flow_vlan_in_use(self):
         mock_network = f5_network_models.Network(
             mtu=9000, id='test-network-id', subnets=['test-subnet-id'],
             segments=[{'provider:physical_network': 'physnet',
@@ -277,7 +277,7 @@ class TestF5Flows(base.TestCase):
         mock_vcmp.get.side_effect = [mock_guests_response]
         f5flows = f5_flows.F5Flows()
 
-        engines.run(f5flows.remove_vcmp_l2(),
+        engines.run(f5flows.make_remove_vcmp_l2_flow(),
                     store={'network': mock_network,
                            'bigip': mock_vcmp,
                            'bigip_guest_names': ['test-host-1']})

--- a/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
+++ b/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
@@ -188,6 +188,54 @@ class TestF5Flows(base.TestCase):
         mock_bigip.patch.assert_not_called()
         mock_bigip.post.assert_not_called()
 
+    @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
+                ".get_subnet")
+    def test_ensure_selfip(self, mock_get_subnet):
+        """Test the flow returned by make_ensure_selfips_and_subnet_routes_flow
+        to create non-existent but needed SelfIP"""
+
+        # network with one subnet with an LB, no SelfIPs, and no routes
+        mock_network_id = 'test-network-id'
+        mock_subnet_id = 'test-subnet-id'
+        mock_get_subnet.return_value = network_models.Subnet(
+            id=mock_subnet_id, gateway_ip='1.2.3.1',
+            cidr='1.2.3.0/24', network_id=mock_network_id)
+        mock_network = f5_network_models.Network(
+            mtu=9000, id=mock_network_id, subnets=[mock_subnet_id],
+            segments=[{'provider:physical_network': 'physnet',
+                       'provider:segmentation_id': 1234}]
+        )
+
+        # SelfIP port
+        selfip_fixed_ip = network_models.FixedIP(
+            ip_address='1.2.3.2', subnet_id=mock_subnet_id)
+        selfip_port = network_models.Port(
+            id='test-selfip-port-id', fixed_ips=[selfip_fixed_ip],
+        )
+
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip.get.return_value = empty_response()
+
+        store = {'network': mock_network,
+                 'bigip': mock_bigip,
+                 'existing_selfips': [],
+                 'existing_subnet_routes': []}
+        needed_selfips = [selfip_port]
+        subnets_that_need_routes = []
+        f5flows = f5_flows.F5Flows()
+        ensure_selfips_and_subnet_routes_flow = f5flows.make_ensure_selfips_and_subnet_routes_flow(
+            needed_selfips, subnets_that_need_routes, store=store)
+        engines.run(ensure_selfips_and_subnet_routes_flow, store=store)
+
+        mock_bigip.get.assert_called()
+        mock_bigip.patch.assert_not_called()
+        mock_bigip.post.assert_called_with(
+            path=f"/mgmt/tm/net/self",
+            json={'name': f'port-{selfip_port.id}',
+                  'vlan': '/Common/vlan-1234',
+                  'address': '1.2.3.2%1234/24'}
+        )
+
     def test_ensure_vcmp_l2_flow(self):
         """Check that the ensure_vcmp_l2_flow flow correctly configures the VLAN"""
 

--- a/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
+++ b/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
@@ -276,6 +276,38 @@ class TestF5Flows(base.TestCase):
                   'network': '1.2.3.0%1234/24'}
         )
 
+    def test_remove_selfip(self):
+        """Test the flow returned by make_remove_selfips_and_subnet_routes_flow
+        to remove unneeded SelfIP"""
+
+        # network with one subnet supposedly deleted LB whose SelfIP still exists, and no routes
+        mock_network_id = 'test-network-id'
+        mock_network = f5_network_models.Network(id=mock_network_id)
+
+        # SelfIP port
+        selfip_port = network_models.Port(id='test-selfip-port-id')
+
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip.get.return_value = empty_response()
+
+        store = {'network': mock_network,
+                 'bigip': mock_bigip,
+                 'existing_selfips': [selfip_port],
+                 'existing_subnet_routes': []}
+        needed_selfips = []
+        subnets_that_need_routes = []
+        f5flows = f5_flows.F5Flows()
+        ensure_selfips_and_subnet_routes_flow = f5flows.make_remove_selfips_and_subnet_routes_flow(
+            needed_selfips, subnets_that_need_routes, store=store)
+        engines.run(ensure_selfips_and_subnet_routes_flow, store=store)
+
+        mock_bigip.get.assert_not_called()
+        mock_bigip.patch.assert_not_called()
+        mock_bigip.post.assert_not_called()
+        mock_bigip.delete.assert_called_with(
+            path=f"/mgmt/tm/net/self/port-{selfip_port.id}"
+        )
+
     def test_ensure_vcmp_l2_flow(self):
         """Check that the ensure_vcmp_l2_flow flow correctly configures the VLAN"""
 

--- a/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
+++ b/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
@@ -236,6 +236,46 @@ class TestF5Flows(base.TestCase):
                   'address': '1.2.3.2%1234/24'}
         )
 
+    @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
+                ".get_subnet")
+    def test_ensure_subnet_route(self, mock_get_subnet):
+        """Test the flow returned by make_ensure_selfips_and_subnet_routes_flow
+        to create non-existent but needed subnet route"""
+
+        mock_network_id = 'test-network-id'
+        mock_subnet_id = 'test-subnet-id'
+        mock_get_subnet.return_value = network_models.Subnet(
+            id=mock_subnet_id, gateway_ip='1.2.3.1',
+            cidr='1.2.3.0/24', network_id=mock_network_id)
+        mock_network = f5_network_models.Network(
+            mtu=9000, id=mock_network_id, subnets=[mock_subnet_id],
+            segments=[{'provider:physical_network': 'physnet',
+                       'provider:segmentation_id': 1234}]
+        )
+
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip.get.return_value = empty_response()
+
+        store = {'network': mock_network,
+                 'bigip': mock_bigip,
+                 'existing_selfips': [],
+                 'existing_subnet_routes': []}
+        needed_selfips = []
+        subnets_that_need_routes = [mock_subnet_id]
+        f5flows = f5_flows.F5Flows()
+        ensure_selfips_and_subnet_routes_flow = f5flows.make_ensure_selfips_and_subnet_routes_flow(
+            needed_selfips, subnets_that_need_routes, store=store)
+        engines.run(ensure_selfips_and_subnet_routes_flow, store=store)
+
+        mock_bigip.get.assert_called()
+        mock_bigip.patch.assert_not_called()
+        mock_bigip.post.assert_called_with(
+            path=f"/mgmt/tm/net/route",
+            json={'name': f'net_{mock_network_id}_sub_{mock_subnet_id}',
+                  'tmInterface': '/Common/vlan-1234',
+                  'network': '1.2.3.0%1234/24'}
+        )
+
     def test_ensure_vcmp_l2_flow(self):
         """Check that the ensure_vcmp_l2_flow flow correctly configures the VLAN"""
 

--- a/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
+++ b/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
@@ -308,6 +308,39 @@ class TestF5Flows(base.TestCase):
             path=f"/mgmt/tm/net/self/port-{selfip_port.id}"
         )
 
+    def test_remove_subnet_route(self):
+        """Test the flow returned by make_remove_selfips_and_subnet_routes_flow
+        to remove unneeded subnet route"""
+
+        # network with one subnet that has an unneeded subnet route
+        mock_network_id = 'test-network-id'
+        mock_subnet_id = 'test-subnet-id'
+        mock_network = f5_network_models.Network(id=mock_network_id)
+
+        # subnet route
+        subnet_route = {'name': f'net_{mock_network_id}_sub_{mock_subnet_id}'}
+
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip.get.return_value = empty_response()
+
+        store = {'network': mock_network,
+                 'bigip': mock_bigip,
+                 'existing_selfips': [],
+                 'existing_subnet_routes': [subnet_route]}
+        needed_selfips = []
+        subnets_that_need_routes = []
+        f5flows = f5_flows.F5Flows()
+        ensure_selfips_and_subnet_routes_flow = f5flows.make_remove_selfips_and_subnet_routes_flow(
+            needed_selfips, subnets_that_need_routes, store=store)
+        engines.run(ensure_selfips_and_subnet_routes_flow, store=store)
+
+        mock_bigip.get.assert_not_called()
+        mock_bigip.patch.assert_not_called()
+        mock_bigip.post.assert_not_called()
+        mock_bigip.delete.assert_called_with(
+            path=f"/mgmt/tm/net/route/~Common~{subnet_route['name']}"
+        )
+
     def test_ensure_vcmp_l2_flow(self):
         """Check that the ensure_vcmp_l2_flow flow correctly configures the VLAN"""
 

--- a/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
+++ b/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
@@ -87,11 +87,13 @@ class TestF5Flows(base.TestCase):
                                       MockResponse({'items':[]}, status_code=200)]
         f5flows = f5_flows.F5Flows()
 
-        engines.run(f5flows.ensure_l2([selfip_port]),
-                    store={'network': mock_network,
-                           'bigip': mock_bigip,
-                           'subnet_id': selfip_fixed_ip.subnet_id})
+        store = {'network': mock_network,
+                 'bigip': mock_bigip,
+                 'subnet_id': selfip_fixed_ip.subnet_id}
+        ensure_l2_flow = f5flows.make_ensure_l2_flow([selfip_port], store=store)
+        engines.run(ensure_l2_flow, store=store)
 
+        # check that VLAN, RD, SelfIP, and default route have been created
         calls = [
             mock.call(json={'name': 'vlan-1234', 'tag': 1234,
                             'mtu': 9000, 'hardwareSyncookie': 'enabled',
@@ -163,10 +165,11 @@ class TestF5Flows(base.TestCase):
                                       MockResponse({'items':[]}, status_code=200)]
         f5flows = f5_flows.F5Flows()
 
-        engines.run(f5flows.ensure_l2([selfip_port]),
-                    store={'network': mock_network,
-                           'bigip': mock_bigip,
-                           'subnet_id': selfip_fixed_ip.subnet_id})
+        store = {'network': mock_network,
+                 'bigip': mock_bigip,
+                 'subnet_id': selfip_fixed_ip.subnet_id}
+        ensure_l2_flow = f5flows.make_ensure_l2_flow([selfip_port], store=store)
+        engines.run(ensure_l2_flow, store=store)
 
         mock_bigip.get.assert_called()
         mock_bigip.patch.assert_not_called()

--- a/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
+++ b/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
@@ -292,7 +292,7 @@ class TestF5Flows(base.TestCase):
 
         store = {'network': mock_network,
                  'bigip': mock_bigip,
-                 'existing_selfips': [selfip_port],
+                 'existing_selfips': [{'name': f"port-{selfip_port.id}", 'port_id': selfip_port.id}],
                  'existing_subnet_routes': []}
         needed_selfips = []
         subnets_that_need_routes = []
@@ -371,7 +371,7 @@ class TestF5Flows(base.TestCase):
 
         store = {'network': mock_network,
                  'bigip': mock_bigip,
-                 'existing_selfips': [selfip_port],
+                 'existing_selfips': [{'name': f"port-{selfip_port.id}", 'port_id': selfip_port.id}],
                  'existing_subnet_routes': []}
         needed_selfips = []
         subnets_that_need_routes = [mock_subnet_id]

--- a/octavia_f5/tests/unit/controller/worker/tasks/test_f5_tasks.py
+++ b/octavia_f5/tests/unit/controller/worker/tasks/test_f5_tasks.py
@@ -374,9 +374,8 @@ class TestF5Tasks(base.TestCase):
 
         selfip_fixed_ip = network_models.FixedIP(
             ip_address='1.2.3.2', subnet_id=mock_subnet_id)
-        selfip_port = network_models.Port(
-            id='test-selfip-port-id', fixed_ips=[selfip_fixed_ip],
-        )
+        # SelfIPs to remove come from the GetExistingSelfIPsForVLAN task and thus only contain ID, nothing else
+        selfip_port = network_models.Port(id='test-selfip-port-id')
         selfip_name = f"port-{selfip_port.id}"
 
         # Revert before SelfIP deletion, so that we can check that post is called unconditionally

--- a/octavia_f5/tests/unit/controller/worker/tasks/test_f5_tasks.py
+++ b/octavia_f5/tests/unit/controller/worker/tasks/test_f5_tasks.py
@@ -177,6 +177,7 @@ class TestF5Tasks(base.TestCase):
             'bigip': mock_bigip,
             'network': mock_network,
             'subnet_id': mock_subnet.id,
+            'existing_subnet_routes': [],
         }
         engines.run(f5_tasks.EnsureSubnetRoute(), store=store)
         mock_bigip.delete.assert_not_called()
@@ -200,6 +201,7 @@ class TestF5Tasks(base.TestCase):
             'bigip': mock_bigip,
             'network': mock_network,
             'subnet_id': mock_subnet.id,
+            'existing_subnet_routes': [],
         }
         engines.run(f5_tasks.EnsureSubnetRoute(), store=store)
         mock_bigip.delete.assert_not_called()

--- a/octavia_f5/tests/unit/controller/worker/tasks/test_f5_tasks.py
+++ b/octavia_f5/tests/unit/controller/worker/tasks/test_f5_tasks.py
@@ -372,8 +372,6 @@ class TestF5Tasks(base.TestCase):
                        'provider:segmentation_id': 1234}]
         )
 
-        selfip_fixed_ip = network_models.FixedIP(
-            ip_address='1.2.3.2', subnet_id=mock_subnet_id)
         # SelfIPs to remove come from the GetExistingSelfIPsForVLAN task and thus only contain ID, nothing else
         selfip_port = network_models.Port(id='test-selfip-port-id')
         selfip_name = f"port-{selfip_port.id}"
@@ -384,10 +382,16 @@ class TestF5Tasks(base.TestCase):
         mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
         mock_bigip.delete.side_effect = TestException(
             "Test exception to trigger rollback of EnsureSelfIP")
+        selfip_port_dict = {
+            'name': f"port-{selfip_port.id}",
+            'port_id': selfip_port.id,
+            'address': "1.2.3.2%1234/24",
+            'vlan': '/Common/vlan-1234',
+        }
         store = {
             'bigip': mock_bigip,
-            'existing_selfips': [selfip_port],
-            'port': selfip_port,
+            'existing_selfips': [selfip_port_dict],
+            'selfip': selfip_port_dict,
             'network': mock_network,
         }
 

--- a/octavia_f5/tests/unit/controller/worker/tasks/test_f5_tasks.py
+++ b/octavia_f5/tests/unit/controller/worker/tasks/test_f5_tasks.py
@@ -437,7 +437,9 @@ class TestF5Tasks(base.TestCase):
         )
 
         subnet_route_name = f'net_{mock_network_id}_sub_{mock_subnet_id}'
-        subnet_route = {'name': subnet_route_name}
+        subnet_route = {'name': subnet_route_name,
+                        'tmInterface': 'original_subnet_route_tmInterface',
+                        'network': 'original_subnet_route_network'}
 
         # Revert before SelfIP deletion, so that we can check that post is called unconditionally
         class TestException(Exception):
@@ -447,7 +449,7 @@ class TestF5Tasks(base.TestCase):
             "Test exception to trigger rollback of EnsureSubnetRoute")
         store = {
             'bigip': mock_bigip,
-            'subnet_route_name': subnet_route_name,
+            'subnet_route': subnet_route,
             'existing_subnet_routes': [subnet_route],
             'network': mock_network,
         }
@@ -459,8 +461,8 @@ class TestF5Tasks(base.TestCase):
             path=f"/mgmt/tm/net/route",
             json={
                 'name': subnet_route_name,
-                'tmInterface': "/Common/vlan-1234",
-                'network': "2.3.4.0%1234/24",
+                'tmInterface': "original_subnet_route_tmInterface",
+                'network': "original_subnet_route_network",
             },
         )
         mock_bigip.get.assert_not_called()

--- a/octavia_f5/tests/unit/controller/worker/tasks/test_f5_tasks.py
+++ b/octavia_f5/tests/unit/controller/worker/tasks/test_f5_tasks.py
@@ -376,12 +376,6 @@ class TestF5Tasks(base.TestCase):
         selfip_port = network_models.Port(id='test-selfip-port-id')
         selfip_name = f"port-{selfip_port.id}"
 
-        # Revert before SelfIP deletion, so that we can check that post is called unconditionally
-        class TestException(Exception):
-            pass
-        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
-        mock_bigip.delete.side_effect = TestException(
-            "Test exception to trigger rollback of EnsureSelfIP")
         selfip_port_dict = {
             'name': f"port-{selfip_port.id}",
             'port_id': selfip_port.id,
@@ -389,15 +383,31 @@ class TestF5Tasks(base.TestCase):
             'vlan': '/Common/vlan-1234',
         }
         store = {
-            'bigip': mock_bigip,
-            'existing_selfips': [selfip_port_dict],
             'selfip': selfip_port_dict,
             'network': mock_network,
         }
+        # exception to be thrown during task execution
+        class TestException(Exception):
+            pass
 
-        # Case: SelfIP existed before the task, so it has to be restored
+        # The SelfIP only has to be restored if did exist before but doesn't
+        # exist anymore (because deletion worked). So we have to test three cases:
+        # 1) SelfIP is gone, but existed before => restore
+        # 2) SelfIP is gone, and didn't exist before => NOP
+        # 3) SelfIP is still there => NOP
+
+        # Case 1: SelfIP is gone, but existed before => restore
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip.delete.side_effect = TestException(
+            "Test exception to trigger rollback of EnsureSelfIP (case 1)")
+        mock_bigip.get.side_effect = [test_f5_flows.MockResponse({}, 404)]
+        store['bigip'] = mock_bigip
+        store['existing_selfips'] = [selfip_port_dict]
         self.assertRaises(TestException, engines.run, f5_tasks.RemoveSelfIP(), store=store)
+        # calls in execute()
         mock_bigip.delete.assert_called_with(path=f"/mgmt/tm/net/self/{selfip_name}")
+        # calls in revert()
+        mock_bigip.get.assert_called_with(path=f"/mgmt/tm/net/self/{selfip_port.id}")
         mock_bigip.post.assert_called_with(
             path=f"/mgmt/tm/net/self/",
             json={
@@ -406,19 +416,36 @@ class TestF5Tasks(base.TestCase):
                 'address': "1.2.3.2%1234/24",
             },
         )
-        mock_bigip.get.assert_not_called()
         mock_bigip.patch.assert_not_called()
 
-        # Case: SelfIP didn't exist before the task, so it shouldn't be restored
+        # Case 2: SelfIP is gone, and didn't exist before => NOP
         mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
         mock_bigip.delete.side_effect = TestException(
-            "Test exception to trigger rollback of EnsureSelfIP")
+            "Test exception to trigger rollback of EnsureSelfIP (case 2)")
+        mock_bigip.get.side_effect = [test_f5_flows.MockResponse({}, 404)]
         store['bigip'] = mock_bigip
         store['existing_selfips'] = []
         self.assertRaises(TestException, engines.run, f5_tasks.RemoveSelfIP(), store=store)
+        # calls in execute()
         mock_bigip.delete.assert_called_with(path=f"/mgmt/tm/net/self/{selfip_name}")
-        mock_bigip.post.assert_not_called()
+        # calls in revert()
         mock_bigip.get.assert_not_called()
+        mock_bigip.post.assert_not_called()
+        mock_bigip.patch.assert_not_called()
+
+        # Case 3: SelfIP is still there => NOP
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip.delete.side_effect = TestException(
+            "Test exception to trigger rollback of EnsureSelfIP (case 3)")
+        mock_bigip.get.side_effect = [test_f5_flows.MockResponse({}, 200)] # only HTTP code matters
+        store['bigip'] = mock_bigip
+        store['existing_selfips'] = [selfip_port_dict]
+        self.assertRaises(TestException, engines.run, f5_tasks.RemoveSelfIP(), store=store)
+        # calls in execute()
+        mock_bigip.delete.assert_called_with(path=f"/mgmt/tm/net/self/{selfip_name}")
+        # calls in revert()
+        mock_bigip.get.assert_called_with(path=f"/mgmt/tm/net/self/{selfip_port.id}")
+        mock_bigip.post.assert_not_called()
         mock_bigip.patch.assert_not_called()
 
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
@@ -440,42 +467,70 @@ class TestF5Tasks(base.TestCase):
         subnet_route = {'name': subnet_route_name,
                         'tmInterface': 'original_subnet_route_tmInterface',
                         'network': 'original_subnet_route_network'}
-
-        # Revert before SelfIP deletion, so that we can check that post is called unconditionally
-        class TestException(Exception):
-            pass
-        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
-        mock_bigip.delete.side_effect = TestException(
-            "Test exception to trigger rollback of EnsureSubnetRoute")
         store = {
-            'bigip': mock_bigip,
             'subnet_route': subnet_route,
-            'existing_subnet_routes': [subnet_route],
             'network': mock_network,
         }
+        # exception to be thrown during task execution
+        class TestException(Exception):
+            pass
 
-        # Case: Subnet route existed before the task, so it has to be restored
+        # The subnet route only has to be restored if did exist before but
+        # doesn't exist anymore (because deletion worked). So we have to test
+        # three cases:
+        # 1) Subnet route is gone, but existed before => restore
+        # 2) Subnet route is gone, and didn't exist before => NOP
+        # 3) Subnet route is still there => NOP
+
+        # Case 1: Subnet route is gone, but existed before => restore
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip.delete.side_effect = TestException(
+            "Test exception to trigger rollback of EnsureSubnetRoute (case 1)")
+        mock_bigip.get.side_effect = [test_f5_flows.MockResponse({}, 404)]
+        store['bigip'] = mock_bigip
+        store['existing_subnet_routes'] = [subnet_route]
         self.assertRaises(TestException, engines.run, f5_tasks.RemoveSubnetRoute(), store=store)
+        # calls in execute()
         mock_bigip.delete.assert_called_with(path=f"/mgmt/tm/net/route/~Common~{subnet_route_name}")
+        # calls in revert()
+        mock_bigip.get.assert_called_with(path=f"/mgmt/tm/net/route/~Common~{subnet_route_name}")
         mock_bigip.post.assert_called_with(
             path=f"/mgmt/tm/net/route",
             json={
                 'name': subnet_route_name,
-                'tmInterface': "original_subnet_route_tmInterface",
-                'network': "original_subnet_route_network",
+                'tmInterface': subnet_route['tmInterface'],
+                'network': subnet_route['network'],
             },
         )
-        mock_bigip.get.assert_not_called()
         mock_bigip.patch.assert_not_called()
 
-        # Case: Subnet route didn't exist before the task, so it shouldn't be restored
+        # Case 2: Subnet route is gone, and didn't exist before => NOP
         mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
         mock_bigip.delete.side_effect = TestException(
-            "Test exception to trigger rollback of EnsureSelfIP")
+            "Test exception to trigger rollback of EnsureSubnetRoute (case 2)")
+        mock_bigip.get.side_effect = [test_f5_flows.MockResponse({}, 404)]
         store['bigip'] = mock_bigip
         store['existing_subnet_routes'] = []
         self.assertRaises(TestException, engines.run, f5_tasks.RemoveSubnetRoute(), store=store)
+        # calls in execute()
         mock_bigip.delete.assert_called_with(path=f"/mgmt/tm/net/route/~Common~{subnet_route_name}")
-        mock_bigip.post.assert_not_called()
+        # calls in revert()
         mock_bigip.get.assert_not_called()
+        mock_bigip.post.assert_not_called()
         mock_bigip.patch.assert_not_called()
+
+        # Case 3: Subnet route is still there => NOP
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip.delete.side_effect = TestException(
+            "Test exception to trigger rollback of EnsureSubnetRoute (case 3)")
+        mock_bigip.get.side_effect = [test_f5_flows.MockResponse({}, 200)] # only HTTP code matters
+        store['bigip'] = mock_bigip
+        store['existing_subnet_routes'] = [subnet_route]
+        self.assertRaises(TestException, engines.run, f5_tasks.RemoveSubnetRoute(), store=store)
+        # calls in execute()
+        mock_bigip.delete.assert_called_with(path=f"/mgmt/tm/net/route/~Common~{subnet_route_name}")
+        # calls in revert()
+        mock_bigip.get.assert_called_with(path=f"/mgmt/tm/net/route/~Common~{subnet_route_name}")
+        mock_bigip.post.assert_not_called()
+        mock_bigip.patch.assert_not_called()
+

--- a/octavia_f5/tests/unit/controller/worker/tasks/test_f5_tasks.py
+++ b/octavia_f5/tests/unit/controller/worker/tasks/test_f5_tasks.py
@@ -43,7 +43,7 @@ class TestF5Tasks(base.TestCase):
 
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")
-    def test_EnsureRoute(self, mock_get_subnet):
+    def test_EnsureDefaultRoute(self, mock_get_subnet):
         mock_get_subnet.return_value = network_models.Subnet(
             id='test-subnet-id', gateway_ip='2.3.4.5',
             cidr='2.3.4.0/24', network_id='test-network-id')

--- a/octavia_f5/tests/unit/controller/worker/tasks/test_f5_tasks.py
+++ b/octavia_f5/tests/unit/controller/worker/tasks/test_f5_tasks.py
@@ -76,7 +76,7 @@ class TestF5Tasks(base.TestCase):
 
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")
-    def test_EnsureRoute_legacy(self, mock_get_subnet):
+    def test_EnsureDefaultRoute_legacy(self, mock_get_subnet):
         mock_get_subnet.return_value = network_models.Subnet(
             id='test-subnet-id', gateway_ip='1.2.3.1',
             cidr='1.2.3.0/24', network_id='test-network-id')
@@ -112,7 +112,7 @@ class TestF5Tasks(base.TestCase):
 
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")
-    def test_EnsureRoute_legacy_conflict(self, mock_get_subnet):
+    def test_EnsureDefaultRoute_legacy_conflict(self, mock_get_subnet):
         mock_get_subnet.return_value = network_models.Subnet(
             id='test-subnet-id', gateway_ip='8.8.8.8',
             cidr='1.2.3.0/24', network_id='test-network-id')
@@ -154,13 +154,80 @@ class TestF5Tasks(base.TestCase):
 
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")
-    def test_EnsureSubnetRoute(self, mock_get_subnet):
+    def test_EnsureSelfIP(self, mock_get_subnet):
         mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
-        mock_subnet = network_models.Subnet(
-            id=uuidutils.generate_uuid(), gateway_ip='2.3.4.5',
+        mock_network_id = 'test-network-id'
+        mock_subnet_id = 'test-subnet-id'
+        mock_get_subnet.return_value = network_models.Subnet(
+            id=mock_subnet_id, gateway_ip='2.3.4.5',
             cidr='2.3.4.0/24', network_id='test-network-id')
         mock_network = f5_network_models.Network(
-            mtu=9000, id=uuidutils.generate_uuid(),
+            mtu=9000, id=mock_network_id,
+            subnets=[mock_subnet_id],
+            segments=[{'provider:physical_network': 'physnet',
+                       'provider:segmentation_id': 1234}]
+        )
+
+        selfip_fixed_ip = network_models.FixedIP(
+            ip_address='1.2.3.2', subnet_id=mock_subnet_id)
+        selfip_port = network_models.Port(
+            id='test-selfip-port-id', fixed_ips=[selfip_fixed_ip],
+        )
+        selfip_name = f"port-{selfip_port.id}"
+
+        mock_bigip.get.side_effect = [
+            test_f5_flows.MockResponse({}, 404),
+        ]
+
+        # case: SelfIP doesn't exist yet
+        store = {
+            'bigip': mock_bigip,
+            'network': mock_network,
+            'port': selfip_port,
+            'existing_selfips': [],
+        }
+        engines.run(f5_tasks.EnsureSelfIP(), store=store)
+        mock_bigip.delete.assert_not_called()
+        mock_bigip.get.assert_called_with(
+            path=f"/mgmt/tm/net/self/{selfip_name}")
+        mock_bigip.post.assert_called_with(
+            path=f"/mgmt/tm/net/self",
+            json={
+                'name': selfip_name,
+                'vlan': "/Common/vlan-1234",
+                'address': "1.2.3.2%1234/24",
+            })
+        mock_bigip.patch.assert_not_called()
+
+        # case: SelfIP exists
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip.get.side_effect = [
+            test_f5_flows.MockResponse({'name': selfip_name}, 200),
+        ]
+        store['bigip'] = mock_bigip
+        engines.run(f5_tasks.EnsureSelfIP(), store=store)
+        mock_bigip.delete.assert_not_called()
+        mock_bigip.get.assert_called_with(
+            path=f"/mgmt/tm/net/self/{selfip_name}")
+        mock_bigip.post.assert_not_called()
+        mock_bigip.patch.assert_called_with(
+            path=f"/mgmt/tm/net/self/{selfip_name}",
+            json={
+                'name': selfip_name,
+                'vlan': "/Common/vlan-1234",
+                'address': "1.2.3.2%1234/24",
+            })
+
+    @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
+                ".get_subnet")
+    def test_EnsureSubnetRoute(self, mock_get_subnet):
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_network_id = 'test-network-id'
+        mock_subnet = network_models.Subnet(
+            id=uuidutils.generate_uuid(), gateway_ip='2.3.4.5',
+            cidr='2.3.4.0/24', network_id=mock_network_id)
+        mock_network = f5_network_models.Network(
+            mtu=9000, id=mock_network_id,
             subnets=mock_subnet,
             segments=[{'provider:physical_network': 'physnet',
                        'provider:segmentation_id': 1234}]
@@ -197,12 +264,7 @@ class TestF5Tasks(base.TestCase):
         mock_bigip.get.side_effect = [
             test_f5_flows.MockResponse({'name': subnet_route_name}, 200),
         ]
-        store = {
-            'bigip': mock_bigip,
-            'network': mock_network,
-            'subnet_id': mock_subnet.id,
-            'existing_subnet_routes': [],
-        }
+        store['bigip'] = mock_bigip
         engines.run(f5_tasks.EnsureSubnetRoute(), store=store)
         mock_bigip.delete.assert_not_called()
         mock_bigip.get.assert_called_with(
@@ -213,3 +275,202 @@ class TestF5Tasks(base.TestCase):
                   'tmInterface': '/Common/vlan-1234',
                   'network': '2.3.4.0%1234/24'})
         mock_bigip.post.assert_not_called()
+
+    @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
+                ".get_subnet")
+    def test_revert_EnsureSelfIP(self, mock_get_subnet):
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_network_id = 'test-network-id'
+        mock_subnet_id = 'test-subnet-id'
+        mock_get_subnet.return_value = network_models.Subnet(
+            id=mock_subnet_id, gateway_ip='2.3.4.5',
+            cidr='2.3.4.0/24', network_id='test-network-id')
+        mock_network = f5_network_models.Network(
+            mtu=9000, id=mock_network_id,
+            subnets=[mock_subnet_id],
+            segments=[{'provider:physical_network': 'physnet',
+                       'provider:segmentation_id': 1234}]
+        )
+
+        selfip_fixed_ip = network_models.FixedIP(
+            ip_address='1.2.3.2', subnet_id=mock_subnet_id)
+        selfip_port = network_models.Port(
+            id='test-selfip-port-id', fixed_ips=[selfip_fixed_ip],
+        )
+        selfip_name = f"port-{selfip_port.id}"
+
+        # Revert before SelfIP creation, so that we can check that delete is called unconditionaly
+        class TestException(Exception):
+            pass
+        mock_bigip.get.side_effect = TestException(
+            "Test exception to trigger rollback of EnsureSelfIP")
+        store = {
+            'bigip': mock_bigip,
+            'network': mock_network,
+            'port': selfip_port,
+            'existing_selfips': [],
+        }
+        self.assertRaises(TestException, engines.run, f5_tasks.EnsureSelfIP(), store=store)
+        mock_bigip.get.assert_called_with(path=f"/mgmt/tm/net/self/{selfip_name}")
+        # delete is always called during rollback, ignoring 404
+        mock_bigip.delete.assert_called_with(
+            path=f"/mgmt/tm/net/self/{selfip_name}"
+        )
+        mock_bigip.post.assert_not_called()
+        mock_bigip.patch.assert_not_called()
+
+    @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
+                ".get_subnet")
+    def test_revert_EnsureSubnetRoute(self, mock_get_subnet):
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_network_id = 'test-network-id'
+        mock_subnet_id = 'test-subnet-id'
+        mock_get_subnet.return_value = network_models.Subnet(
+            id=mock_subnet_id, gateway_ip='2.3.4.5',
+            cidr='2.3.4.0/24', network_id='test-network-id')
+        mock_network = f5_network_models.Network(
+            mtu=9000, id=mock_network_id,
+            subnets=[mock_subnet_id],
+            segments=[{'provider:physical_network': 'physnet',
+                       'provider:segmentation_id': 1234}]
+        )
+
+        subnet_route_name = f'net_{mock_network_id}_sub_{mock_subnet_id}'
+
+        # Revert before subnet route creation, so that we can check that delete is called unconditionaly
+        class TestException(Exception):
+            pass
+        mock_bigip.get.side_effect = TestException(
+            "Test exception to trigger rollback of EnsureSubnetRoute")
+        store = {
+            'bigip': mock_bigip,
+            'network': mock_network,
+            'subnet_id': mock_subnet_id,
+            'existing_subnet_routes': [],
+        }
+        self.assertRaises(TestException, engines.run, f5_tasks.EnsureSubnetRoute(), store=store)
+        mock_bigip.get.assert_called_with(path=f"/mgmt/tm/net/route/~Common~{subnet_route_name}")
+        # delete is always called during rollback, ignoring 404
+        mock_bigip.delete.assert_called_with(
+            path=f"/mgmt/tm/net/route/~Common~{subnet_route_name}"
+        )
+        mock_bigip.post.assert_not_called()
+        mock_bigip.patch.assert_not_called()
+
+    @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
+                ".get_subnet")
+    def test_revert_RemoveSelfIP(self, mock_get_subnet):
+        mock_network_id = 'test-network-id'
+        mock_subnet_id = 'test-subnet-id'
+        mock_get_subnet.return_value = network_models.Subnet(
+            id=mock_subnet_id, gateway_ip='2.3.4.5',
+            cidr='2.3.4.0/24', network_id='test-network-id')
+        mock_network = f5_network_models.Network(
+            mtu=9000, id=mock_network_id,
+            subnets=[mock_subnet_id],
+            segments=[{'provider:physical_network': 'physnet',
+                       'provider:segmentation_id': 1234}]
+        )
+
+        selfip_fixed_ip = network_models.FixedIP(
+            ip_address='1.2.3.2', subnet_id=mock_subnet_id)
+        selfip_port = network_models.Port(
+            id='test-selfip-port-id', fixed_ips=[selfip_fixed_ip],
+        )
+        selfip_name = f"port-{selfip_port.id}"
+
+        # Revert before SelfIP deletion, so that we can check that post is called unconditionally
+        class TestException(Exception):
+            pass
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip.delete.side_effect = TestException(
+            "Test exception to trigger rollback of EnsureSelfIP")
+        store = {
+            'bigip': mock_bigip,
+            'existing_selfips': [selfip_port],
+            'port': selfip_port,
+            'network': mock_network,
+        }
+
+        # Case: SelfIP existed before the task, so it has to be restored
+        self.assertRaises(TestException, engines.run, f5_tasks.RemoveSelfIP(), store=store)
+        mock_bigip.delete.assert_called_with(path=f"/mgmt/tm/net/self/{selfip_name}")
+        mock_bigip.post.assert_called_with(
+            path=f"/mgmt/tm/net/self/",
+            json={
+                'name': selfip_name,
+                'vlan': "/Common/vlan-1234",
+                'address': "1.2.3.2%1234/24",
+            },
+        )
+        mock_bigip.get.assert_not_called()
+        mock_bigip.patch.assert_not_called()
+
+        # Case: SelfIP didn't exist before the task, so it shouldn't be restored
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip.delete.side_effect = TestException(
+            "Test exception to trigger rollback of EnsureSelfIP")
+        store['bigip'] = mock_bigip
+        store['existing_selfips'] = []
+        self.assertRaises(TestException, engines.run, f5_tasks.RemoveSelfIP(), store=store)
+        mock_bigip.delete.assert_called_with(path=f"/mgmt/tm/net/self/{selfip_name}")
+        mock_bigip.post.assert_not_called()
+        mock_bigip.get.assert_not_called()
+        mock_bigip.patch.assert_not_called()
+
+    @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
+                ".get_subnet")
+    def test_revert_RemoveSubnetRoute(self, mock_get_subnet):
+        mock_network_id = 'test-network-id'
+        mock_subnet_id = 'test-subnet-id'
+        mock_get_subnet.return_value = network_models.Subnet(
+            id=mock_subnet_id, gateway_ip='2.3.4.5',
+            cidr='2.3.4.0/24', network_id='test-network-id')
+        mock_network = f5_network_models.Network(
+            mtu=9000, id=mock_network_id,
+            subnets=[mock_subnet_id],
+            segments=[{'provider:physical_network': 'physnet',
+                       'provider:segmentation_id': 1234}]
+        )
+
+        subnet_route_name = f'net_{mock_network_id}_sub_{mock_subnet_id}'
+        subnet_route = {'name': subnet_route_name}
+
+        # Revert before SelfIP deletion, so that we can check that post is called unconditionally
+        class TestException(Exception):
+            pass
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip.delete.side_effect = TestException(
+            "Test exception to trigger rollback of EnsureSubnetRoute")
+        store = {
+            'bigip': mock_bigip,
+            'subnet_route_name': subnet_route_name,
+            'existing_subnet_routes': [subnet_route],
+            'network': mock_network,
+        }
+
+        # Case: Subnet route existed before the task, so it has to be restored
+        self.assertRaises(TestException, engines.run, f5_tasks.RemoveSubnetRoute(), store=store)
+        mock_bigip.delete.assert_called_with(path=f"/mgmt/tm/net/route/~Common~{subnet_route_name}")
+        mock_bigip.post.assert_called_with(
+            path=f"/mgmt/tm/net/route",
+            json={
+                'name': subnet_route_name,
+                'tmInterface': "/Common/vlan-1234",
+                'network': "2.3.4.0%1234/24",
+            },
+        )
+        mock_bigip.get.assert_not_called()
+        mock_bigip.patch.assert_not_called()
+
+        # Case: Subnet route didn't exist before the task, so it shouldn't be restored
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip.delete.side_effect = TestException(
+            "Test exception to trigger rollback of EnsureSelfIP")
+        store['bigip'] = mock_bigip
+        store['existing_subnet_routes'] = []
+        self.assertRaises(TestException, engines.run, f5_tasks.RemoveSubnetRoute(), store=store)
+        mock_bigip.delete.assert_called_with(path=f"/mgmt/tm/net/route/~Common~{subnet_route_name}")
+        mock_bigip.post.assert_not_called()
+        mock_bigip.get.assert_not_called()
+        mock_bigip.patch.assert_not_called()


### PR DESCRIPTION
There is currently no revert logic for when SelfIP or subnet route creation/deletion fails.
This can lead to a problem when a SelfIP fails to be created (e.g. due to conflicting pool member) but the subnet route it replaces has already been deleted. In that case the deleted subnet route won't be restored.

In order to enable reverting subnet route creation/deletion, the subnet routes that existed before the L2 flow runs must be known beforehand, so that the tasks know what the desired state is. For this to work, two things are done:
- Fetching the previously existing subnet routes and SelfIPs via a dedicated flow
- Running one task for every single subnet route creation/deletion (instead of running one task to create all at once)

These changes are made in the first commit of this PR.
The second commit adds the actual revert methods.

Please read the commit messages for more detailed explanations.