### PR TITLE
Add retries for Barbican

### DIFF
--- a/octavia_f5/utils/cert_manager.py
+++ b/octavia_f5/utils/cert_manager.py
@@ -21,6 +21,7 @@ from oslo_config import cfg
 from oslo_context import context as oslo_context
 from stevedore import driver as stevedore_driver
 
+from octavia.common import exceptions as octavia_exc
 from octavia.common.tls_utils import cert_parser
 from octavia_f5.common import constants
 from octavia_f5.restclient.as3objects import certificate as m_cert
@@ -42,8 +43,7 @@ class CertManagerWrapper(object):
 
     @tenacity.retry(
         retry=tenacity.retry_if_exception_type(
-            (urllib_exc.NewConnectionError,
-             requests_exc.ConnectionError)),
+            (octavia_exc.CertificateRetrievalException)),
         wait=tenacity.wait_incrementing(
             RETRY_INITIAL_DELAY, RETRY_BACKOFF, RETRY_MAX),
         stop=tenacity.stop_after_attempt(RETRY_ATTEMPTS))
@@ -84,8 +84,7 @@ class CertManagerWrapper(object):
 
     @tenacity.retry(
         retry=tenacity.retry_if_exception_type(
-            (urllib_exc.NewConnectionError,
-             requests_exc.ConnectionError)),
+            (octavia_exc.CertificateRetrievalException)),
         wait=tenacity.wait_incrementing(
             RETRY_INITIAL_DELAY, RETRY_BACKOFF, RETRY_MAX),
         stop=tenacity.stop_after_attempt(RETRY_ATTEMPTS))

--- a/octavia_f5/utils/cert_manager.py
+++ b/octavia_f5/utils/cert_manager.py
@@ -13,6 +13,9 @@
 # under the License.
 
 import hashlib
+import tenacity
+from requests import exceptions as requests_exc
+from urllib3 import exceptions as urllib_exc
 
 from oslo_config import cfg
 from oslo_context import context as oslo_context
@@ -23,6 +26,10 @@ from octavia_f5.common import constants
 from octavia_f5.restclient.as3objects import certificate as m_cert
 
 CONF = cfg.CONF
+RETRY_ATTEMPTS = 15
+RETRY_INITIAL_DELAY = 1
+RETRY_BACKOFF = 1
+RETRY_MAX = 5
 
 
 class CertManagerWrapper(object):
@@ -33,6 +40,13 @@ class CertManagerWrapper(object):
             invoke_on_load=True,
         ).driver
 
+    @tenacity.retry(
+        retry=tenacity.retry_if_exception_type(
+            (urllib_exc.NewConnectionError,
+             requests_exc.ConnectionError)),
+        wait=tenacity.wait_incrementing(
+            RETRY_INITIAL_DELAY, RETRY_BACKOFF, RETRY_MAX),
+        stop=tenacity.stop_after_attempt(RETRY_ATTEMPTS))
     def get_certificates(self, obj, context=None):
         """Fetches certificates and creates dict out of octavia objects
 
@@ -68,6 +82,13 @@ class CertManagerWrapper(object):
 
         return certificates
 
+    @tenacity.retry(
+        retry=tenacity.retry_if_exception_type(
+            (urllib_exc.NewConnectionError,
+             requests_exc.ConnectionError)),
+        wait=tenacity.wait_incrementing(
+            RETRY_INITIAL_DELAY, RETRY_BACKOFF, RETRY_MAX),
+        stop=tenacity.stop_after_attempt(RETRY_ATTEMPTS))
     def load_secret(self, project_id, secret_ref):
         """Loads secrets from secret store
 

--- a/octavia_f5/utils/cert_manager.py
+++ b/octavia_f5/utils/cert_manager.py
@@ -41,7 +41,7 @@ class CertManagerWrapper(object):
 
     @tenacity.retry(
         retry=tenacity.retry_if_exception_type(
-            (octavia_exc.CertificateRetrievalException)),
+            octavia_exc.CertificateRetrievalException),
         wait=tenacity.wait_incrementing(
             RETRY_INITIAL_DELAY, RETRY_BACKOFF, RETRY_MAX),
         stop=tenacity.stop_after_attempt(RETRY_ATTEMPTS))
@@ -82,7 +82,7 @@ class CertManagerWrapper(object):
 
     @tenacity.retry(
         retry=tenacity.retry_if_exception_type(
-            (octavia_exc.CertificateRetrievalException)),
+            octavia_exc.CertificateRetrievalException),
         wait=tenacity.wait_incrementing(
             RETRY_INITIAL_DELAY, RETRY_BACKOFF, RETRY_MAX),
         stop=tenacity.stop_after_attempt(RETRY_ATTEMPTS))

--- a/octavia_f5/utils/cert_manager.py
+++ b/octavia_f5/utils/cert_manager.py
@@ -14,8 +14,6 @@
 
 import hashlib
 import tenacity
-from requests import exceptions as requests_exc
-from urllib3 import exceptions as urllib_exc
 
 from oslo_config import cfg
 from oslo_context import context as oslo_context


### PR DESCRIPTION
This PR adds a simple retries mechanism for requests to Barbican. Hardcoded values were used to keep the same style for calls of this decorator: https://github.com/search?q=repo%3Asapcc%2Foctavia-f5-provider-driver%20%22tenacity.retry%22&type=code