### PR TITLE
Add Big IP exceptions metrics, fix logging add retries for sync RouteDomain.

### DIFF
--- a/octavia_f5/controller/worker/tasks/f5_tasks.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks.py
@@ -152,6 +152,11 @@ class EnsureRouteDomain(task.Task):
     """ Task to create or update Route Domain if needed """
 
     @decorators.RaisesIControlRestError()
+    @tenacity.retry(
+        retry=tenacity.retry_if_exception_type(requests.HTTPError),
+        wait=tenacity.wait_fixed(2),
+        stop=tenacity.stop_after_attempt(3)
+    )
     def execute(self, network: f5_network_models.Network,
                 bigip: bigip_restclient.BigIPRestClient):
 

--- a/octavia_f5/restclient/as3logging.py
+++ b/octavia_f5/restclient/as3logging.py
@@ -52,6 +52,6 @@ def get_response_log(response):
             # No valid json
             msg += response.text
     else:
-        msg += response.txt
+        msg += response.text
 
     return msg.strip()

--- a/octavia_f5/restclient/bigip/bigip_restclient.py
+++ b/octavia_f5/restclient/bigip/bigip_restclient.py
@@ -14,6 +14,7 @@
 
 from urllib import parse
 
+import prometheus_client as prometheus
 import requests
 from oslo_log import log as logging
 from urllib3.util.retry import Retry
@@ -27,6 +28,17 @@ BIGIP_CM_PATH = '/mgmt/tm/cm'
 
 
 class BigIPRestClient(requests.Session):
+    _metric_get_exceptions = prometheus.metrics.Counter(
+        'octavia_bigip_get_exceptions', 'Number of exceptions at GET requests sent to Big IP')
+    _metric_post_exceptions = prometheus.metrics.Counter(
+        'octavia_bigip_post_exceptions', 'Number of exceptions at POST requests sent to Big IP')
+    _metric_put_exceptions = prometheus.metrics.Counter(
+        'octavia_bigip_put_exceptions', 'Number of exceptions at PUT request sent to Big IP')
+    _metric_patch_exceptions = prometheus.metrics.Counter(
+        'octavia_bigip_patch_exceptions', 'Number of exceptions at PATCH request sent to Big IP')
+    _metric_delete_exceptions = prometheus.metrics.Counter(
+        'octavia_bigip_delete_exceptions', 'Number of exceptions at DELETE request sent to Big IP')
+
     def __init__(self, bigip_url, verify=True, auth=None):
         super(BigIPRestClient, self).__init__()
         self.url = parse.urlparse(bigip_url, allow_fragments=False)
@@ -87,6 +99,7 @@ class BigIPRestClient(requests.Session):
         self._active = statuses[self.hostname]
         return self._active
 
+    @_metric_get_exceptions.count_exceptions()
     def get(self, url=None, **kwargs):
         """ Override get for baseurl compatbility
         """
@@ -95,6 +108,7 @@ class BigIPRestClient(requests.Session):
 
         return super(BigIPRestClient, self).get(url, **kwargs)
 
+    @_metric_post_exceptions.count_exceptions()
     def post(self, url=None, **kwargs):
         """ Override get for baseurl compatbility
         """
@@ -103,6 +117,7 @@ class BigIPRestClient(requests.Session):
 
         return super(BigIPRestClient, self).post(url, **kwargs)
 
+    @_metric_delete_exceptions.count_exceptions()
     def delete(self, url=None, **kwargs):
         """ Override get for baseurl compatbility
         """
@@ -111,6 +126,7 @@ class BigIPRestClient(requests.Session):
 
         return super(BigIPRestClient, self).delete(url, **kwargs)
 
+    @_metric_patch_exceptions.count_exceptions()
     def patch(self, url=None, **kwargs):
         """ Override get for baseurl compatbility
         """
@@ -119,6 +135,7 @@ class BigIPRestClient(requests.Session):
 
         return super(BigIPRestClient, self).patch(url, **kwargs)
 
+    @_metric_put_exceptions.count_exceptions()
     def put(self, url=None, **kwargs):
         """ Override get for baseurl compatbility
         """


### PR DESCRIPTION
This PR adds several fixes for l2_sync problems:
1. Fixes for attribute error in response logging handler:
    ```
   ERROR octavia_f5.controller.worker.controller_worker AttributeError: 'Response' object has no attribute 'txt'
    ```
2. Adds retries for `EnsureRouteDomain` task to avoid situation when route domain was not configured in first attempt
3. Adds several metrics for low-level Big IP REST client to monitor exceptions in l2_sync flows and to be able to see exact number of failed requests.

Related to issue: https://github.wdf.sap.corp/cc/octavia-issues/issues/39
