### PR TITLE
[SetQueue] implement priority queue for improved worker queues

### DIFF
--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -268,7 +268,7 @@ class ControllerWorker(object):
         # because each network is synced separately
         pending_networks = set(lb.vip.network_id for lb in lbs)
         for network_id in pending_networks:
-            self.queue.put_nowait((network_id, None))
+            self.queue.put_priority((network_id, None))
 
     @tenacity.retry(
         retry=tenacity.retry_if_exception_type(db_exceptions.NoResultFound),
@@ -323,17 +323,17 @@ class ControllerWorker(object):
 
         self.ensure_amphora_exists(lb.id)
         self.ensure_host_set(lb)
-        self.queue.put((lb.vip.network_id, None))
+        self.queue.put_priority((lb.vip.network_id, None))
 
     def update_load_balancer(self, load_balancer_id, load_balancer_updates):
         lb = self._loadbalancer_repo.get(db_apis.get_session(), id=load_balancer_id)
-        self.queue.put((lb.vip.network_id, None))
+        self.queue.put_priority((lb.vip.network_id, None))
 
     def delete_load_balancer(self, load_balancer_id, cascade=False):
         lb = self._loadbalancer_repo.get(db_apis.get_session(), id=load_balancer_id)
         # could be deleted by sync-loop meanwhile
         if lb:
-            self.queue.put((lb.vip.network_id, None))
+            self.queue.put_priority((lb.vip.network_id, None))
 
     """
     Listener
@@ -352,19 +352,19 @@ class ControllerWorker(object):
                         '60 seconds.', 'listener', listener_id)
             raise db_exceptions.NoResultFound
 
-        self.queue.put((listener.load_balancer.vip.network_id, None))
+        self.queue.put_priority((listener.load_balancer.vip.network_id, None))
 
     def update_listener(self, listener_id, listener_updates):
         listener = self._listener_repo.get(db_apis.get_session(),
                                            id=listener_id)
-        self.queue.put((listener.load_balancer.vip.network_id, None))
+        self.queue.put_priority((listener.load_balancer.vip.network_id, None))
 
     def delete_listener(self, listener_id):
         listener = self._listener_repo.get(db_apis.get_session(),
                                            id=listener_id)
         # could be deleted by sync-loop meanwhile
         if listener:
-            self.queue.put((listener.load_balancer.vip.network_id, None))
+            self.queue.put_priority((listener.load_balancer.vip.network_id, None))
 
     """
     Pool
@@ -383,19 +383,19 @@ class ControllerWorker(object):
                         '60 seconds.', 'pool', pool_id)
             raise db_exceptions.NoResultFound
 
-        self.queue.put((pool.load_balancer.vip.network_id, None))
+        self.queue.put_priority((pool.load_balancer.vip.network_id, None))
 
     def update_pool(self, pool_id, pool_updates):
         pool = self._pool_repo.get(db_apis.get_session(),
                                    id=pool_id)
-        self.queue.put((pool.load_balancer.vip.network_id, None))
+        self.queue.put_priority((pool.load_balancer.vip.network_id, None))
 
     def delete_pool(self, pool_id):
         pool = self._pool_repo.get(db_apis.get_session(),
                                    id=pool_id)
         # could be deleted by sync-loop meanwhile
         if pool:
-            self.queue.put((pool.load_balancer.vip.network_id, None))
+            self.queue.put_priority((pool.load_balancer.vip.network_id, None))
 
     """
     Member
@@ -415,7 +415,7 @@ class ControllerWorker(object):
             raise db_exceptions.NoResultFound
 
         self.ensure_amphora_exists(member.pool.load_balancer.id)
-        self.queue.put((member.pool.load_balancer.vip.network_id, None))
+        self.queue.put_priority((member.pool.load_balancer.vip.network_id, None))
 
     def batch_update_members(self, old_member_ids, new_member_ids,
                              updated_members):
@@ -434,18 +434,18 @@ class ControllerWorker(object):
             pool = updated_members[0][0].pool
         else:
             return
-        self.queue.put((pool.load_balancer.vip.network_id, None))
+        self.queue.put_priority((pool.load_balancer.vip.network_id, None))
 
     def update_member(self, member_id, member_updates):
         member = self._member_repo.get(db_apis.get_session(),
                                        id=member_id)
-        self.queue.put((member.pool.load_balancer.vip.network_id, None))
+        self.queue.put_priority((member.pool.load_balancer.vip.network_id, None))
 
     def delete_member(self, member_id):
         member = self._member_repo.get(db_apis.get_session(),
                                        id=member_id)
         # could be deleted by sync-loop meanwhile
-        self.queue.put((member.pool.load_balancer.vip.network_id, None))
+        self.queue.put_priority((member.pool.load_balancer.vip.network_id, None))
 
     """
     Health Monitor
@@ -459,19 +459,19 @@ class ControllerWorker(object):
                         '60 seconds.', 'health_monitor', health_monitor_id)
             raise db_exceptions.NoResultFound
 
-        self.queue.put((health_mon.pool.load_balancer.vip.network_id, None))
+        self.queue.put_priority((health_mon.pool.load_balancer.vip.network_id, None))
 
     def update_health_monitor(self, health_monitor_id, health_monitor_updates):
         health_mon = self._health_mon_repo.get(db_apis.get_session(),
                                                id=health_monitor_id)
-        self.queue.put((health_mon.pool.load_balancer.vip.network_id, None))
+        self.queue.put_priority((health_mon.pool.load_balancer.vip.network_id, None))
 
     def delete_health_monitor(self, health_monitor_id):
         health_mon = self._health_mon_repo.get(db_apis.get_session(),
                                                id=health_monitor_id)
         # could be deleted by sync-loop meanwhile
         if health_mon:
-            self.queue.put((health_mon.pool.load_balancer.vip.network_id, None))
+            self.queue.put_priority((health_mon.pool.load_balancer.vip.network_id, None))
 
     """
     l7policy
@@ -490,19 +490,19 @@ class ControllerWorker(object):
                         '60 seconds.', 'l7policy', l7policy_id)
             raise db_exceptions.NoResultFound
 
-        self.queue.put((l7policy.listener.load_balancer.vip.network_id, None))
+        self.queue.put_priority((l7policy.listener.load_balancer.vip.network_id, None))
 
     def update_l7policy(self, l7policy_id, l7policy_updates):
         l7policy = self._l7policy_repo.get(db_apis.get_session(),
                                            id=l7policy_id)
-        self.queue.put((l7policy.listener.load_balancer.vip.network_id, None))
+        self.queue.put_priority((l7policy.listener.load_balancer.vip.network_id, None))
 
     def delete_l7policy(self, l7policy_id):
         l7policy = self._l7policy_repo.get(db_apis.get_session(),
                                            id=l7policy_id)
         # could be deleted by sync-loop meanwhile
         if l7policy:
-            self.queue.put((l7policy.listener.load_balancer.vip.network_id, None))
+            self.queue.put_priority((l7policy.listener.load_balancer.vip.network_id, None))
 
     """
     l7rule
@@ -521,19 +521,19 @@ class ControllerWorker(object):
                         '60 seconds.', 'l7rule', l7rule_id)
             raise db_exceptions.NoResultFound
 
-        self.queue.put((l7rule.l7policy.listener.load_balancer.vip.network_id, None))
+        self.queue.put_priority((l7rule.l7policy.listener.load_balancer.vip.network_id, None))
 
     def update_l7rule(self, l7rule_id, l7rule_updates):
         l7rule = self._l7rule_repo.get(db_apis.get_session(),
                                        id=l7rule_id)
-        self.queue.put((l7rule.l7policy.listener.load_balancer.vip.network_id, None))
+        self.queue.put_priority((l7rule.l7policy.listener.load_balancer.vip.network_id, None))
 
     def delete_l7rule(self, l7rule_id):
         l7rule = self._l7rule_repo.get(db_apis.get_session(),
                                        id=l7rule_id)
         # could be deleted by sync-loop meanwhile
         if l7rule:
-            self.queue.put((l7rule.l7policy.listener.load_balancer.vip.network_id, None))
+            self.queue.put_priority((l7rule.l7policy.listener.load_balancer.vip.network_id, None))
 
     """
     Amphora

--- a/octavia_f5/controller/worker/set_queue.py
+++ b/octavia_f5/controller/worker/set_queue.py
@@ -16,12 +16,33 @@ from queue import Queue
 
 
 class SetQueue(Queue):
+    """
+    A thread-safe queue that stores unique items using sets and supports priority items.
+
+    Inherits from `Queue` but overrides the internal storage to use sets, ensuring all items are unique.
+    Items added via `put_priority` are returned first when retrieving from the queue.
+    """
     def _init(self, maxsize):
         self.maxsize = maxsize
         self.queue = set()
+        self.priority_queue = set()
+
+    def put_priority(self, item):
+        """Add an item to the priority queue."""
+        self.priority_queue.add(item)
+        self.queue.discard(item)
 
     def _put(self, item):
         self.queue.add(item)
 
+    def _qsize(self):
+        """Return the approximate size of the queue."""
+        return len(self.queue) + len(self.priority_queue)
+
     def _get(self):
+        if len(self.priority_queue) > 0:
+            # If there are priority items, return one of them
+            item = self.priority_queue.pop()
+            self.queue.discard(item)
+            return item
         return self.queue.pop()

--- a/octavia_f5/tests/unit/controller/worker/test_set_queue.py
+++ b/octavia_f5/tests/unit/controller/worker/test_set_queue.py
@@ -1,0 +1,102 @@
+# Copyright 2025 SAP SE
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import octavia.tests.unit.base as base
+from octavia_f5.controller.worker.set_queue import SetQueue
+
+
+class TestSetQueue(base.TestCase):
+    def test_set_queue(self):
+        queue = SetQueue()
+        # Add items to the queue
+        queue.put('item1')
+        queue.put('item2')
+        # Check that items are in the queue
+        self.assertFalse(queue.empty())
+
+        rest = [queue.get(), queue.get()]
+        self.assertTrue(queue.empty())
+        self.assertIn('item1', rest)
+        self.assertIn('item2', rest)
+
+    def test_set_queue_priority(self):
+        # Test priority items in SetQueue
+
+        queue = SetQueue()
+        queue.put('item1')
+        queue.put_priority('priority_item1')
+        queue.put('item2')
+
+        # Check that priority item is returned first
+        self.assertEqual(queue.get(), 'priority_item1')
+
+        rest = [queue.get(), queue.get()]
+        self.assertTrue(queue.empty())
+        self.assertIn('item1', rest)
+        self.assertIn('item2', rest)
+
+    def test_set_queue_unique_items(self):
+        # Test that SetQueue only contains unique items
+        queue = SetQueue()
+        queue.put('item1')
+        queue.put('item1')
+        queue.put('item2')
+        queue.put_priority('priority_item1')
+        queue.put_priority('priority_item1')
+        queue.put_priority('priority_item2')
+
+        # Check that only unique items are present
+        self.assertEqual(queue.qsize(), 4)
+        prio = [queue.get(), queue.get()]
+        rest = [queue.get(), queue.get()]
+        self.assertTrue(queue.empty())
+
+        self.assertIn('priority_item1', prio)
+        self.assertIn('priority_item2', prio)
+        self.assertIn('item1', rest)
+        self.assertIn('item2', rest)
+
+    def test_set_queue_size(self):
+        # Test the size of the SetQueue
+        queue = SetQueue()
+        self.assertEqual(queue.qsize(), 0)
+
+        queue.put('item1')
+        self.assertEqual(queue.qsize(), 1)
+
+        queue.put('item2')
+        self.assertEqual(queue.qsize(), 2)
+
+        queue.put_priority('priority_item1')
+        self.assertEqual(queue.qsize(), 3)
+
+        queue.get()
+        self.assertEqual(queue.qsize(), 2)
+
+    def test_set_queue_empty(self):
+        # Test if the SetQueue is empty
+        queue = SetQueue()
+        self.assertTrue(queue.empty())
+
+        queue.put('item1')
+        self.assertFalse(queue.empty())
+
+        queue.get()
+        self.assertTrue(queue.empty())
+
+        queue.put_priority('priority_item1')
+        self.assertFalse(queue.empty())
+
+        queue.get()
+        self.assertTrue(queue.empty())


### PR DESCRIPTION
the additional priority queue helps to prioritize urgent updates
over full-sync updates. This should improve pending-sync-alerts
drastically since individual updates via RPC are always priorized.

low priority:
full sync loadbalancers
cleanup orphan tenants

high priority:
callbacks via RPC for individual objects of a signle loadbalancer
pending sync loadbalancers
