### PR TITLE
Hotfix: remove SubnetRoute creation for SelfIPs.

### DIFF
--- a/octavia_f5/controller/worker/flows/f5_flows.py
+++ b/octavia_f5/controller/worker/flows/f5_flows.py
@@ -41,8 +41,9 @@ class F5Flows(object):
             ensure_selfip_task = f5_tasks.EnsureSelfIP(
                 name=f'ensure-selfip-{bigip_hostname}-{selfip_port.id}',
                 inject={
-                    'port': selfip_port,
-                    **store
+                    # store data should come first because it also contains port data
+                    **store,
+                    'port': selfip_port
                 }
             )
             ensure_selfips_subflow.add(ensure_selfip_task)
@@ -60,8 +61,9 @@ class F5Flows(object):
             ensure_subnet_route_task = f5_tasks.EnsureSubnetRoute(
                 name=f'ensure-subnet-route-{bigip_hostname}-{subnet_route_name}',
                 inject={
-                    'subnet_id': subnet_id,
-                    **store
+                    # store data should come first because it also contains subnet_id
+                    **store,
+                    'subnet_id': subnet_id
                 }
             )
             ensure_subnet_routes_subflow.add(ensure_subnet_route_task)

--- a/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
+++ b/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
@@ -258,15 +258,15 @@ class TestL2SyncManager(base.TestCase):
                 ".get_subnet")
     def test__do_ensure_l2_flow_nothing_exist_no_errors(self, mock_get_subnet):
         mock_get_subnet.return_value = network_models.Subnet(
-            id='test-subnet-id', gateway_ip='1.2.3.1',
+            id='test-subnet-id-1', gateway_ip='1.2.3.1',
             cidr='1.2.3.0/24', network_id='test-network-id')
         mock_network = f5_network_models.Network(
-            mtu=8950, id='test-network-id', subnets=['test-subnet-id'],
+            mtu=8950, id='test-network-id', subnets=['test-subnet-id-1', 'test-subnet-id-2'],
             segments=[{'provider:physical_network': 'physnet',
                        'provider:segmentation_id': 1234}]
         )
         selfip_fixed_ip = network_models.FixedIP(
-            ip_address='1.2.3.2', subnet_id='test-subnet-id-2')
+            ip_address='5.6.7.8', subnet_id='test-subnet-id-2')
         selfip_port = network_models.Port(
             id='test-selfip-port-id', fixed_ips=[selfip_fixed_ip],
         )
@@ -284,7 +284,7 @@ class TestL2SyncManager(base.TestCase):
                 'store': {
                     'network': mock_network,
                     'bigip': mock_bigips[0],
-                    'subnet_id': 'test-subnet-id',
+                    'subnet_id': 'test-subnet-id-2',
                     'existing_selfips': []
                 }
             },
@@ -293,7 +293,7 @@ class TestL2SyncManager(base.TestCase):
                 'store': {
                     'network': mock_network,
                     'bigip': mock_bigips[1],
-                    'subnet_id': 'test-subnet-id',
+                    'subnet_id': 'test-subnet-id-2',
                     'existing_selfips': []
                 }
             }
@@ -306,6 +306,25 @@ class TestL2SyncManager(base.TestCase):
         self.assertEqual(mock_bigips[1].post.call_count, 5)
         self.assertEqual(mock_bigips[0].delete.call_count, 0)
         self.assertEqual(mock_bigips[1].delete.call_count, 0)
+        for i in range(0, 2):
+            # check SelfIP creation
+            mock_bigips[i].post.assert_any_call(
+                path='/mgmt/tm/net/self',
+                json={'name': 'port-test-selfip-port-id', 'vlan': '/Common/vlan-1234',
+                      'address': '5.6.7.8%1234/24'})
+            # check DefaultRoute creation
+            mock_bigips[i].post.assert_any_call(
+                path='/mgmt/tm/net/route',
+                json={'name': 'vlan-1234', 'gw': '1.2.3.1%1234',
+                      'network': 'default%1234'})
+            # check SubnetRoute existence
+            mock_bigips[i].get.assert_any_call(
+                path='/mgmt/tm/net/route/~Common~net_test-network-id_sub_test-subnet-id-1')
+            # check SubnetRoute creation
+            mock_bigips[i].post.assert_any_call(
+                path='/mgmt/tm/net/route',
+                json={'name': 'net_test-network-id_sub_test-subnet-id-1',
+                      'tmInterface': '/Common/vlan-1234', 'network': '1.2.3.0%1234/24'})
 
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")


### PR DESCRIPTION
This commit fixes the order of injection for two flows, EnsureSubnetRoute and EnsureSelfIP. The store variable also contains port and subnet_id keys that conflict with our injections.

The unit test was adopted to check this situation.

Fixed error:
```
Static route duplicates Self IP 10.180.121.0%2002 / 255.255.255.0 implied route
```