### PR TITLE
refactor x_ssl_client_cn irule

### DIFF
--- a/octavia_f5/restclient/as3objects/irule.py
+++ b/octavia_f5/restclient/as3objects/irule.py
@@ -77,24 +77,13 @@ X_SSL_CLIENT_DN = """when HTTP_REQUEST {
         HTTP::header insert "X-SSL-Client-DN" $subject_dn
     }
 }"""
-X_SSL_CLIENT_CN = """proc x509CNExtract { str } {
-    set res "CN notFound"
-    foreach field [ split $str " "] {
-        foreach { fname  fval } [ split $field "=" ]  break
-        if { $fname eq "CN" } {
-            set res $fval
-            break
-        }
-    }
-    return $res
-}
-when HTTP_REQUEST {
+X_SSL_CLIENT_CN = """when HTTP_REQUEST {
     if { [HTTP::has_responded] }{ return }
     if { [SSL::cert count] > 0 }{
-        set subject_cn [X509::subject [SSL::cert 0]]
+        set subject_cn [X509::subject [SSL::cert 0] commonName]
     }
     if { [info exists subject_cn] } {
-        HTTP::header insert "X-SSL-Client-CN" [call x509CNExtract $subject_cn]
+        HTTP::header insert "X-SSL-Client-CN" $subject_cn
     }
 }"""
 X_SSL_CLIENT_SHA1 = """when HTTP_REQUEST {


### PR DESCRIPTION
The `X_SSL_CLIENT_CN` can be simplified and enhanced since we are now running TMOS version >16.1.3 (17.1.1.1)
The change is described in F5 docu https://clouddocs.f5.com/api/irules/X509__subject.html
It's not a functional change, but rather code simplification/reduction.

More details in https://github.wdf.sap.corp/cc/octavia-issues/issues/51
For context, see also older issue #266

Refactored irule was tested/validated in qa-de-1