### PR TITLE
Add X-FORWARDED-HOST header insert irule

### DIFF
--- a/octavia_f5/restclient/as3objects/irule.py
+++ b/octavia_f5/restclient/as3objects/irule.py
@@ -22,6 +22,13 @@ PROXY_PROTOCOL_INITIATIOR = """when CLIENT_ACCEPTED {
 when SERVER_CONNECTED {
     TCP::respond $proxyheader
 }"""
+X_FORWARDED_HOST = """when HTTP_REQUEST priority 500 {
+    if { [HTTP::has_responded] }{ return }
+    if { [HTTP::header exists {X-Forwarded-Host}] } {
+        HTTP::header remove {X-Forwarded-Host}
+        HTTP::header insert {X-Forwarded-Host} [HTTP::host]
+    }
+}"""
 X_FORWARDED_FOR = """when HTTP_REQUEST {
     if { [HTTP::has_responded] }{ return }
     HTTP::header insert "X-Forwarded-For" [getfield [IP::remote_addr] "%" 1]
@@ -168,6 +175,11 @@ def get_header_irules(insert_headers):
     # Entities is a list of tuples, which each describe AS3 objects
     # which may reference each other but do not form a hierarchy.
     entities = []
+    if insert_headers.get('X-Forwarded-Host', False):
+        irule = IRule(X_FORWARDED_HOST,
+                      remark="Insert X-Forwarded-Host Header")
+        entities.append(('irule_x_forwarded_host', irule))
+
     if insert_headers.get('X-Forwarded-For', False):
         irule = IRule(X_FORWARDED_FOR,
                       remark="Insert X-Forwarded-For Header")


### PR DESCRIPTION
Based on customer RFE - https://github.wdf.sap.corp/PlusOne/enhancements/issues/125
Tracked in https://github.wdf.sap.corp/cc/octavia-issues/issues/23

In this PR I'm adding X-FORWARDED-HOST irule. Once added to a listener, the XFH host header will be replaced by the value of the HTTP "Host" header. This is primarily security based, to prevent clients to inject arbitrary data into the XFH.

I will request adjustment of the "Insert headers" drop-down in listener config in Elektra separately.

iRule functionally tested in qa-de-1, working as expected:

**Client request:**
```
$ curl -vkI -H "X-Forwarded-Host: blablabla" https://test-listener-3.f5tests.only.sap/
*   Trying 10.236.36.112:443...
* Connected to test-listener-3.f5tests.only.sap (10.236.36.112) port 443
> HEAD / HTTP/1.1
> Host: test-listener-3.f5tests.only.sap
> User-Agent: curl/8.4.0
> Accept: */*
> X-Forwarded-Host: blablabla
>
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
```

**Server receives:**
```
ccloud@srv-1:~$ sudo tcpdump -vnnn -i ens192 src host 10.180.88.99
tcpdump: listening on ens192, link-type EN10MB (Ethernet), snapshot length 262144 bytes
12:42:59.582243 IP (tos 0x0, ttl 255, id 35519, offset 0, flags [DF], proto TCP (6), length 231)
    10.180.88.99.35928 > 10.180.88.141.80: Flags [P.], cksum 0xdb22 (correct), seq 0:179, ack 1, win 42, options [nop,nop,TS val 3183195773 ecr 1977627832], length 179: HTTP, length: 179
        HEAD / HTTP/1.1
        Host: test-listener-3.f5tests.only.sap
        User-Agent: curl/8.4.0
        Accept: */*
        X-Forwarded-Host: test-listener-3.f5tests.only.sap
```

**Outputs of irule-based logging:**
```
info tmm1[11378]: Rule /Common/cc_x_forwarded_host <HTTP_REQUEST>: Client-side value of "host" header: blablabla
info tmm1[11378]: Rule /Common/cc_x_forwarded_host <HTTP_REQUEST>: Client-side value of "XFH" header: test-listener-3.f5tests.only.sap
info tmm1[11378]: Rule /Common/cc_x_forwarded_host <HTTP_REQUEST_RELEASE>: Server-side value of "host" header: test-listener-3.f5tests.only.sap
info tmm1[11378]: Rule /Common/cc_x_forwarded_host <HTTP_REQUEST_RELEASE>: Server-side value of "XFH" header: test-listener-3.f5tests.only.sap
```
