### PR TITLE
pylint.yml: Specify ubuntu-22.04

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: [3.8]


### PR DESCRIPTION
Same reason as in 37c025148c358c5920c1802b228361a29b058377, even though this workflow didn't break (yet).