### PR TITLE
pythonpackage.yml: Set Ubuntu version to 22.04

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: [3.8]


### PR DESCRIPTION
We use Ubuntu 22.04 in our deployments. Also, [the ubuntu-latest tag was recently changed from 22.04 to 24.04](https://github.com/actions/runner-images/commit/976232da217887825e7541c2635bf39cbbf22654), which [doesn't include Python3.8](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#python) anymore, [as opposed to 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#python).
[This made our GH Actions fail](https://github.com/sapcc/octavia-f5-provider-driver/actions/runs/12885340847/job/35923567140?pr=282).

This commit pins the Ubuntu version for the "Python package" workflow to 22.04.