### PR TITLE
[l2] Fix ensure_l2_flow: BigIPRestClient needed, not just hostname

### DIFF
--- a/octavia_f5/controller/worker/l2_sync_manager.py
+++ b/octavia_f5/controller/worker/l2_sync_manager.py
@@ -202,13 +202,13 @@ class L2SyncManager(BaseTaskFlowEngine):
 
             selfips_for_host = [selfip for selfip in selfips if bigip.hostname in selfip.name]
             subnet_ids = set(sip.fixed_ips[0].subnet_id for sip in selfips_for_host)
-            ensure_l2_flow_data[bigip.hostname] = {
+            ensure_l2_flow_data[bigip] = {
                 'store': {'bigip': bigip, 'network': network, 'subnet_id': subnet_ids.pop()},
                 'selfips': selfips_for_host,
             }
         fs[self.executor.submit(
             self._do_ensure_l2_flow,
-            data=ensure_l2_flow_data)] = ','.join(ensure_l2_flow_data.keys())
+            data=ensure_l2_flow_data)] = ensure_l2_flow_data.keys()
 
         # run VCMP l2 flow for all VCMPs in parallel
         for vcmp in self._vcmps:
@@ -217,19 +217,23 @@ class L2SyncManager(BaseTaskFlowEngine):
                 store['bigip_guest_names'] = CONF.networking.override_vcmp_guest_names
             else:
                 store['bigip_guest_names'] = [bigip.hostname for bigip in self._bigips]
-            fs[self.executor.submit(self._do_ensure_vcmp_l2_flow, store=store)] = vcmp
+            fs[self.executor.submit(self._do_ensure_vcmp_l2_flow, store=store)] = [vcmp]
 
         # wait for all flows to finish
         failed_bigips = []
         done, not_done = futures.wait(fs, timeout=CONF.networking.l2_timeout)
         for f in done | not_done:
-            bigip = fs[f]
+            bigips = fs[f]
             try:
                 f.result(0)
             except Exception as e:
-                self._metric_failed_futures.labels(bigip.hostname, 'ensure_l2_flow').inc()
-                LOG.error("Failed running ensure_l2_flow for host %s: %s", bigip.hostname, e)
-                failed_bigips.append(bigip)
+                hostnames = [bigip.hostname for bigip in bigips]
+                for hostname in hostnames:
+                    # consider both device flows as failed, since we don't know
+                    # which one the error originated in.
+                    self._metric_failed_futures.labels(hostname, 'ensure_l2_flow').inc()
+                    failed_bigips.append(hostname)
+                LOG.error(f"Failed running ensure_l2_flow for hosts {', '.join(hostnames)}: {e}")
 
         # raise error only if all pairs failed
         if self._bigips and all(bigip in failed_bigips for bigip in self._bigips):

--- a/octavia_f5/controller/worker/l2_sync_manager.py
+++ b/octavia_f5/controller/worker/l2_sync_manager.py
@@ -84,9 +84,9 @@ class L2SyncManager(BaseTaskFlowEngine):
         for bigip in self._bigips:
             bigip.update_status()
 
-    def _do_ensure_l2_flow(self, data: dict):
+    def _do_ensure_l2_flow(self, data: list):
         ensure_l2_flow = unordered_flow.Flow('ensure-l2-flow-from-all-devices')
-        for flow_data in data.values():
+        for flow_data in data:
             # get existing SelfIPs and subnet routes - they are needed to determine,
             # which ones have to be created and which already exist
             e = self.taskflow_load(self._f5flows.make_get_existing_selfips_and_subnet_routes_flow(),
@@ -190,7 +190,7 @@ class L2SyncManager(BaseTaskFlowEngine):
 
         # run l2 flow for all devices in parallel
         fs = {}
-        ensure_l2_flow_data = {}
+        ensure_l2_flow_data = []
         for bigip in self._bigips:
             if device and bigip.hostname != device:
                 continue
@@ -202,13 +202,13 @@ class L2SyncManager(BaseTaskFlowEngine):
 
             selfips_for_host = [selfip for selfip in selfips if bigip.hostname in selfip.name]
             subnet_ids = set(sip.fixed_ips[0].subnet_id for sip in selfips_for_host)
-            ensure_l2_flow_data[bigip] = {
+            ensure_l2_flow_data.append({
                 'store': {'bigip': bigip, 'network': network, 'subnet_id': subnet_ids.pop()},
                 'selfips': selfips_for_host,
-            }
+            })
         fs[self.executor.submit(
             self._do_ensure_l2_flow,
-            data=ensure_l2_flow_data)] = ensure_l2_flow_data.keys()
+            data=ensure_l2_flow_data)] = self._bigips
 
         # run VCMP l2 flow for all VCMPs in parallel
         for vcmp in self._vcmps:

--- a/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
+++ b/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
@@ -100,12 +100,12 @@ class TestL2SyncManager(base.TestCase):
         ]
         self.manager.ensure_l2_flow(mocked_selfips, 'test-network-id')
         mock_l2_flow.assert_called_once_with(data={
-            'test-guest-hostname_0': {
+            self.manager._bigips[0]: {
                 'selfips': [mocked_selfips[0]],
                 'store': {'bigip': self.manager._bigips[0],
                           'network': mock_get_network.return_value,
                           'subnet_id': MOCK_FIXED_IP.subnet_id}},
-            'test-guest-hostname_1': {
+            self.manager._bigips[1]: {
                 'selfips': [mocked_selfips[1]],
                 'store': {'bigip': self.manager._bigips[1],
                           'network': mock_get_network.return_value,
@@ -145,7 +145,7 @@ class TestL2SyncManager(base.TestCase):
         self.manager._bigips[1].is_available.assert_called_once_with(timeout=5)
         # expect only one call for BigIP, only for available device
         mock_l2_flow.assert_called_once_with(data={
-            'test-guest-hostname_0': {
+            self.manager._bigips[0]: {
                 'selfips': [mocked_selfips[0]],
                 'store': {'bigip': self.manager._bigips[0],
                           'network': mock_get_network.return_value,
@@ -185,12 +185,12 @@ class TestL2SyncManager(base.TestCase):
         ]
         self.manager.ensure_l2_flow(mocked_selfips, 'test-network-id')
         mock_l2_flow.assert_called_once_with(data={
-            'test-guest-hostname_0': {
+            self.manager._bigips[0]: {
                 'selfips': [mocked_selfips[0]],
                 'store': {'bigip': self.manager._bigips[0],
                           'network': mock_get_network.return_value,
                           'subnet_id': MOCK_FIXED_IP.subnet_id}},
-            'test-guest-hostname_1': {
+            self.manager._bigips[1]: {
                 'selfips': [mocked_selfips[1]],
                 'store': {'bigip': self.manager._bigips[1],
                           'network': mock_get_network.return_value,
@@ -230,12 +230,12 @@ class TestL2SyncManager(base.TestCase):
                              e.args[0])
 
         mock_l2_flow.assert_called_once_with(data={
-            'test-guest-hostname_0': {
+            self.manager._bigips[0]: {
                 'selfips': [mocked_selfips[0]],
                 'store': {'bigip': self.manager._bigips[0],
                           'network': mock_get_network.return_value,
                           'subnet_id': MOCK_FIXED_IP.subnet_id}},
-            'test-guest-hostname_1': {
+            self.manager._bigips[1]: {
                 'selfips': [mocked_selfips[1]],
                 'store': {'bigip': self.manager._bigips[1],
                           'network': mock_get_network.return_value,

--- a/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
+++ b/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
@@ -99,18 +99,19 @@ class TestL2SyncManager(base.TestCase):
                 name=f"local-OTHER_HOST-{uuidutils.generate_uuid()}")
         ]
         self.manager.ensure_l2_flow(mocked_selfips, 'test-network-id')
-        mock_l2_flow.assert_called_once_with(data={
-            self.manager._bigips[0]: {
+        mock_l2_flow.assert_called_once_with(data=[
+            {
                 'selfips': [mocked_selfips[0]],
                 'store': {'bigip': self.manager._bigips[0],
                           'network': mock_get_network.return_value,
-                          'subnet_id': MOCK_FIXED_IP.subnet_id}},
-            self.manager._bigips[1]: {
+                          'subnet_id': MOCK_FIXED_IP.subnet_id}
+            },
+            {
                 'selfips': [mocked_selfips[1]],
                 'store': {'bigip': self.manager._bigips[1],
                           'network': mock_get_network.return_value,
-                          'subnet_id': MOCK_FIXED_IP.subnet_id}}
-        })
+                          'subnet_id': MOCK_FIXED_IP.subnet_id}
+            }])
         self.assertEqual(mock_vcmp_l2_flow.call_count, 2)
         vcmp_l2_flow_calls = [
             mock.call(store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
@@ -144,13 +145,13 @@ class TestL2SyncManager(base.TestCase):
         self.manager.ensure_l2_flow(mocked_selfips, 'test-network-id')
         self.manager._bigips[1].is_available.assert_called_once_with(timeout=5)
         # expect only one call for BigIP, only for available device
-        mock_l2_flow.assert_called_once_with(data={
-            self.manager._bigips[0]: {
+        mock_l2_flow.assert_called_once_with(data=[
+            {
                 'selfips': [mocked_selfips[0]],
                 'store': {'bigip': self.manager._bigips[0],
                           'network': mock_get_network.return_value,
-                          'subnet_id': MOCK_FIXED_IP.subnet_id}}
-        })
+                          'subnet_id': MOCK_FIXED_IP.subnet_id}
+            }])
         self.assertEqual(mock_vcmp_l2_flow.call_count, 2)
         vcmp_l2_flow_calls = [
             mock.call(store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
@@ -184,18 +185,19 @@ class TestL2SyncManager(base.TestCase):
                 name=f"local-OTHER_HOST-{uuidutils.generate_uuid()}")
         ]
         self.manager.ensure_l2_flow(mocked_selfips, 'test-network-id')
-        mock_l2_flow.assert_called_once_with(data={
-            self.manager._bigips[0]: {
+        mock_l2_flow.assert_called_once_with(data=[
+            {
                 'selfips': [mocked_selfips[0]],
                 'store': {'bigip': self.manager._bigips[0],
                           'network': mock_get_network.return_value,
-                          'subnet_id': MOCK_FIXED_IP.subnet_id}},
-            self.manager._bigips[1]: {
+                          'subnet_id': MOCK_FIXED_IP.subnet_id}
+            },
+            {
                 'selfips': [mocked_selfips[1]],
                 'store': {'bigip': self.manager._bigips[1],
                           'network': mock_get_network.return_value,
-                          'subnet_id': MOCK_FIXED_IP.subnet_id}}
-        })
+                          'subnet_id': MOCK_FIXED_IP.subnet_id}
+            }])
         self.assertEqual(mock_vcmp_l2_flow.call_count, 2)
         vcmp_l2_flow_calls = [
             mock.call(store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
@@ -229,18 +231,19 @@ class TestL2SyncManager(base.TestCase):
             self.assertEqual("Failed ensure_l2_flow for all vcmp devices of network_id=test-network-id",
                              e.args[0])
 
-        mock_l2_flow.assert_called_once_with(data={
-            self.manager._bigips[0]: {
+        mock_l2_flow.assert_called_once_with(data=[
+            {
                 'selfips': [mocked_selfips[0]],
                 'store': {'bigip': self.manager._bigips[0],
                           'network': mock_get_network.return_value,
-                          'subnet_id': MOCK_FIXED_IP.subnet_id}},
-            self.manager._bigips[1]: {
+                          'subnet_id': MOCK_FIXED_IP.subnet_id}
+            },
+            {
                 'selfips': [mocked_selfips[1]],
                 'store': {'bigip': self.manager._bigips[1],
                           'network': mock_get_network.return_value,
-                          'subnet_id': MOCK_FIXED_IP.subnet_id}}
-        })
+                          'subnet_id': MOCK_FIXED_IP.subnet_id}
+            }])
         self.assertEqual(mock_vcmp_l2_flow.call_count, 2)
         vcmp_l2_flow_calls = [
             mock.call(store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
@@ -274,8 +277,8 @@ class TestL2SyncManager(base.TestCase):
                 MockResponse({}, 404) for _ in range(9)]
             mock_bigips.append(mock_bigip)
         mock_bigips[0].is_active = True
-        data = {
-            mock_bigips[0].hostname: {
+        data = [
+            {
                 'selfips': [selfip_port],
                 'store': {
                     'network': mock_network,
@@ -284,7 +287,7 @@ class TestL2SyncManager(base.TestCase):
                     'existing_selfips': []
                 }
             },
-            mock_bigips[1].hostname: {
+            {
                 'selfips': [selfip_port],
                 'store': {
                     'network': mock_network,
@@ -293,7 +296,7 @@ class TestL2SyncManager(base.TestCase):
                     'existing_selfips': []
                 }
             }
-        }
+        ]
         self.manager._do_ensure_l2_flow(data=data)
         # check thath both devices were called and REVERT tasks were not called
         self.assertEqual(mock_bigips[0].get.call_count, 9)
@@ -345,8 +348,8 @@ class TestL2SyncManager(base.TestCase):
             # Route Domain creation
             MockResponse({}, 502)
         ]
-        data = {
-            'hostname-1': {
+        data = [
+            {
                 'selfips': [selfip_port],
                 'store': {
                     'network': mock_network,
@@ -355,7 +358,7 @@ class TestL2SyncManager(base.TestCase):
                     'existing_selfips': []
                 }
             },
-            'hostname-2': {
+            {
                 'selfips': [selfip_port],
                 'store': {
                     'network': mock_network,
@@ -364,7 +367,7 @@ class TestL2SyncManager(base.TestCase):
                     'existing_selfips': []
                 }
             }
-        }
+        ]
         # self.manager._do_ensure_l2_flow(data=data)
         self.assertRaises(Exception, self.manager._do_ensure_l2_flow, data=data)
         # check thath both devices were called and REVERT tasks were also called


### PR DESCRIPTION
This commit fixes two things introduced in #285:

1) Since the L2 creation flow was changed to run on both hosts simultaneously, one future now handles two devices. This means that iterating over the futures can yield two hostnames instead of one. This breaks the `octavia_l2_failed_futures` metric, which only takes one hostname as label. This commit fixes this by treating all values of the futures dictionary as lists and (in the case of a failure) iterating over them to set the `octavia_l2_failed_futures` metric for each host therein.

2) After the futures have been iterated over, the failed BigIPs are checked to see whether all BigIP hosts/guest flows failed. This check needs `BigIPRestClient` instances (to compare to `self._bigips` and `self.vcmps`, respectively), but for the BigIP guests only the hostnames are provided in the futures list.