### PR TITLE
Fix error RequestURITooLong in full sync.

### DIFF
--- a/octavia_f5/network/drivers/neutron/neutron_client.py
+++ b/octavia_f5/network/drivers/neutron/neutron_client.py
@@ -348,7 +348,7 @@ class NeutronClient(neutron_base.BaseNeutronDriver,
 
         raise Exception(f"Hostname not found for host {host}")
 
-    def _get_subnets_chunks(self, subnets: list, max_size: int=100):
+    def _get_subnets_chunks(self, subnets: list, max_size: int = 100):
         for i in range(0, len(subnets), max_size):
             yield subnets[i:i + max_size]
 

--- a/octavia_f5/network/drivers/neutron/neutron_client.py
+++ b/octavia_f5/network/drivers/neutron/neutron_client.py
@@ -348,6 +348,10 @@ class NeutronClient(neutron_base.BaseNeutronDriver,
 
         raise Exception(f"Hostname not found for host {host}")
 
+    def _get_subnets_chunks(self, subnets: list, max_size: int=100):
+        for i in range(0, len(subnets), max_size):
+            yield subnets[i:i + max_size]
+
     @tenacity.retry(
         retry=tenacity.retry_if_exception_type(
             (neutron_client_exceptions.Conflict,
@@ -396,14 +400,17 @@ class NeutronClient(neutron_base.BaseNeutronDriver,
         else:
             hosts_id = [agent]
 
-        all_subnets = set(lb.vip.subnet_id for lb in load_balancers)
+        all_subnets = list(set(lb.vip.subnet_id for lb in load_balancers))
         needed_subnets = set(lb.vip.subnet_id for lb in load_balancers
                              if lb.provisioning_status != lib_consts.PENDING_DELETE)
-        filter = {'device_owner': [constants.DEVICE_OWNER_SELFIP,
-                                   constants.DEVICE_OWNER_LEGACY],
-                  'binding:host_id': hosts_id,
-                  'fixed_ips': [f'subnet_id={subnet}' for subnet in all_subnets]}
-        selfips = self.neutron_client.list_ports(**filter).get('ports', [])
+        subnets_in_chunks = list(self._get_subnets_chunks(all_subnets))
+        selfips = []
+        for chunk in subnets_in_chunks:
+            filter = {'device_owner': [constants.DEVICE_OWNER_SELFIP,
+                                       constants.DEVICE_OWNER_LEGACY],
+                      'binding:host_id': hosts_id,
+                      'fixed_ips': [f'subnet_id={subnet}' for subnet in chunk]}
+            selfips += self.neutron_client.list_ports(**filter).get('ports', [])
 
         # For every subnet and f5host, we expect a selfip
         f5hosts = {host: set() for host in self._get_f5_hostnames(hosts_id[0])}


### PR DESCRIPTION
This PR adds chunks for list_ports requests in ensure_selfips to avoid error:
```
2024-09-04 15:27:39,431 23 ERROR futurist.periodics [-] Failed to call immediate 'octavia_f5.controller.worker.controller_worker.ControllerWorker.full_sync_l2' (it runs every 86400.00 seconds): neutronclient.common.exceptions.RequestURITooLong: An unknown exception occurred.
Traceback (most recent call last):
  File "/var/lib/openstack/lib/python3.8/site-packages/futurist/periodics.py", line 293, in run
    work()
  File "/var/lib/openstack/lib/python3.8/site-packages/futurist/periodics.py", line 67, in __call__
    return self.callback(*self.args, **self.kwargs)
  File "/var/lib/openstack/lib/python3.8/site-packages/futurist/periodics.py", line 181, in decorator
    return f(*args, **kwargs)
  File "/var/lib/openstack/src/octavia-f5-provider-driver/octavia_f5/controller/worker/controller_worker.py", line 215, in full_sync_l2
    self.l2sync.full_sync(loadbalancers)
  File "/usr/lib/python3.8/contextlib.py", line 75, in inner
    return func(*args, **kwds)
  File "/var/lib/openstack/src/octavia-f5-provider-driver/octavia_f5/controller/worker/l2_sync_manager.py", line 302, in full_sync
    self._network_driver.ensure_selfips(loadbalancers, cleanup_orphans=True)))
  File "/var/lib/openstack/lib/python3.8/site-packages/tenacity/__init__.py", line 333, in wrapped_f
    return self(f, *args, **kw)
  File "/var/lib/openstack/lib/python3.8/site-packages/tenacity/__init__.py", line 423, in __call__
    do = self.iter(retry_state=retry_state)
  File "/var/lib/openstack/lib/python3.8/site-packages/tenacity/__init__.py", line 360, in iter
    return fut.result()
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 437, in result
    return self.__get_result()
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 389, in __get_result
    raise self._exception
  File "/var/lib/openstack/lib/python3.8/site-packages/tenacity/__init__.py", line 426, in __call__
    result = fn(*args, **kwargs)
  File "/var/lib/openstack/src/octavia-f5-provider-driver/octavia_f5/network/drivers/neutron/neutron_client.py", line 406, in ensure_selfips
    selfips = self.neutron_client.list_ports(**filter).get('ports', [])
  File "/var/lib/openstack/lib/python3.8/site-packages/neutronclient/v2_0/client.py", line 813, in list_ports
    return self.list('ports', self.ports_path, retrieve_all,
  File "/var/lib/openstack/lib/python3.8/site-packages/neutronclient/v2_0/client.py", line 372, in list
    for r in self._pagination(collection, path, **params):
  File "/var/lib/openstack/lib/python3.8/site-packages/neutronclient/v2_0/client.py", line 387, in _pagination
    res = self.get(path, params=params)
  File "/var/lib/openstack/lib/python3.8/site-packages/neutronclient/v2_0/client.py", line 356, in get
    return self.retry_request("GET", action, body=body,
  File "/var/lib/openstack/lib/python3.8/site-packages/neutronclient/v2_0/client.py", line 333, in retry_request
    return self.do_request(method, action, body=body,
  File "/var/lib/openstack/lib/python3.8/site-packages/neutronclient/v2_0/client.py", line 284, in do_request
    resp, replybody = self.httpclient.do_request(action, method, body=body,
  File "/var/lib/openstack/lib/python3.8/site-packages/neutronclient/client.py", line 341, in do_request
    self._check_uri_length(url)
  File "/var/lib/openstack/lib/python3.8/site-packages/neutronclient/client.py", line 336, in _check_uri_length
    raise exceptions.RequestURITooLong(
neutronclient.common.exceptions.RequestURITooLong: An unknown exception occurred.
```