### PR TITLE
Run remove L2 flow dependently on both devices

### DIFF
--- a/octavia_f5/controller/worker/flows/f5_flows.py
+++ b/octavia_f5/controller/worker/flows/f5_flows.py
@@ -94,35 +94,69 @@ class F5Flows(object):
         return ensure_l2_flow
 
     def make_remove_l2_flow(self, store: dict) -> flow.Flow:
-        """Construct and return a flow to remove complete L2 configuration of a partition."""
+        """
+        Construct and return a flow to remove complete L2 configuration of a partition.
+
+        We have to inject all required variables to each flow/task because these flows will
+        be running as part of main flow and storage contains equal variables but for two F5
+        devices, their variables' names overlap. Also in one flow, every subflow/task should
+        have a unique name that's why we have to add BigIP hostname.
+        """
+        bigip_hostname = store["bigip"].hostname
+
         existing_selfips = store['existing_selfips']
         existing_subnet_routes = store['existing_subnet_routes']
 
         # remove subnet routes
-        remove_subnet_routes_subflow = unordered_flow.Flow('remove-subnet-routes-subflow')
+        remove_subnet_routes_subflow = unordered_flow.Flow(
+            f'remove-subnet-routes-subflow-{bigip_hostname}')
         for subnet_route in existing_subnet_routes:
-            remove_subnet_route_task = f5_tasks.RemoveSubnetRoute(name=f"remove-subnet-route-{subnet_route['name']}",
-                                                                  inject={'subnet_route': subnet_route})
+            remove_subnet_route_task = f5_tasks.RemoveSubnetRoute(
+                name=f"remove-subnet-route-{bigip_hostname}-{subnet_route['name']}",
+                inject={
+                    'subnet_route': subnet_route,
+                    **store
+                }
+            )
             remove_subnet_routes_subflow.add(remove_subnet_route_task)
 
         # remove SelfIPs
-        remove_selfips_subflow = unordered_flow.Flow('remove-selfips-subflow')
+        remove_selfips_subflow = unordered_flow.Flow(f'remove-selfips-subflow-{bigip_hostname}')
         for selfip in existing_selfips:
-            remove_selfip_task = f5_tasks.RemoveSelfIP(name=f"remove-selfip-{selfip['port_id']}",
-                                                       inject={'selfip': selfip})
+            remove_selfip_task = f5_tasks.RemoveSelfIP(
+                name=f"remove-selfip-{bigip_hostname}-{selfip['port_id']}",
+                inject={
+                    'selfip': selfip,
+                    **store
+                }
+            )
             remove_selfips_subflow.add(remove_selfip_task)
 
         # remove other L2 objects
-        remove_default_route_task = f5_tasks.RemoveDefaultRoute()
-        remove_route_domain_task = f5_tasks.RemoveRouteDomain()
-        remove_vlan_task = f5_tasks.RemoveVLAN()
+        remove_default_route_task = f5_tasks.RemoveDefaultRoute(
+            name=f'remove-defult-route-{bigip_hostname}',
+            inject=store)
+        get_existing_route_domain = f5_tasks.GetExistingRouteDomain(
+            name=f'get-existing-route-domain-{bigip_hostname}',
+            inject=store)
+        remove_route_domain_task = f5_tasks.RemoveRouteDomain(
+            name=f'remove-route-domain-{bigip_hostname}',
+            inject=store)
+        get_existing_vlan = f5_tasks.GetExistingVLAN(
+            name=f'get-existing-vlan-{bigip_hostname}',
+            inject=store)
+        remove_vlan_task = f5_tasks.RemoveVLAN(
+            name=f'remove-vlan-{bigip_hostname}',
+            inject=store)
 
-        remove_l2_flow = linear_flow.Flow('remove-l2-flow')
+        remove_l2_flow = linear_flow.Flow(f'remove-l2-flow-{bigip_hostname}')
         remove_l2_flow.add(remove_subnet_routes_subflow,
                            remove_default_route_task,
                            # SelfIPs must be deleted after routes, otherwise a route would be unreachable
                            remove_selfips_subflow,
+                           get_existing_route_domain,
                            remove_route_domain_task,
+                           get_existing_vlan,
                            remove_vlan_task)
         return remove_l2_flow
 

--- a/octavia_f5/controller/worker/l2_sync_manager.py
+++ b/octavia_f5/controller/worker/l2_sync_manager.py
@@ -116,20 +116,23 @@ class L2SyncManager(BaseTaskFlowEngine):
         with tf_logging.DynamicLoggingListener(e, log=LOG):
             e.run()
 
-    def _do_remove_l2_flow(self, store: dict):
+    def _do_remove_l2_flow(self, data: dict):
+        remove_l2_flow = unordered_flow.Flow('remove-l2-flow-from-all-devices')
+        for flow_data in data.values():
+            # get existing SelfIPs and subnet routes
+            e = self.taskflow_load(self._f5flows.make_get_existing_selfips_and_subnet_routes_flow(),
+                                   store=flow_data['store'])
+            with tf_logging.LoggingListener(e, log=LOG):
+                e.run()
 
-        # get existing SelfIPs and subnet routes
-        e = self.taskflow_load(self._f5flows.make_get_existing_selfips_and_subnet_routes_flow(), store=store)
-        with tf_logging.LoggingListener(e, log=LOG):
-            e.run()
+            # info about existing SelfIPs and subnet routes could be needed for either
+            # flow construction or in the tasks themselves, or both
+            flow_data['store']['existing_selfips'] = e.storage.get('get-existing-selfips')
+            flow_data['store']['existing_subnet_routes'] = e.storage.get('get-existing-subnet-routes')
 
-        # info about existing SelfIPs and subnet routes could be needed for either
-        # flow construction or in the tasks themselves, or both
-        store['existing_selfips'] = e.storage.get('get-existing-selfips')
-        store['existing_subnet_routes'] = e.storage.get('get-existing-subnet-routes')
+            remove_l2_flow.add(self._f5flows.make_remove_l2_flow(store=flow_data['store']))
 
-        remove_l2_flow = self._f5flows.make_remove_l2_flow(store=store)
-        e = self.taskflow_load(remove_l2_flow, store=store)
+        e = self.taskflow_load(remove_l2_flow)
         with tf_logging.LoggingListener(e, log=LOG):
             e.run()
 
@@ -255,13 +258,25 @@ class L2SyncManager(BaseTaskFlowEngine):
                       network_id)
             return
 
+        # run l2 flow for all devices in parallel
         fs = {}
+        remove_l2_flow_data = {}
         for bigip in self._bigips:
             if device and bigip.hostname != device:
                 continue
 
-            store = {'bigip': bigip, 'network': network}
-            fs[self.executor.submit(self._do_remove_l2_flow, store=store)] = bigip
+            # Check if device available by symple GET request
+            if not bigip.is_available(timeout=CONF.status_manager.failover_timeout):
+                LOG.debug(f"Device {bigip.hostname} is unreachable for API requests.")
+                continue
+
+            remove_l2_flow_data[bigip.hostname] = {
+                'store': {'bigip': bigip, 'network': network},
+            }
+
+        fs[self.executor.submit(
+            self._do_remove_l2_flow,
+            data=remove_l2_flow_data)] = ','.join(remove_l2_flow_data.keys())
 
         if CONF.networking.override_vcmp_guest_names:
             guest_names = CONF.networking.override_vcmp_guest_names

--- a/octavia_f5/controller/worker/tasks/f5_tasks.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks.py
@@ -546,6 +546,8 @@ class RemoveSelfIP(task.Task):
 
 
 class RemoveRouteDomain(task.Task):
+
+    @decorators.RaisesIControlRestError()
     def execute(self, network: f5_network_models.Network,
                 bigip: bigip_restclient.BigIPRestClient,
                 existing_route_domain):

--- a/octavia_f5/controller/worker/tasks/f5_tasks.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks.py
@@ -17,6 +17,7 @@ from netaddr import IPNetwork
 from oslo_config import cfg
 from oslo_log import log as logging
 from taskflow import task
+from taskflow.types import failure
 
 from octavia.network import data_models as network_models
 from octavia_f5.common import constants
@@ -296,7 +297,6 @@ class GetExistingRouteDomain(task.Task):
             return None
         return device_response.json()
 
-
 class GetExistingSelfIPsForVLAN(task.Task):
     default_provides = 'existing_selfips'
 
@@ -547,34 +547,67 @@ class RemoveSelfIP(task.Task):
 
 class RemoveRouteDomain(task.Task):
     def execute(self, network: f5_network_models.Network,
-                bigip: bigip_restclient.BigIPRestClient):
-
-        paths = [
-            f"/mgmt/tm/net/route-domain/vlan-{network.vlan_id}",
-            f"/mgmt/tm/net/route-domain/net-{network.id}"
-        ]
+                bigip: bigip_restclient.BigIPRestClient,
+                existing_route_domain):
 
         """ Task to delete Route Domain """
-        res = None
-        for path in paths:
-            if bigip.get(path=path).ok:
-                res = bigip.delete(path=path)
-                break
+        if existing_route_domain is None:
+            return
+        res = bigip.delete(path=f"/mgmt/tm/net/route-domain/{existing_route_domain['fullPath']}")
+        res.raise_for_status()
 
-        if res and not res.ok:
-            LOG.warning("%s: Failed removing route domain for network_id=%s vlan_id=%s: %s",
-                        bigip.hostname, network.id, network.vlan_id, res.content)
-
+    @decorators.RaisesIControlRestError()
+    def revert(self,
+                bigip: bigip_restclient.BigIPRestClient,
+                existing_route_domain, result, *args, **kwargs):
+        if isinstance(result, failure.Failure):
+            # If this task failed it means that object was not removed
+            return
+        # Restore RouteDomain if it existed before
+        if existing_route_domain is not None:
+            res = bigip.post(
+                path='/mgmt/tm/net/route-domain',
+                json={
+                    'name': existing_route_domain['name'],
+                    'vlans': existing_route_domain['vlans'],
+                    'id': existing_route_domain['id']
+                }
+            )
+            res.raise_for_status()
 
 class RemoveVLAN(task.Task):
+
+    @decorators.RaisesIControlRestError()
     def execute(self, network: f5_network_models.Network,
-                bigip: bigip_restclient.BigIPRestClient):
+                bigip: bigip_restclient.BigIPRestClient,
+                existing_vlan: dict):
         """ Task to delete VLAN """
-        name = f'vlan-{network.vlan_id}'
-        res = bigip.delete(path=f"/mgmt/tm/net/vlan/~Common~{name}")
-        if not res.ok:
-            LOG.warning("%s: Failed removing VLAN for vlan_id=%s: %s",
-                        bigip.hostname, network.vlan_id, res.content)
+        if existing_vlan is None:
+            return
+        res = bigip.delete(path=f"/mgmt/tm/net/vlan/~Common~vlan-{network.vlan_id}")
+        res.raise_for_status()
+
+    @decorators.RaisesIControlRestError()
+    def revert(self,
+                bigip: bigip_restclient.BigIPRestClient,
+                existing_vlan: dict, result, *args, **kwargs):
+        if isinstance(result, failure.Failure):
+            # If this task failed it means that object was not removed
+            return
+        # Restore VLAN existed before
+        if existing_vlan is not None:
+            res = bigip.post(
+                path='/mgmt/tm/net/vlan',
+                json={
+                    'name': existing_vlan['name'],
+                    'tag': existing_vlan['tag'],
+                    'mtu': existing_vlan['mtu'],
+                    'hardwareSyncookie': existing_vlan['hardwareSyncookie'],
+                    'synFloodRateLimit': existing_vlan['synFloodRateLimit'],
+                    'syncacheThreshold': existing_vlan['syncacheThreshold']
+                }
+            )
+            res.raise_for_status()
 
 
 class GetVCMPGuests(task.Task):

--- a/octavia_f5/controller/worker/tasks/f5_tasks.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks.py
@@ -564,6 +564,9 @@ class RemoveRouteDomain(task.Task):
                 existing_route_domain, result, *args, **kwargs):
         if isinstance(result, failure.Failure):
             # If this task failed it means that object was not removed
+            LOG.warning("Revert task was called for removing route domain due to some errors, but deletion failed "
+                        f"on device: {bigip.hostname} for route domain: {existing_route_domain}. Usually, it means"
+                        "that route domain is still on the device as expected.")
             return
         # Restore RouteDomain if it existed before
         if existing_route_domain is not None:
@@ -595,6 +598,9 @@ class RemoveVLAN(task.Task):
                 existing_vlan: dict, result, *args, **kwargs):
         if isinstance(result, failure.Failure):
             # If this task failed it means that object was not removed
+            LOG.warning("Revert task was called for removing VLAN due to some errors, but deletion failed "
+                        f"on device: {bigip.hostname} for VLAN: {existing_vlan}. Usually, it means"
+                        "that VLAN is still on the device as expected.")
             return
         # Restore VLAN existed before
         if existing_vlan is not None:

--- a/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
+++ b/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
@@ -43,10 +43,11 @@ MOCK_SELFIP = network_models.Port(
 
 
 class MockResponse:
-    def __init__(self, json_data, status_code):
+    def __init__(self, json_data, status_code, content=""):
         self.json_data = json_data
         self.status_code = status_code
         self.ok = status_code < 400
+        self.content = content
 
     def json(self):
         return self.json_data
@@ -365,7 +366,7 @@ class TestL2SyncManager(base.TestCase):
                 }
             }
         }
-        # self.manager._do_ensure_l2_flow(data=data)
+
         self.assertRaises(Exception, self.manager._do_ensure_l2_flow, data=data)
         # check thath both devices were called and REVERT tasks were also called
         self.assertEqual(mock_bigip_1.get.call_count, 10)
@@ -377,9 +378,9 @@ class TestL2SyncManager(base.TestCase):
         bigip_1_delete_calls = [
             # check that VLAN reverted
             mock.call(path='/mgmt/tm/net/vlan/~Common~vlan-1234'),
-            # check that Route Domaun was reverted
+            # check that Route Domain was reverted
             mock.call(path='/mgmt/tm/net/route-domain/vlan-1234'),
-            # Check that Self IP was reverted
+            # check that Self IP was reverted
             mock.call(path='/mgmt/tm/net/self/port-test-selfip-port-id'),
             # check that Subnet Route was reverted
             mock.call(path='/mgmt/tm/net/route/~Common~net_test-network-id_sub_test-subnet-id')
@@ -391,3 +392,225 @@ class TestL2SyncManager(base.TestCase):
         ]
         mock_bigip_2.delete.assert_has_calls(bigip_2_delete_calls, any_order=True)
 
+    @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
+                "L2SyncManager._do_remove_vcmp_l2_flow")
+    @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
+                "L2SyncManager._do_remove_l2_flow")
+    @mock.patch('octavia_f5.network.drivers.noop_driver_f5.driver.'
+                'NoopNetworkDriverF5.get_network')
+    def test_remove_l2_flow_all_available(self, mock_get_network,
+                            mock_l2_flow, mock_vcmp_l2_flow):
+        self.manager.remove_l2_flow('test-network-id')
+        mock_l2_flow.assert_called_once_with(data={
+            'test-guest-hostname_0': {
+                'store': {'bigip': self.manager._bigips[0],
+                          'network': mock_get_network.return_value}},
+            'test-guest-hostname_1': {
+                'store': {'bigip': self.manager._bigips[1],
+                          'network': mock_get_network.return_value}}
+        })
+        self.assertEqual(mock_vcmp_l2_flow.call_count, 2)
+        vcmp_l2_flow_calls = [
+            mock.call(store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
+                   'bigip_guest_names': [MOCK_BIGIP_HOSTNAME + "_0", MOCK_BIGIP_HOSTNAME + "_1"]}),
+            mock.call(store={'bigip': self.manager._vcmps[1], 'network': mock_get_network.return_value,
+                   'bigip_guest_names': [MOCK_BIGIP_HOSTNAME + "_0", MOCK_BIGIP_HOSTNAME + "_1"]})
+        ]
+        mock_vcmp_l2_flow.assert_has_calls(vcmp_l2_flow_calls, any_order=True)
+
+    @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
+                "L2SyncManager._do_remove_vcmp_l2_flow")
+    @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
+                "L2SyncManager._do_remove_l2_flow")
+    @mock.patch('octavia_f5.network.drivers.noop_driver_f5.driver.'
+                'NoopNetworkDriverF5.get_network')
+    def test_remove_l2_flow_second_unavailable(self, mock_get_network,
+                                               mock_l2_flow, mock_vcmp_l2_flow):
+        self.manager._bigips[1].is_available.side_effect = [False]
+        self.manager.remove_l2_flow('test-network-id')
+        self.manager._bigips[1].is_available.assert_called_once_with(timeout=5)
+        # expect only one call for BigIP, only for available device
+        mock_l2_flow.assert_called_once_with(data={
+            'test-guest-hostname_0': {
+                'store': {'bigip': self.manager._bigips[0],
+                          'network': mock_get_network.return_value}}
+        })
+        self.assertEqual(mock_vcmp_l2_flow.call_count, 2)
+        vcmp_l2_flow_calls = [
+            mock.call(store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
+                   'bigip_guest_names': [MOCK_BIGIP_HOSTNAME + "_0", MOCK_BIGIP_HOSTNAME + "_1"]}),
+            mock.call(store={'bigip': self.manager._vcmps[1], 'network': mock_get_network.return_value,
+                   'bigip_guest_names': [MOCK_BIGIP_HOSTNAME + "_0", MOCK_BIGIP_HOSTNAME + "_1"]})
+        ]
+        mock_vcmp_l2_flow.assert_has_calls(vcmp_l2_flow_calls, any_order=True)
+
+    @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
+                ".get_subnet")
+    def test__do_remove_l2_flow_nothing_exist_no_errors(self, mock_get_subnet):
+        mock_get_subnet.return_value = network_models.Subnet(
+            id='test-subnet-id', gateway_ip='1.2.3.1',
+            cidr='1.2.3.0/24', network_id='test-network-id')
+        mock_network = f5_network_models.Network(
+            mtu=8950, id='test-network-id', subnets=['test-subnet-id'],
+            segments=[{'provider:physical_network': 'physnet',
+                       'provider:segmentation_id': 1234}]
+        )
+        mock_bigips = []
+        for i in range(0, 2):
+            mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+            mock_bigip.hostname = f'hostname-{i}'
+            mock_bigip.get.side_effect = [
+                MockResponse({}, 404) for _ in range(9)]
+            mock_bigips.append(mock_bigip)
+        mock_bigips[0].is_active = True
+        data = {
+            mock_bigips[0].hostname: {
+                'store': {
+                    'network': mock_network,
+                    'bigip': mock_bigips[0],
+                    'subnet_id': 'test-subnet-id',
+                }
+            },
+            mock_bigips[1].hostname: {
+                'store': {
+                    'network': mock_network,
+                    'bigip': mock_bigips[1],
+                    'subnet_id': 'test-subnet-id',
+                }
+            }
+        }
+        self.manager._do_remove_l2_flow(data=data)
+        # check thath both devices were called and REVERT tasks were not called
+        self.assertEqual(mock_bigips[0].get.call_count, 7)
+        self.assertEqual(mock_bigips[1].get.call_count, 7)
+        self.assertEqual(mock_bigips[0].post.call_count, 0)
+        self.assertEqual(mock_bigips[1].post.call_count, 0)
+        self.assertEqual(mock_bigips[0].delete.call_count, 0)
+        self.assertEqual(mock_bigips[1].delete.call_count, 0)
+
+    @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
+                ".get_subnet")
+    def test__do_remove_l2_flow_all_exist_vlan_failed_on_second_device(
+            self, mock_get_subnet):
+        mock_get_subnet.return_value = network_models.Subnet(
+            id='test-subnet-id', gateway_ip='1.2.3.1',
+            cidr='1.2.3.0/24', network_id='test-network-id')
+        mock_network = f5_network_models.Network(
+            mtu=8950, id='test-network-id', subnets=['test-subnet-id'],
+            segments=[{'provider:physical_network': 'physnet',
+                       'provider:segmentation_id': 1234}]
+        )
+        mock_bigip_1 = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip_1.hostname = 'hostname-1'
+        mock_bigip_1.is_active = True
+        mock_bigip_1.get.side_effect = [
+            MockResponse({}, 404),
+            MockResponse({}, 404),
+            # DefaultRoute
+            MockResponse({}, 200),
+            # RouteDomain
+            MockResponse(
+                {
+                    'name': 'vlan-1234',
+                    'vlans': ['/Common/vlan-1234'],
+                    'id': '1234',
+                    'fullPath': 'vlan-1234'
+                },
+                200
+            ),
+            # VLAN
+            MockResponse(
+                {
+                    'name': 'vlan-1234',
+                    'tag': 1234,
+                    'mtu': 8950,
+                    'hardwareSyncookie': 'enabled',
+                    'synFloodRateLimit': 123,
+                    'syncacheThreshold': 123
+                },
+                200
+            )
+        ]
+        mock_bigip_1.delete.side_effect = [
+            # DefaultRoute delete
+            MockResponse({}, 200),
+            # RouteDomain delete
+            MockResponse({}, 200),
+            # VLAN delete
+            MockResponse({}, 200)
+        ]
+        mock_bigip_2 = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip_2.hostname = 'hostname-2'
+        mock_bigip_2.get.side_effect = [
+            MockResponse({}, 404),
+            MockResponse({}, 404),
+            # DefaultRoute
+            MockResponse({}, 200),
+            # RouteDomain
+            MockResponse(
+                {
+                    'name': 'vlan-1234',
+                    'vlans': ['/Common/vlan-1234'],
+                    'id': '1234',
+                    'fullPath': 'vlan-1234'
+                },
+                200
+            ),
+            # VLAN
+            MockResponse(
+                {
+                    'name': 'vlan-1234',
+                    'tag': 1234,
+                    'mtu': 8950,
+                    'hardwareSyncookie': 'enabled',
+                    'synFloodRateLimit': 123,
+                    'syncacheThreshold': 123
+                },
+                200
+            )
+        ]
+        mock_bigip_2.delete.side_effect = [
+            # DefaultRoute delete
+            MockResponse({}, 200),
+            # RouteDomain delete
+            MockResponse({}, 200),
+            # VLAN delete
+            MockResponse({}, 502, "something happend")
+        ]
+        data = {
+            'hostname-1': {
+                'store': {
+                    'network': mock_network,
+                    'bigip': mock_bigip_1,
+                    'subnet_id': 'test-subnet-id',
+                }
+            },
+            'hostname-2': {
+                'store': {
+                    'network': mock_network,
+                    'bigip': mock_bigip_2,
+                    'subnet_id': 'test-subnet-id',
+                }
+            }
+        }
+        # self.manager._do_remove_l2_flow(data=data)
+        self.assertRaises(Exception, self.manager._do_remove_l2_flow, data=data)
+        # check thath both devices were called and REVERT tasks were not called
+        self.assertEqual(mock_bigip_1.get.call_count, 5)
+        self.assertEqual(mock_bigip_2.get.call_count, 5)
+        self.assertEqual(mock_bigip_1.post.call_count, 2)
+        self.assertEqual(mock_bigip_2.post.call_count, 1)
+        self.assertEqual(mock_bigip_1.delete.call_count, 3)
+        self.assertEqual(mock_bigip_2.delete.call_count, 3)
+        bigip_1_post_calls = [
+            # check that VLAN reverted
+            mock.call(path='/mgmt/tm/net/vlan', json={'name': 'vlan-1234', 'tag': 1234, 'mtu': 8950, 'hardwareSyncookie': 'enabled', 'synFloodRateLimit': 123, 'syncacheThreshold': 123}),
+            # check that RouteDomain was reverted
+            mock.call(path='/mgmt/tm/net/route-domain', json={'name': 'vlan-1234', 'vlans': ['/Common/vlan-1234'], 'id': '1234'}),
+        ]
+        mock_bigip_1.post.assert_has_calls(bigip_1_post_calls, any_order=True)
+        bigip_2_post_calls = [
+            # check that RouteDomain reverted
+            mock.call(path='/mgmt/tm/net/route-domain', json={'name': 'vlan-1234', 'vlans': ['/Common/vlan-1234'], 'id': '1234'}),
+        ]
+        mock_bigip_2.post.assert_has_calls(bigip_2_post_calls, any_order=True)


### PR DESCRIPTION
This PR changes `remove_l2_flow` to synchronize both F5 devices dependently. This change implements:

1. unordered flow for both synchronizations and it means if one device fails the changes on the second device will be reverted
2. revert function for `RemoveVLAN`
3. revert function for `RemoveRouteDomain`

How the task flow was before:
![remove_l2_1](https://github.com/user-attachments/assets/399cc298-eb4e-4a25-bd9a-fbf1bf1b69dd)

How it will be when this PR merged:
![asdsad](https://github.com/user-attachments/assets/54f75b23-a5b5-4262-a62e-c4d859ae0d43)
