### PR TITLE
Rescheduling: Always set availability zone to target host

### DIFF
--- a/octavia_f5/api/drivers/f5_driver/tasks/reschedule_tasks.py
+++ b/octavia_f5/api/drivers/f5_driver/tasks/reschedule_tasks.py
@@ -133,6 +133,8 @@ class RewriteLoadBalancerEntry(RescheduleTasks):
             LOG.error("RewriteLoadBalancerEntry: Unable to update loadbalancer %s",
                       load_balancer.id)
             return
-        LOG.warning("RewriteLoadBalancerEntry: Reverting host change of loadbalancer %s from '%s' to '%s'",
-                    load_balancer.id, candidate, removal_host)
-        self._loadbalancer_repo.update(db_apis.get_session(), load_balancer.id, server_group_id=removal_host)
+
+        LOG.warning("RewriteLoadBalancerEntry: Reverting host change of loadbalancer %s: Changing host from '%s' to '%s' and availability zone back to '%s'.",
+                    load_balancer.id, candidate, removal_host, load_balancer.availability_zone)
+        self._loadbalancer_repo.update(db_apis.get_session(), load_balancer.id,
+                server_group_id=removal_host, availability_zone=load_balancer.availability_zone)

--- a/octavia_f5/api/drivers/f5_driver/tasks/reschedule_tasks.py
+++ b/octavia_f5/api/drivers/f5_driver/tasks/reschedule_tasks.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import json
 from abc import ABCMeta
 
 from oslo_config import cfg
@@ -21,7 +22,8 @@ from taskflow.types import failure
 
 from octavia.common import data_models as models
 from octavia.db import api as db_apis
-from octavia_f5.db import repositories as repo
+from octavia.db import repositories as repo
+from octavia_f5.db import repositories as f5_repo
 
 LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
@@ -32,8 +34,9 @@ class RescheduleTasks(task.Task, metaclass=ABCMeta):
     def __init__(self, **kwargs):
         self.rpc = kwargs.pop("rpc", None)
         super(RescheduleTasks, self).__init__(**kwargs)
-        self._loadbalancer_repo = repo.LoadBalancerRepository()
-        self._amphora_repo = repo.AmphoraRepository()
+        self._loadbalancer_repo = f5_repo.LoadBalancerRepository()
+        self._amphora_repo = f5_repo.AmphoraRepository()
+        self._azp_repo = repo.AvailabilityZoneProfileRepository()
 
 
 class GetLoadBalancerByID(RescheduleTasks):
@@ -106,9 +109,22 @@ class RewriteAmphoraEntry(RescheduleTasks):
 
 class RewriteLoadBalancerEntry(RescheduleTasks):
     def execute(self, load_balancer: models.LoadBalancer, candidate: str, *args, **kwargs):
-        LOG.debug("RewriteLoadBalancerEntry %s: Changing host '%s' to '%s'.",
-                  load_balancer.id, load_balancer.server_group_id, candidate)
-        self._loadbalancer_repo.update(db_apis.get_session(), load_balancer.id, server_group_id=candidate)
+        with db_apis.get_session() as session:
+
+            # find out new availability zone
+            azps, _ = self._azp_repo.get_all(session)
+            az = None
+            for azp in azps:
+                azd = json.loads(azp.availability_zone_data)
+                hosts = azd.get('hosts')
+                if hosts and candidate in hosts:
+                    az = azp.name
+                    break
+
+            # adjust load balancer DB entry
+            LOG.debug("RewriteLoadBalancerEntry for LB %s: Changing host from '%s' to '%s' and availability zone from '%s' to '%s'.",
+                      load_balancer.id, load_balancer.server_group_id, candidate, load_balancer.availability_zone, az)
+            self._loadbalancer_repo.update(session, load_balancer.id, server_group_id=candidate, availability_zone=az)
 
     def revert(self, result, load_balancer: models.LoadBalancer, candidate: str, removal_host: str, **kwargs):
         """Handle a failure to force adding a loadbalancer."""


### PR DESCRIPTION
When a LB DB entry is rewritten after it has been rescheduled, it can be considered expected behavior to also adjust the availability zone.

Tested in QA with both cases; Rescheduling to an AZ-aware device and rescheduling away from an AZ-aware device.