### PR TITLE
Run ensure L2 flow dependently on both devices

### DIFF
--- a/octavia_f5/controller/statusmanager/status_manager.py
+++ b/octavia_f5/controller/statusmanager/status_manager.py
@@ -192,14 +192,7 @@ class StatusManager(object):
             timeout = CONF.status_manager.failover_timeout
 
             # Try reaching device
-            available = True
-            try:
-                requests.get(bigip.scheme + '://' + bigip.hostname, timeout=timeout, verify=False)
-                LOG.info('Found device with URL {}'.format(bigip.hostname))
-            except requests.exceptions.Timeout:
-                LOG.info('Device timed out, considering it unavailable. Timeout: {}s Hostname: {}'.format(
-                         timeout, bigip.hostname))
-                available = False
+            available = bigip.is_available(timeout)
 
             if self.bigip_status[bigip.hostname] != available:
                 # Update database entry

--- a/octavia_f5/controller/statusmanager/status_manager.py
+++ b/octavia_f5/controller/statusmanager/status_manager.py
@@ -18,7 +18,6 @@ import time
 import futurist
 import oslo_messaging as messaging
 import prometheus_client as prometheus
-import requests
 from oslo_config import cfg
 from oslo_db import exception as db_exc
 from oslo_log import log as logging

--- a/octavia_f5/controller/worker/flows/f5_flows.py
+++ b/octavia_f5/controller/worker/flows/f5_flows.py
@@ -30,22 +30,19 @@ class F5Flows(object):
 
         We have to inject all required variables to each flow/task because these flows will
         be running as part of Graph flow and storage contains equal variables but for two F5
-        devices, their variables' names overlap. devices, their variables' names overlap. Also
-        in graph flow, every subflow/task should have a unique name that's why we have to add
-        BigIP hostname.
+        devices, their variables' names overlap. Also in graph flow, every subflow/task should
+        have a unique name that's why we have to add BigIP hostname.
         """
-
+        bigip_hostname = store["bigip"].hostname
         # make SelfIP creation subflow
         ensure_selfips_subflow = unordered_flow.Flow(
-            f'ensure-selfips-subflow-{store["bigip"].hostname}')
+            f'ensure-selfips-subflow-{bigip_hostname}')
         for selfip_port in selfips:
             ensure_selfip_task = f5_tasks.EnsureSelfIP(
-                name=f'ensure-selfip-{selfip_port.id}-{store["bigip"].hostname}',
+                name=f'ensure-selfip-{bigip_hostname}-{selfip_port.id}',
                 inject={
                     'port': selfip_port,
-                    'bigip': store['bigip'],
-                    'network': store['network'],
-                    'existing_selfips': store['existing_selfips']
+                    **store
                 }
             )
             ensure_selfips_subflow.add(ensure_selfip_task)
@@ -55,60 +52,37 @@ class F5Flows(object):
         subnets_to_create_routes_for = [subnet for subnet in network.subnets
                                         if not f5_tasks.selfip_for_subnet_exists(subnet, selfips)]
         ensure_subnet_routes_subflow = unordered_flow.Flow(
-            f'ensure-subnet-routes-subflow-{store["bigip"].hostname}')
+            f'ensure-subnet-routes-subflow-{bigip_hostname}')
 
         # make subnet route creation subflow
         for subnet_id in subnets_to_create_routes_for:
             subnet_route_name = f5_tasks.get_subnet_route_name(network.id, subnet_id)
             ensure_subnet_route_task = f5_tasks.EnsureSubnetRoute(
-                name=f'ensure-subnet-route-{subnet_route_name}-{store["bigip"].hostname}',
+                name=f'ensure-subnet-route-{subnet_route_name}-{bigip_hostname}',
                 inject={
                     'subnet_id': subnet_id,
-                    'bigip': store['bigip'],
-                    'network': store['network'],
-                    'existing_subnet_routes': store['existing_subnet_routes']
+                    **store
                 }
             )
             ensure_subnet_routes_subflow.add(ensure_subnet_route_task)
 
         get_existing_route_domain = f5_tasks.GetExistingRouteDomain(
-            name=f'get-existing-route-domain-{store["bigip"].hostname}',
-            inject={
-                'bigip': store['bigip'],
-                'network': store['network']
-            }
-        )
+            name=f'get-existing-route-domain-{bigip_hostname}',
+            inject=store)
         ensure_route_domain = f5_tasks.EnsureRouteDomain(
-            name=f'ensure-route-domain-{store["bigip"].hostname}',
-            inject={
-                'bigip': store['bigip'],
-                'network': store['network']
-            }
-        )
+            name=f'ensure-route-domain-{bigip_hostname}',
+            inject=store)
         ensure_default_route = f5_tasks.EnsureDefaultRoute(
-            name=f'ensure-default-route-{store["bigip"].hostname}',
-            inject={
-                'bigip': store['bigip'],
-                'network': store['network'],
-                'subnet_id': store['subnet_id'],
-            }
-        )
+            name=f'ensure-default-route-{bigip_hostname}',
+            inject=store)
         get_existing_vlan = f5_tasks.GetExistingVLAN(
-            name=f'get-existing-vlan-{store["bigip"].hostname}',
-            inject={
-                'bigip': store['bigip'],
-                'network': store['network']
-            }
-        )
+            name=f'get-existing-vlan-{bigip_hostname}',
+            inject=store)
         ensure_vlan = f5_tasks.EnsureVLAN(
-            name=f'ensure-vlan-{store["bigip"].hostname}',
-            inject={
-                'bigip': store['bigip'],
-                'network': store['network']
-            }
-        )
+            name=f'ensure-vlan-{bigip_hostname}',
+            inject=store)
 
-        ensure_l2_flow = linear_flow.Flow(f'ensure-l2-flow-{store["bigip"].hostname}')
+        ensure_l2_flow = linear_flow.Flow(f'ensure-l2-flow-{bigip_hostname}')
         ensure_l2_flow.add(get_existing_vlan,
                            ensure_vlan,
                            get_existing_route_domain,
@@ -241,7 +215,7 @@ class F5Flows(object):
         ensure_selfips_subflow = unordered_flow.Flow('ensure-selfips-subflow')
         for selfip_port in selfips_to_create:
             ensure_selfip_task = f5_tasks.EnsureSelfIP(
-                name=f'ensure-selfip-{selfip_port.id}-{store["bigip"].hostname}',
+                name=f'ensure-selfip-{store["bigip"].hostname}-{selfip_port.id}',
                 inject={'port': selfip_port})
             ensure_selfips_subflow.add(ensure_selfip_task)
 

--- a/octavia_f5/controller/worker/flows/f5_flows.py
+++ b/octavia_f5/controller/worker/flows/f5_flows.py
@@ -27,34 +27,91 @@ class F5Flows(object):
         """
         Construct and return a flow to ensure complete L2 configuration for a new partition.
         The flow assumes that no L2 objects exist yet for the network so nothing is cleaned up.
+
+        We have to inject all required variables to each flow/task because these flows will
+        be running as part of Graph flow and storage contains equal variables but for two F5
+        devices, their variables' names overlap. devices, their variables' names overlap. Also
+        in graph flow, every subflow/task should have a unique name that's why we have to add
+        BigIP hostname.
         """
 
         # make SelfIP creation subflow
-        ensure_selfips_subflow = unordered_flow.Flow('ensure-selfips-subflow')
+        ensure_selfips_subflow = unordered_flow.Flow(
+            f'ensure-selfips-subflow-{store["bigip"].hostname}')
         for selfip_port in selfips:
             ensure_selfip_task = f5_tasks.EnsureSelfIP(
-                name=f"ensure-selfip-{selfip_port.id}", inject={'port': selfip_port})
+                name=f'ensure-selfip-{selfip_port.id}-{store["bigip"].hostname}',
+                inject={
+                    'port': selfip_port,
+                    'bigip': store['bigip'],
+                    'network': store['network'],
+                    'existing_selfips': store['existing_selfips']
+                }
+            )
             ensure_selfips_subflow.add(ensure_selfip_task)
 
         # create subnet routes for all subnets that don't have a SelfIP
         network = store['network']
         subnets_to_create_routes_for = [subnet for subnet in network.subnets
                                         if not f5_tasks.selfip_for_subnet_exists(subnet, selfips)]
-        ensure_subnet_routes_subflow = unordered_flow.Flow('ensure-subnet-routes-subflow')
+        ensure_subnet_routes_subflow = unordered_flow.Flow(
+            f'ensure-subnet-routes-subflow-{store["bigip"].hostname}')
 
         # make subnet route creation subflow
         for subnet_id in subnets_to_create_routes_for:
             subnet_route_name = f5_tasks.get_subnet_route_name(network.id, subnet_id)
-            ensure_subnet_route_task = f5_tasks.EnsureSubnetRoute(name=f"ensure-subnet-route-{subnet_route_name}",
-                                                                  inject={'subnet_id': subnet_id})
+            ensure_subnet_route_task = f5_tasks.EnsureSubnetRoute(
+                name=f'ensure-subnet-route-{subnet_route_name}-{store["bigip"].hostname}',
+                inject={
+                    'subnet_id': subnet_id,
+                    'bigip': store['bigip'],
+                    'network': store['network'],
+                    'existing_subnet_routes': store['existing_subnet_routes']
+                }
+            )
             ensure_subnet_routes_subflow.add(ensure_subnet_route_task)
 
-        ensure_route_domain = f5_tasks.EnsureRouteDomain()
-        ensure_default_route = f5_tasks.EnsureDefaultRoute()
-        ensure_vlan = f5_tasks.EnsureVLAN()
+        get_existing_route_domain = f5_tasks.GetExistingRouteDomain(
+            name=f'get-existing-route-domain-{store["bigip"].hostname}',
+            inject={
+                'bigip': store['bigip'],
+                'network': store['network']
+            }
+        )
+        ensure_route_domain = f5_tasks.EnsureRouteDomain(
+            name=f'ensure-route-domain-{store["bigip"].hostname}',
+            inject={
+                'bigip': store['bigip'],
+                'network': store['network']
+            }
+        )
+        ensure_default_route = f5_tasks.EnsureDefaultRoute(
+            name=f'ensure-default-route-{store["bigip"].hostname}',
+            inject={
+                'bigip': store['bigip'],
+                'network': store['network'],
+                'subnet_id': store['subnet_id'],
+            }
+        )
+        get_existing_vlan = f5_tasks.GetExistingVLAN(
+            name=f'get-existing-vlan-{store["bigip"].hostname}',
+            inject={
+                'bigip': store['bigip'],
+                'network': store['network']
+            }
+        )
+        ensure_vlan = f5_tasks.EnsureVLAN(
+            name=f'ensure-vlan-{store["bigip"].hostname}',
+            inject={
+                'bigip': store['bigip'],
+                'network': store['network']
+            }
+        )
 
-        ensure_l2_flow = linear_flow.Flow('ensure-l2-flow')
-        ensure_l2_flow.add(ensure_vlan,
+        ensure_l2_flow = linear_flow.Flow(f'ensure-l2-flow-{store["bigip"].hostname}')
+        ensure_l2_flow.add(get_existing_vlan,
+                           ensure_vlan,
+                           get_existing_route_domain,
                            ensure_route_domain,
                            # SelfIPs must be present for routes to work
                            ensure_selfips_subflow,
@@ -184,7 +241,8 @@ class F5Flows(object):
         ensure_selfips_subflow = unordered_flow.Flow('ensure-selfips-subflow')
         for selfip_port in selfips_to_create:
             ensure_selfip_task = f5_tasks.EnsureSelfIP(
-                name=f"ensure-selfip-{selfip_port.id}", inject={'port': selfip_port})
+                name=f'ensure-selfip-{selfip_port.id}-{store["bigip"].hostname}',
+                inject={'port': selfip_port})
             ensure_selfips_subflow.add(ensure_selfip_task)
 
         # find subnet routes for subnets that need them but don't have any yet
@@ -226,12 +284,14 @@ class F5Flows(object):
         return get_existing_sip_sr_flow
 
     def make_ensure_vcmp_l2_flow(self) -> flow.Flow:
+        get_existing_vlan = f5_tasks.GetExistingVLAN()
         ensure_vlan = f5_tasks.EnsureVLAN()
         ensure_vlan_interface = f5_tasks.EnsureVLANInterface()
         ensure_guest_vlan = f5_tasks.EnsureGuestVLAN()
 
         ensure_vcmp_l2_flow = linear_flow.Flow('ensure-vcmp-l2-flow')
-        ensure_vcmp_l2_flow.add(ensure_vlan,
+        ensure_vcmp_l2_flow.add(get_existing_vlan,
+                                ensure_vlan,
                                 ensure_vlan_interface,
                                 ensure_guest_vlan)
         return ensure_vcmp_l2_flow

--- a/octavia_f5/controller/worker/flows/f5_flows.py
+++ b/octavia_f5/controller/worker/flows/f5_flows.py
@@ -58,7 +58,7 @@ class F5Flows(object):
         for subnet_id in subnets_to_create_routes_for:
             subnet_route_name = f5_tasks.get_subnet_route_name(network.id, subnet_id)
             ensure_subnet_route_task = f5_tasks.EnsureSubnetRoute(
-                name=f'ensure-subnet-route-{subnet_route_name}-{bigip_hostname}',
+                name=f'ensure-subnet-route-{bigip_hostname}-{subnet_route_name}',
                 inject={
                     'subnet_id': subnet_id,
                     **store

--- a/octavia_f5/controller/worker/l2_sync_manager.py
+++ b/octavia_f5/controller/worker/l2_sync_manager.py
@@ -20,7 +20,7 @@ import requests
 from oslo_config import cfg
 from oslo_log import log as logging
 from taskflow.listeners import logging as tf_logging
-from taskflow.patterns import graph_flow
+from taskflow.patterns import unordered_flow
 
 from octavia.common import data_models as octavia_models
 from octavia.common.base_taskflow import BaseTaskFlowEngine
@@ -85,7 +85,7 @@ class L2SyncManager(BaseTaskFlowEngine):
             bigip.update_status()
 
     def _do_ensure_l2_flow(self, data: dict):
-        ensure_l2_flow = graph_flow.Flow('ensure-l2-flow-from-all-devices')
+        ensure_l2_flow = unordered_flow.Flow('ensure-l2-flow-from-all-devices')
         for flow_data in data.values():
             # get existing SelfIPs and subnet routes - they are needed to determine,
             # which ones have to be created and which already exist

--- a/octavia_f5/controller/worker/l2_sync_manager.py
+++ b/octavia_f5/controller/worker/l2_sync_manager.py
@@ -197,6 +197,7 @@ class L2SyncManager(BaseTaskFlowEngine):
 
             # Check if device available by symple GET request
             if not bigip.is_available(timeout=CONF.status_manager.failover_timeout):
+                LOG.debug(f"Device {bigip.hostname} is unreachable for API requests.")
                 continue
 
             selfips_for_host = [selfip for selfip in selfips if bigip.hostname in selfip.name]

--- a/octavia_f5/controller/worker/l2_sync_manager.py
+++ b/octavia_f5/controller/worker/l2_sync_manager.py
@@ -20,6 +20,7 @@ import requests
 from oslo_config import cfg
 from oslo_log import log as logging
 from taskflow.listeners import logging as tf_logging
+from taskflow.patterns import graph_flow
 
 from octavia.common import data_models as octavia_models
 from octavia.common.base_taskflow import BaseTaskFlowEngine
@@ -83,21 +84,26 @@ class L2SyncManager(BaseTaskFlowEngine):
         for bigip in self._bigips:
             bigip.update_status()
 
-    def _do_ensure_l2_flow(self, selfips: [network_models.Port], store: dict):
+    def _do_ensure_l2_flow(self, data: dict):
+        ensure_l2_flow = graph_flow.Flow('ensure-l2-flow-from-all-devices')
+        for flow_data in data.values():
+            # get existing SelfIPs and subnet routes - they are needed to determine,
+            # which ones have to be created and which already exist
+            e = self.taskflow_load(self._f5flows.make_get_existing_selfips_and_subnet_routes_flow(),
+                                   store=flow_data['store'])
+            with tf_logging.LoggingListener(e, log=LOG):
+                e.run()
 
-        # get existing SelfIPs and subnet routes - they are needed to determine,
-        # which ones have to be created and which already exist
-        e = self.taskflow_load(self._f5flows.make_get_existing_selfips_and_subnet_routes_flow(), store=store)
-        with tf_logging.LoggingListener(e, log=LOG):
-            e.run()
+            # info about existing SelfIPs and subnet routes could be needed for either
+            # flow construction or in the tasks themselves, or both
+            flow_data['store']['existing_selfips'] = e.storage.get('get-existing-selfips')
+            flow_data['store']['existing_subnet_routes'] = e.storage.get('get-existing-subnet-routes')
 
-        # info about existing SelfIPs and subnet routes could be needed for either
-        # flow construction or in the tasks themselves, or both
-        store['existing_selfips'] = e.storage.get('get-existing-selfips')
-        store['existing_subnet_routes'] = e.storage.get('get-existing-subnet-routes')
+            ensure_l2_flow.add(
+                self._f5flows.make_ensure_l2_flow(
+                    flow_data['selfips'], store=flow_data['store']))
 
-        ensure_l2_flow = self._f5flows.make_ensure_l2_flow(selfips, store=store)
-        e = self.taskflow_load(ensure_l2_flow, store=store)
+        e = self.taskflow_load(ensure_l2_flow)
         with tf_logging.DynamicLoggingListener(e, log=LOG):
             e.run()
 
@@ -180,14 +186,20 @@ class L2SyncManager(BaseTaskFlowEngine):
 
         # run l2 flow for all devices in parallel
         fs = {}
+        ensure_l2_flow_data = {}
         for bigip in self._bigips:
             if device and bigip.hostname != device:
                 continue
 
             selfips_for_host = [selfip for selfip in selfips if bigip.hostname in selfip.name]
             subnet_ids = set(sip.fixed_ips[0].subnet_id for sip in selfips_for_host)
-            store = {'bigip': bigip, 'network': network, 'subnet_id': subnet_ids.pop()}
-            fs[self.executor.submit(self._do_ensure_l2_flow, selfips=selfips_for_host, store=store)] = bigip
+            ensure_l2_flow_data[bigip.hostname] = {
+                'store': {'bigip': bigip, 'network': network, 'subnet_id': subnet_ids.pop()},
+                'selfips': selfips_for_host,
+            }
+        fs[self.executor.submit(
+            self._do_ensure_l2_flow,
+            data=ensure_l2_flow_data)] = ','.join(ensure_l2_flow_data.keys())
 
         # run VCMP l2 flow for all VCMPs in parallel
         for vcmp in self._vcmps:

--- a/octavia_f5/controller/worker/l2_sync_manager.py
+++ b/octavia_f5/controller/worker/l2_sync_manager.py
@@ -103,6 +103,10 @@ class L2SyncManager(BaseTaskFlowEngine):
                 self._f5flows.make_ensure_l2_flow(
                     flow_data['selfips'], store=flow_data['store']))
 
+        # We have to inject all required variables to each flow/task because these flows will
+        # be running as part of Graph flow and storage contains equal variables but for two F5
+        # devices, their variables' names overlap. Also in graph flow, every subflow/task should
+        # have a unique name that's why we have to add BigIP hostname.
         e = self.taskflow_load(ensure_l2_flow)
         with tf_logging.DynamicLoggingListener(e, log=LOG):
             e.run()

--- a/octavia_f5/controller/worker/l2_sync_manager.py
+++ b/octavia_f5/controller/worker/l2_sync_manager.py
@@ -195,6 +195,10 @@ class L2SyncManager(BaseTaskFlowEngine):
             if device and bigip.hostname != device:
                 continue
 
+            # Check if device available by symple GET request
+            if not bigip.is_available(timeout=CONF.status_manager.failover_timeout):
+                continue
+
             selfips_for_host = [selfip for selfip in selfips if bigip.hostname in selfip.name]
             subnet_ids = set(sip.fixed_ips[0].subnet_id for sip in selfips_for_host)
             ensure_l2_flow_data[bigip.hostname] = {

--- a/octavia_f5/controller/worker/tasks/f5_tasks.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks.py
@@ -274,7 +274,6 @@ class EnsureSelfIP(task.Task):
 class GetExistingVLAN(task.Task):
     default_provides = 'existing_vlan'
 
-    @decorators.RaisesIControlRestError()
     def execute(self, bigip: bigip_restclient.BigIPRestClient,
                 network: f5_network_models.Network):
         device_response = bigip.get(path=f"/mgmt/tm/net/vlan/~Common~vlan-{network.vlan_id}?expandSubcollections=true")
@@ -286,7 +285,6 @@ class GetExistingVLAN(task.Task):
 class GetExistingRouteDomain(task.Task):
     default_provides = 'existing_route_domain'
 
-    @decorators.RaisesIControlRestError()
     def execute(self, bigip: bigip_restclient.BigIPRestClient,
                 network: f5_network_models.Network):
         device_response = bigip.get(path=f"/mgmt/tm/net/route-domain/vlan-{network.vlan_id}")

--- a/octavia_f5/controller/worker/tasks/f5_tasks.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks.py
@@ -53,8 +53,8 @@ class EnsureVLAN(task.Task):
     )
     def execute(self,
                 bigip: bigip_restclient.BigIPRestClient,
-                network: f5_network_models.Network):
-
+                network: f5_network_models.Network,
+                existing_vlan: dict):
         vlan = {
             'name': f'vlan-{network.vlan_id}',
             'tag': network.vlan_id,
@@ -64,22 +64,33 @@ class EnsureVLAN(task.Task):
             'syncacheThreshold': CONF.networking.syncache_threshold
         }
 
-        device_response = bigip.get(path=f"/mgmt/tm/net/vlan/~Common~{vlan['name']}?expandSubcollections=true")
         # Create vlan if not existing
-        if device_response.status_code == 404:
+        if existing_vlan is None:
             res = bigip.post(path='/mgmt/tm/net/vlan', json=vlan)
             res.raise_for_status()
             return res.json()
 
-        device_vlan = device_response.json()
-        if not vlan.items() <= device_vlan.items():
+        if not vlan.items() <= existing_vlan.items():
             res = bigip.patch(path=f"/mgmt/tm/net/vlan/~Common~{vlan['name']}",
                               json=vlan)
             res.raise_for_status()
             return res.json()
 
         # No Changes needed
-        return device_vlan
+        return existing_vlan
+
+    @decorators.RaisesIControlRestError()
+    def revert(self, network: f5_network_models.Network,
+               bigip: bigip_restclient.BigIPRestClient,
+               existing_vlan, *args, **kwargs):
+        if existing_vlan is not None:
+            LOG.warning(f"Reverting EnsureVLAN: Not deleting VLAN, since it existed before "
+                        f"the task was run: {existing_vlan}")
+            return
+        res = bigip.delete(path=f"/mgmt/tm/net/vlan/~Common~vlan-{network.vlan_id}")
+        if not res.ok:
+            LOG.warning("%s: Failed removing VLAN for vlan_id=%s: %s",
+                        bigip.hostname, network.vlan_id, res.content)
 
 
 class EnsureVLANInterface(task.Task):
@@ -158,29 +169,48 @@ class EnsureRouteDomain(task.Task):
         stop=tenacity.stop_after_attempt(3)
     )
     def execute(self, network: f5_network_models.Network,
-                bigip: bigip_restclient.BigIPRestClient):
-
+                bigip: bigip_restclient.BigIPRestClient,
+                existing_route_domain: dict):
         vlans = [f"/Common/vlan-{network.vlan_id}"]
         rd = {'name': f"vlan-{network.vlan_id}", 'vlans': vlans, 'id': network.vlan_id}
 
-        device_response = bigip.get(path=f"/mgmt/tm/net/route-domain/{rd['name']}")
-        if device_response.status_code == 404:
-            path = f"/mgmt/tm/net/route-domain/net-{network.id}"
-            device_response = bigip.get(path=path)
-
         # Create route_domain if not existing
-        if device_response.status_code == 404:
+        if existing_route_domain is None:
             res = bigip.post(path='/mgmt/tm/net/route-domain', json=rd)
             res.raise_for_status()
             return res.json()
 
-        device_rd = device_response.json()
-        if device_rd.get('vlans', []) != vlans:
-            res = bigip.patch(path=f"/mgmt/tm/net/route-domain/{device_rd['fullPath']}",
+        if existing_route_domain.get('vlans', []) != vlans:
+            res = bigip.patch(path=f"/mgmt/tm/net/route-domain/{existing_route_domain['fullPath']}",
                               json={'vlans': vlans})
             res.raise_for_status()
             return res.json()
-        return device_rd
+
+        return existing_route_domain
+
+    @decorators.RaisesIControlRestError()
+    def revert(self, network: f5_network_models.Network,
+               bigip: bigip_restclient.BigIPRestClient,
+               existing_route_domain, *args, **kwargs):
+        paths = [
+            f"/mgmt/tm/net/route-domain/vlan-{network.vlan_id}",
+            f"/mgmt/tm/net/route-domain/net-{network.id}"
+        ]
+        if existing_route_domain is not None:
+            LOG.warning(f"Reverting EnsureRouteDomain: Not deleting RouteDomain, since it existed before "
+                        f"the task was run: {existing_route_domain}")
+            return
+
+        """ Task to delete Route Domain """
+        res = None
+        for path in paths:
+            if bigip.get(path=path).ok:
+                res = bigip.delete(path=path)
+                break
+
+        if res and not res.ok:
+            LOG.warning("%s: Failed removing route domain for network_id=%s vlan_id=%s: %s",
+                        bigip.hostname, network.id, network.vlan_id, res.content)
 
 
 class EnsureSelfIP(task.Task):
@@ -190,7 +220,6 @@ class EnsureSelfIP(task.Task):
     def execute(self, bigip: bigip_restclient.BigIPRestClient,
                 network: f5_network_models.Network,
                 port: network_models.Port):
-
         # payload
         name = f"port-{port.id}"
         vlan = f"/Common/vlan-{network.vlan_id}"
@@ -225,7 +254,6 @@ class EnsureSelfIP(task.Task):
                bigip: bigip_restclient.BigIPRestClient,
                existing_selfips, *args, **kwargs):
         selfip_name = f"port-{port.id}"
-
         # don't remove the SelfIP if it existed before this task was executed
         if port.id in [p['port_id'] for p in existing_selfips]:
             LOG.warning("Reverting EnsureSelfIP: Not deleting SelfIP, since it existed before the task was run: "
@@ -239,6 +267,34 @@ class EnsureSelfIP(task.Task):
             LOG.warning(f"Reverting EnsureSelfIP: SelfIP {selfip_name} was already removed")
         else:
             device_response.raise_for_status()
+
+
+class GetExistingVLAN(task.Task):
+    default_provides = 'existing_vlan'
+
+    @decorators.RaisesIControlRestError()
+    def execute(self, bigip: bigip_restclient.BigIPRestClient,
+                network: f5_network_models.Network):
+        device_response = bigip.get(path=f"/mgmt/tm/net/vlan/~Common~vlan-{network.vlan_id}?expandSubcollections=true")
+        if device_response.status_code == 404:
+            return None
+        return device_response.json()
+
+
+class GetExistingRouteDomain(task.Task):
+    default_provides = 'existing_route_domain'
+
+    @decorators.RaisesIControlRestError()
+    def execute(self, bigip: bigip_restclient.BigIPRestClient,
+                network: f5_network_models.Network):
+        device_response = bigip.get(path=f"/mgmt/tm/net/route-domain/vlan-{network.vlan_id}")
+        if device_response.status_code == 404:
+            path = f"/mgmt/tm/net/route-domain/net-{network.id}"
+            device_response = bigip.get(path=path)
+
+        if device_response.status_code == 404:
+            return None
+        return device_response.json()
 
 
 class GetExistingSelfIPsForVLAN(task.Task):
@@ -289,7 +345,6 @@ class EnsureDefaultRoute(task.Task):
     def execute(self, bigip: bigip_restclient.BigIPRestClient,
                 subnet_id: str,
                 network: f5_network_models.Network):
-
         if CONF.networking.route_on_active and not bigip.is_active:
             # Skip passive device if route_on_active is enabled
             return None
@@ -334,7 +389,6 @@ class EnsureSubnetRoute(task.Task):
     def execute(self, bigip: bigip_restclient.BigIPRestClient,
                 network: f5_network_models.Network,
                 subnet_id):
-
         # Skip passive device if route_on_active is enabled
         if CONF.networking.route_on_active and not bigip.is_active:
             return
@@ -374,7 +428,6 @@ class EnsureSubnetRoute(task.Task):
                subnet_id, existing_subnet_routes,
                *args, **kwargs):
         subnet_route_name = get_subnet_route_name(network.id, subnet_id)
-
         # Don't remove the route if it existed before this task was executed
         if subnet_route_name in [r['name'] for r in existing_subnet_routes]:
             LOG.warning("Reverting EnsureSubnetRoute: Not deleting route, since it existed before the task was run: "

--- a/octavia_f5/controller/worker/tasks/f5_tasks.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks.py
@@ -89,8 +89,9 @@ class EnsureVLAN(task.Task):
             return
         res = bigip.delete(path=f"/mgmt/tm/net/vlan/~Common~vlan-{network.vlan_id}")
         if not res.ok:
-            LOG.warning("%s: Failed removing VLAN for vlan_id=%s: %s",
-                        bigip.hostname, network.vlan_id, res.content)
+            LOG.warning("Reverting EnsureVLAN: Failed removing VLAN on the device %s for "
+                        "vlan_id=%s: %s", bigip.hostname, network.vlan_id, res.content)
+            res.raise_for_status()
 
 
 class EnsureVLANInterface(task.Task):
@@ -201,7 +202,6 @@ class EnsureRouteDomain(task.Task):
                         f"the task was run: {existing_route_domain}")
             return
 
-        """ Task to delete Route Domain """
         res = None
         for path in paths:
             if bigip.get(path=path).ok:
@@ -209,8 +209,10 @@ class EnsureRouteDomain(task.Task):
                 break
 
         if res and not res.ok:
-            LOG.warning("%s: Failed removing route domain for network_id=%s vlan_id=%s: %s",
+            LOG.warning("Reverting EnsureRouteDomain: Failed removing route domain on the device %s "
+                        "for network_id=%s vlan_id=%s: %s",
                         bigip.hostname, network.id, network.vlan_id, res.content)
+            res.raise_for_status()
 
 
 class EnsureSelfIP(task.Task):

--- a/octavia_f5/restclient/bigip/bigip_restclient.py
+++ b/octavia_f5/restclient/bigip/bigip_restclient.py
@@ -71,8 +71,25 @@ class BigIPRestClient(requests.Session):
 
     @property
     def is_active(self):
+        """
+        Get active device which is MASTER device in F5 devices pair.
+        """
         self.update_status()
         return self._active
+
+    def is_available(self, timeout: int):
+        """
+        Check if BigIP device is available for communications.
+        """
+        available = True
+        try:
+            requests.get(self.url.scheme + '://' + self.url.hostname, timeout=timeout, verify=False)
+            LOG.info('Found device with URL {}'.format(self.url.hostname))
+        except requests.exceptions.Timeout:
+            LOG.info('Device timed out, considering it unavailable. Timeout: {}s Hostname: {}'.format(
+                     timeout, self.url.hostname))
+            available = False
+        return available
 
     def update_status(self):
         """ Update status if device is active or not

--- a/octavia_f5/restclient/bigip/bigip_restclient.py
+++ b/octavia_f5/restclient/bigip/bigip_restclient.py
@@ -72,7 +72,7 @@ class BigIPRestClient(requests.Session):
     @property
     def is_active(self):
         """
-        Get active device which is MASTER device in F5 devices pair.
+        Get active device which is active device in F5 devices pair.
         """
         self.update_status()
         return self._active

--- a/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
+++ b/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
@@ -148,7 +148,7 @@ class TestL2SyncManager(base.TestCase):
             id='test-subnet-id', gateway_ip='1.2.3.1',
             cidr='1.2.3.0/24', network_id='test-network-id')
         mock_network = f5_network_models.Network(
-            mtu=9000, id='test-network-id', subnets=['test-subnet-id'],
+            mtu=8950, id='test-network-id', subnets=['test-subnet-id'],
             segments=[{'provider:physical_network': 'physnet',
                        'provider:segmentation_id': 1234}]
         )
@@ -186,7 +186,7 @@ class TestL2SyncManager(base.TestCase):
             }
         }
         self.manager._do_ensure_l2_flow(data=data)
-        # check thath both devices were called and REVERT task were not called
+        # check thath both devices were called and REVERT tasks were not called
         self.assertEqual(mock_bigips[0].get.call_count, 9)
         self.assertEqual(mock_bigips[1].get.call_count, 9)
         self.assertEqual(mock_bigips[0].post.call_count, 5)
@@ -202,7 +202,7 @@ class TestL2SyncManager(base.TestCase):
             id='test-subnet-id', gateway_ip='1.2.3.1',
             cidr='1.2.3.0/24', network_id='test-network-id')
         mock_network = f5_network_models.Network(
-            mtu=9000, id='test-network-id', subnets=['test-subnet-id'],
+            mtu=8950, id='test-network-id', subnets=['test-subnet-id'],
             segments=[{'provider:physical_network': 'physnet',
                        'provider:segmentation_id': 1234}]
         )
@@ -258,7 +258,7 @@ class TestL2SyncManager(base.TestCase):
         }
         # self.manager._do_ensure_l2_flow(data=data)
         self.assertRaises(Exception, self.manager._do_ensure_l2_flow, data=data)
-        # check thath both devices were called and REVERT task were not called
+        # check thath both devices were called and REVERT tasks were also called
         self.assertEqual(mock_bigip_1.get.call_count, 10)
         self.assertEqual(mock_bigip_2.get.call_count, 7)
         self.assertEqual(mock_bigip_1.post.call_count, 5)

--- a/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
+++ b/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
@@ -24,6 +24,8 @@ from octavia.network import data_models as network_models
 # pylint: disable=unused-import
 from octavia_f5.common import config  # noqa
 from octavia_f5.controller.worker import l2_sync_manager
+from octavia_f5.network import data_models as f5_network_models
+from octavia_f5.restclient import as3restclient
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
@@ -38,6 +40,20 @@ MOCK_SELFIP = network_models.Port(
     name=f"local-{MOCK_BIGIP_HOSTNAME}-{MOCK_FIXED_IP.subnet_id}",
     fixed_ips=[MOCK_FIXED_IP]
 )
+
+
+class MockResponse:
+    def __init__(self, json_data, status_code):
+        self.json_data = json_data
+        self.status_code = status_code
+        self.ok = status_code < 400
+
+    def json(self):
+        return self.json_data
+
+    def raise_for_status(self):
+        if self.status_code > 500:
+            raise Exception('Boom!')
 
 
 class TestL2SyncManager(base.TestCase):
@@ -68,9 +84,12 @@ class TestL2SyncManager(base.TestCase):
         other_selfip = network_models.Port(
             name=f"local-OTHER_HOST-{uuidutils.generate_uuid()}")
         self.manager.ensure_l2_flow([MOCK_SELFIP, other_selfip], 'test-network-id')
-        mock_l2_flow.assert_called_once_with(selfips=[MOCK_SELFIP],
-            store={'bigip': self.manager._bigips[0], 'network': mock_get_network.return_value,
-                   'subnet_id': MOCK_FIXED_IP.subnet_id})
+        mock_l2_flow.assert_called_once_with(data={
+            'test-guest-hostname': {
+                'selfips': [MOCK_SELFIP],
+                'store': {'bigip': self.manager._bigips[0],
+                          'network': mock_get_network.return_value,
+                          'subnet_id': MOCK_FIXED_IP.subnet_id}}})
         mock_vcmp_l2_flow.assert_called_once_with(
             store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
                    'bigip_guest_names': [MOCK_BIGIP_HOSTNAME]})
@@ -88,9 +107,12 @@ class TestL2SyncManager(base.TestCase):
                     override_vcmp_guest_names=['test-host-2'])
 
         self.manager.ensure_l2_flow([MOCK_SELFIP], 'test-network-id')
-        mock_l2_flow.assert_called_once_with(selfips=[MOCK_SELFIP],
-            store={'bigip': self.manager._bigips[0], 'network': mock_get_network.return_value,
-                   'subnet_id': MOCK_FIXED_IP.subnet_id})
+        mock_l2_flow.assert_called_once_with(data={
+            'test-guest-hostname': {
+                'selfips': [MOCK_SELFIP],
+                'store': {'bigip': self.manager._bigips[0],
+                          'network': mock_get_network.return_value,
+                          'subnet_id': MOCK_FIXED_IP.subnet_id}}})
         mock_vcmp_l2_flow.assert_called_once_with(
             store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
                    'bigip_guest_names': ['test-host-2']})
@@ -109,9 +131,154 @@ class TestL2SyncManager(base.TestCase):
             self.assertEqual("Failed ensure_l2_flow for all vcmp devices of network_id=test-network-id",
                              e.args[0])
 
-        mock_l2_flow.assert_called_once_with(selfips=[MOCK_SELFIP],
-            store={'bigip': self.manager._bigips[0], 'network': mock_get_network.return_value,
-                   'subnet_id': MOCK_FIXED_IP.subnet_id})
+        mock_l2_flow.assert_called_once_with(data={
+            'test-guest-hostname': {
+                'selfips': [MOCK_SELFIP],
+                'store': {'bigip': self.manager._bigips[0],
+                          'network': mock_get_network.return_value,
+                          'subnet_id': MOCK_FIXED_IP.subnet_id}}})
         mock_vcmp_l2_flow.assert_called_once_with(
             store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
                    'bigip_guest_names': [MOCK_BIGIP_HOSTNAME]})
+
+    @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
+                ".get_subnet")
+    def test__do_ensure_l2_flow_nothing_exist_no_errors(self, mock_get_subnet):
+        mock_get_subnet.return_value = network_models.Subnet(
+            id='test-subnet-id', gateway_ip='1.2.3.1',
+            cidr='1.2.3.0/24', network_id='test-network-id')
+        mock_network = f5_network_models.Network(
+            mtu=9000, id='test-network-id', subnets=['test-subnet-id'],
+            segments=[{'provider:physical_network': 'physnet',
+                       'provider:segmentation_id': 1234}]
+        )
+        selfip_fixed_ip = network_models.FixedIP(
+            ip_address='1.2.3.2', subnet_id='test-subnet-id-2')
+        selfip_port = network_models.Port(
+            id='test-selfip-port-id', fixed_ips=[selfip_fixed_ip],
+        )
+        mock_bigips = []
+        for i in range(0, 2):
+            mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+            mock_bigip.hostname = f'hostname-{i}'
+            mock_bigip.get.side_effect = [
+                MockResponse({}, 404) for _ in range(9)]
+            mock_bigips.append(mock_bigip)
+        mock_bigips[0].is_active = True
+        data = {
+            mock_bigips[0].hostname: {
+                'selfips': [selfip_port],
+                'store': {
+                    'network': mock_network,
+                    'bigip': mock_bigips[0],
+                    'subnet_id': 'test-subnet-id',
+                    'existing_selfips': []
+                }
+            },
+            mock_bigips[1].hostname: {
+                'selfips': [selfip_port],
+                'store': {
+                    'network': mock_network,
+                    'bigip': mock_bigips[1],
+                    'subnet_id': 'test-subnet-id',
+                    'existing_selfips': []
+                }
+            }
+        }
+        self.manager._do_ensure_l2_flow(data=data)
+        # check thath both devices were called and REVERT task were not called
+        self.assertEqual(mock_bigips[0].get.call_count, 9)
+        self.assertEqual(mock_bigips[1].get.call_count, 9)
+        self.assertEqual(mock_bigips[0].post.call_count, 5)
+        self.assertEqual(mock_bigips[1].post.call_count, 5)
+        self.assertEqual(mock_bigips[0].delete.call_count, 0)
+        self.assertEqual(mock_bigips[1].delete.call_count, 0)
+
+    @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
+                ".get_subnet")
+    def test__do_ensure_l2_flow_nothing_exist_route_domain_failed_on_second_device(
+            self, mock_get_subnet):
+        mock_get_subnet.return_value = network_models.Subnet(
+            id='test-subnet-id', gateway_ip='1.2.3.1',
+            cidr='1.2.3.0/24', network_id='test-network-id')
+        mock_network = f5_network_models.Network(
+            mtu=9000, id='test-network-id', subnets=['test-subnet-id'],
+            segments=[{'provider:physical_network': 'physnet',
+                       'provider:segmentation_id': 1234}]
+        )
+        selfip_fixed_ip = network_models.FixedIP(
+            ip_address='1.2.3.2', subnet_id='test-subnet-id-2')
+        selfip_port = network_models.Port(
+            id='test-selfip-port-id', fixed_ips=[selfip_fixed_ip],
+        )
+        mock_bigip_1 = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip_1.hostname = 'hostname-1'
+        mock_bigip_1.is_active = True
+        mock_bigip_1.get.side_effect = [
+            MockResponse({}, 404),
+            MockResponse({}, 404),
+            MockResponse({}, 404),
+            MockResponse({}, 404),
+            MockResponse({}, 404),
+            MockResponse({}, 404),
+            MockResponse({}, 404),
+            MockResponse({}, 404),
+            MockResponse({}, 404),
+            MockResponse({}, 200),
+        ]
+        mock_bigip_2 = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip_2.hostname = 'hostname-2'
+        mock_bigip_2.get.side_effect = [
+            MockResponse({}, 404) for _ in range(8)]
+        mock_bigip_2.post.side_effect = [
+            # VLAN creation
+            MockResponse({}, 202),
+            # Route Domain creation
+            MockResponse({}, 502)
+        ]
+        data = {
+            'hostname-1': {
+                'selfips': [selfip_port],
+                'store': {
+                    'network': mock_network,
+                    'bigip': mock_bigip_1,
+                    'subnet_id': 'test-subnet-id',
+                    'existing_selfips': []
+                }
+            },
+            'hostname-2': {
+                'selfips': [selfip_port],
+                'store': {
+                    'network': mock_network,
+                    'bigip': mock_bigip_2,
+                    'subnet_id': 'test-subnet-id',
+                    'existing_selfips': []
+                }
+            }
+        }
+        # self.manager._do_ensure_l2_flow(data=data)
+        self.assertRaises(Exception, self.manager._do_ensure_l2_flow, data=data)
+        # check thath both devices were called and REVERT task were not called
+        self.assertEqual(mock_bigip_1.get.call_count, 10)
+        self.assertEqual(mock_bigip_2.get.call_count, 7)
+        self.assertEqual(mock_bigip_1.post.call_count, 5)
+        self.assertEqual(mock_bigip_2.post.call_count, 2)
+        self.assertEqual(mock_bigip_1.delete.call_count, 4)
+        self.assertEqual(mock_bigip_2.delete.call_count, 1)
+        bigip_1_delete_calls = [
+            # check that VLAN reverted
+            mock.call(path='/mgmt/tm/net/vlan/~Common~vlan-1234'),
+            # check that Route Domaun was reverted
+            mock.call(path='/mgmt/tm/net/route-domain/vlan-1234'),
+            # Check that Self IP was reverted
+            mock.call(path='/mgmt/tm/net/self/port-test-selfip-port-id'),
+            # check that Subnet Route was reverted
+            mock.call(path='/mgmt/tm/net/route/~Common~net_test-network-id_sub_test-subnet-id')
+        ]
+        mock_bigip_1.delete.assert_has_calls(bigip_1_delete_calls, any_order=True)
+        bigip_2_delete_calls = [
+            # check that VLAN reverted
+            mock.call(path='/mgmt/tm/net/vlan/~Common~vlan-1234'),
+        ]
+        mock_bigip_2.delete.assert_has_calls(bigip_2_delete_calls, any_order=True)
+

--- a/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
+++ b/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
@@ -63,13 +63,18 @@ class TestL2SyncManager(base.TestCase):
                     network_driver='network_noop_driver_f5')
         with mock.patch("octavia_f5.controller.worker.l2_sync_manager.L2SyncManager"
                         ".initialize_bigips") as init_bigips:
-            self.bigip = mock.Mock()
-            self.bigip.hostname = MOCK_BIGIP_HOSTNAME
+            bigips = []
+            vcmps = []
+            for i in range(2):
+                bigip = mock.Mock()
+                bigip.hostname = f"{MOCK_BIGIP_HOSTNAME}_{i}"
+                bigips.append(bigip)
 
-            self.vcmp = mock.Mock()
-            self.vcmp.hostname = MOCK_VCMP_HOSTNAME
+                vcmp = mock.Mock()
+                vcmp.hostname = f"{MOCK_VCMP_HOSTNAME}_{i}"
+                vcmps.append(vcmp)
 
-            init_bigips.side_effect = [[self.bigip], [self.vcmp]]
+            init_bigips.side_effect = [bigips, vcmps]
             self.manager = l2_sync_manager.L2SyncManager()
         super(TestL2SyncManager, self).setUp()
 
@@ -79,20 +84,81 @@ class TestL2SyncManager(base.TestCase):
                 "L2SyncManager._do_ensure_l2_flow")
     @mock.patch('octavia_f5.network.drivers.noop_driver_f5.driver.'
                 'NoopNetworkDriverF5.get_network')
-    def test_ensure_l2_flow(self, mock_get_network,
+    def test_ensure_l2_flow_all_available(self, mock_get_network,
                             mock_l2_flow, mock_vcmp_l2_flow):
-        other_selfip = network_models.Port(
-            name=f"local-OTHER_HOST-{uuidutils.generate_uuid()}")
-        self.manager.ensure_l2_flow([MOCK_SELFIP, other_selfip], 'test-network-id')
+        mocked_selfips = [
+            network_models.Port(
+                name=f"local-{MOCK_BIGIP_HOSTNAME}_0-{MOCK_FIXED_IP.subnet_id}",
+                fixed_ips=[MOCK_FIXED_IP]
+            ),
+            network_models.Port(
+                name=f"local-{MOCK_BIGIP_HOSTNAME}_1-{MOCK_FIXED_IP.subnet_id}",
+                fixed_ips=[MOCK_FIXED_IP]
+            ),
+            network_models.Port(
+                name=f"local-OTHER_HOST-{uuidutils.generate_uuid()}")
+        ]
+        self.manager.ensure_l2_flow(mocked_selfips, 'test-network-id')
         mock_l2_flow.assert_called_once_with(data={
-            'test-guest-hostname': {
-                'selfips': [MOCK_SELFIP],
+            'test-guest-hostname_0': {
+                'selfips': [mocked_selfips[0]],
                 'store': {'bigip': self.manager._bigips[0],
                           'network': mock_get_network.return_value,
-                          'subnet_id': MOCK_FIXED_IP.subnet_id}}})
-        mock_vcmp_l2_flow.assert_called_once_with(
-            store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
-                   'bigip_guest_names': [MOCK_BIGIP_HOSTNAME]})
+                          'subnet_id': MOCK_FIXED_IP.subnet_id}},
+            'test-guest-hostname_1': {
+                'selfips': [mocked_selfips[1]],
+                'store': {'bigip': self.manager._bigips[1],
+                          'network': mock_get_network.return_value,
+                          'subnet_id': MOCK_FIXED_IP.subnet_id}}
+        })
+        self.assertEqual(mock_vcmp_l2_flow.call_count, 2)
+        vcmp_l2_flow_calls = [
+            mock.call(store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
+                   'bigip_guest_names': [MOCK_BIGIP_HOSTNAME + "_0", MOCK_BIGIP_HOSTNAME + "_1"]}),
+            mock.call(store={'bigip': self.manager._vcmps[1], 'network': mock_get_network.return_value,
+                   'bigip_guest_names': [MOCK_BIGIP_HOSTNAME + "_0", MOCK_BIGIP_HOSTNAME + "_1"]})
+        ]
+        mock_vcmp_l2_flow.assert_has_calls(vcmp_l2_flow_calls, any_order=True)
+
+    @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
+                "L2SyncManager._do_ensure_vcmp_l2_flow")
+    @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
+                "L2SyncManager._do_ensure_l2_flow")
+    @mock.patch('octavia_f5.network.drivers.noop_driver_f5.driver.'
+                'NoopNetworkDriverF5.get_network')
+    def test_ensure_l2_flow_second_unavailable(self, mock_get_network,
+                                               mock_l2_flow, mock_vcmp_l2_flow):
+        mocked_selfips = [
+            network_models.Port(
+                name=f"local-{MOCK_BIGIP_HOSTNAME}_0-{MOCK_FIXED_IP.subnet_id}",
+                fixed_ips=[MOCK_FIXED_IP]
+            ),
+            network_models.Port(
+                name=f"local-{MOCK_BIGIP_HOSTNAME}_1-{MOCK_FIXED_IP.subnet_id}",
+                fixed_ips=[MOCK_FIXED_IP]
+            ),
+            network_models.Port(
+                name=f"local-OTHER_HOST-{uuidutils.generate_uuid()}")
+        ]
+        self.manager._bigips[1].is_available.side_effect = [False]
+        self.manager.ensure_l2_flow(mocked_selfips, 'test-network-id')
+        self.manager._bigips[1].is_available.assert_called_once_with(timeout=5)
+        # expect only one call for BigIP, only for available device
+        mock_l2_flow.assert_called_once_with(data={
+            'test-guest-hostname_0': {
+                'selfips': [mocked_selfips[0]],
+                'store': {'bigip': self.manager._bigips[0],
+                          'network': mock_get_network.return_value,
+                          'subnet_id': MOCK_FIXED_IP.subnet_id}}
+        })
+        self.assertEqual(mock_vcmp_l2_flow.call_count, 2)
+        vcmp_l2_flow_calls = [
+            mock.call(store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
+                   'bigip_guest_names': [MOCK_BIGIP_HOSTNAME + "_0", MOCK_BIGIP_HOSTNAME + "_1"]}),
+            mock.call(store={'bigip': self.manager._vcmps[1], 'network': mock_get_network.return_value,
+                   'bigip_guest_names': [MOCK_BIGIP_HOSTNAME + "_0", MOCK_BIGIP_HOSTNAME + "_1"]})
+        ]
+        mock_vcmp_l2_flow.assert_has_calls(vcmp_l2_flow_calls, any_order=True)
 
     @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
                 "L2SyncManager._do_ensure_vcmp_l2_flow")
@@ -105,19 +171,41 @@ class TestL2SyncManager(base.TestCase):
         conf = self.useFixture(oslo_fixture.Config(cfg.CONF))
         conf.config(group='networking',
                     override_vcmp_guest_names=['test-host-2'])
-
-        self.manager.ensure_l2_flow([MOCK_SELFIP], 'test-network-id')
+        mocked_selfips = [
+            network_models.Port(
+                name=f"local-{MOCK_BIGIP_HOSTNAME}_0-{MOCK_FIXED_IP.subnet_id}",
+                fixed_ips=[MOCK_FIXED_IP]
+            ),
+            network_models.Port(
+                name=f"local-{MOCK_BIGIP_HOSTNAME}_1-{MOCK_FIXED_IP.subnet_id}",
+                fixed_ips=[MOCK_FIXED_IP]
+            ),
+            network_models.Port(
+                name=f"local-OTHER_HOST-{uuidutils.generate_uuid()}")
+        ]
+        self.manager.ensure_l2_flow(mocked_selfips, 'test-network-id')
         mock_l2_flow.assert_called_once_with(data={
-            'test-guest-hostname': {
-                'selfips': [MOCK_SELFIP],
+            'test-guest-hostname_0': {
+                'selfips': [mocked_selfips[0]],
                 'store': {'bigip': self.manager._bigips[0],
                           'network': mock_get_network.return_value,
-                          'subnet_id': MOCK_FIXED_IP.subnet_id}}})
-        mock_vcmp_l2_flow.assert_called_once_with(
-            store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
+                          'subnet_id': MOCK_FIXED_IP.subnet_id}},
+            'test-guest-hostname_1': {
+                'selfips': [mocked_selfips[1]],
+                'store': {'bigip': self.manager._bigips[1],
+                          'network': mock_get_network.return_value,
+                          'subnet_id': MOCK_FIXED_IP.subnet_id}}
+        })
+        self.assertEqual(mock_vcmp_l2_flow.call_count, 2)
+        vcmp_l2_flow_calls = [
+            mock.call(store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
+                   'bigip_guest_names': ['test-host-2']}),
+            mock.call(store={'bigip': self.manager._vcmps[1], 'network': mock_get_network.return_value,
                    'bigip_guest_names': ['test-host-2']})
+        ]
+        mock_vcmp_l2_flow.assert_has_calls(vcmp_l2_flow_calls, any_order=True)
 
-    @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
+    @mock.patch("octavia_f5.controller.worker.l2_sync_manager." 
                 "L2SyncManager._do_ensure_vcmp_l2_flow", side_effect=Exception('Boom!'))
     @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
                 "L2SyncManager._do_ensure_l2_flow")
@@ -125,21 +213,42 @@ class TestL2SyncManager(base.TestCase):
                 'NoopNetworkDriverF5.get_network')
     def test_ensure_l2_flow_exception(self, mock_get_network,
                                           mock_l2_flow, mock_vcmp_l2_flow):
+        mocked_selfips = [
+            network_models.Port(
+                name=f"local-{MOCK_BIGIP_HOSTNAME}_0-{MOCK_FIXED_IP.subnet_id}",
+                fixed_ips=[MOCK_FIXED_IP]
+            ),
+            network_models.Port(
+                name=f"local-{MOCK_BIGIP_HOSTNAME}_1-{MOCK_FIXED_IP.subnet_id}",
+                fixed_ips=[MOCK_FIXED_IP]
+            ),
+        ]
         try:
-            self.manager.ensure_l2_flow([MOCK_SELFIP], 'test-network-id')
+            self.manager.ensure_l2_flow(mocked_selfips, 'test-network-id')
         except Exception as e:
             self.assertEqual("Failed ensure_l2_flow for all vcmp devices of network_id=test-network-id",
                              e.args[0])
 
         mock_l2_flow.assert_called_once_with(data={
-            'test-guest-hostname': {
-                'selfips': [MOCK_SELFIP],
+            'test-guest-hostname_0': {
+                'selfips': [mocked_selfips[0]],
                 'store': {'bigip': self.manager._bigips[0],
                           'network': mock_get_network.return_value,
-                          'subnet_id': MOCK_FIXED_IP.subnet_id}}})
-        mock_vcmp_l2_flow.assert_called_once_with(
-            store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
-                   'bigip_guest_names': [MOCK_BIGIP_HOSTNAME]})
+                          'subnet_id': MOCK_FIXED_IP.subnet_id}},
+            'test-guest-hostname_1': {
+                'selfips': [mocked_selfips[1]],
+                'store': {'bigip': self.manager._bigips[1],
+                          'network': mock_get_network.return_value,
+                          'subnet_id': MOCK_FIXED_IP.subnet_id}}
+        })
+        self.assertEqual(mock_vcmp_l2_flow.call_count, 2)
+        vcmp_l2_flow_calls = [
+            mock.call(store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
+                   'bigip_guest_names': [MOCK_BIGIP_HOSTNAME + "_0", MOCK_BIGIP_HOSTNAME + "_1"]}),
+            mock.call(store={'bigip': self.manager._vcmps[1], 'network': mock_get_network.return_value,
+                   'bigip_guest_names': [MOCK_BIGIP_HOSTNAME + "_0", MOCK_BIGIP_HOSTNAME + "_1"]})
+        ]
+        mock_vcmp_l2_flow.assert_has_calls(vcmp_l2_flow_calls, any_order=True)
 
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")


### PR DESCRIPTION
This PR changes `ensure_l2_flow` to synchronize both F5 devices dependently. This change implements:

1. unordered flow for both synchronizations and it means if one device fails the changes on the second device will be reverted
2. revert function for `EnsureVLAN`
3. revert function for `EnsureRouteDomain`

How the task flow graph was before:
![independant_sync_2](https://github.com/user-attachments/assets/6feff529-8662-4746-b320-4da1d3d831f1)

How it will be when this PR merged:
![atomic_sync](https://github.com/user-attachments/assets/369fdbc4-1180-485c-a318-9d37fcbd832c)

The same changes (using `unordered_flow`) are coming soon for `remove_l2_flow`.