### PR TITLE
Add support for session mirroring configured on TCP listeners.

### DIFF
--- a/octavia_f5/common/constants.py
+++ b/octavia_f5/common/constants.py
@@ -61,6 +61,7 @@ SERVICE_HTTP_TYPES = (SERVICE_HTTP, SERVICE_HTTPS)
 
 # special listener tags
 LISTENER_TAG_NO_SNAT = 'ccloud_special_l4_deactivate_snat'
+LISTENER_TAG_MIRRORING = 'ccloud_special_tcp_mirror'
 
 ROLE_MASTER = 'MASTER'
 ROLE_BACKUP = 'BACKUP'

--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -408,6 +408,10 @@ def get_service(listener, cert_manager, esd_repository):
     elif CONF.f5_agent.snat_virtual:
         service_args['snat'] = 'self'
 
+    # Use session mirroring for TCP listeners
+    if f5_const.LISTENER_TAG_MIRRORING in listener.tags and listener.protocol == lib_consts.PROTOCOL_TCP:
+        service_args['mirroring'] = 'L4'
+
     # create service object and fill in additional fields
     service = as3.Service(**service_args)
 


### PR DESCRIPTION
This pull request implements a custom tag `ccloud_special_tcp_mirror` for supporting session mirroring on TCP listeners. Because we are using `Service_TCP` for both listener protocols `TCP` and `HTTPS` we check `listener.protocol` instead of `_servicetype` to avoid HTTPS listeners enabled with mirroring.

Related to cc/octavia-issues issue 42 and PlusOne/enhancements issue 153