### PR TITLE
Fix: SetQueue doesn't notify polling threads for put_priority

### DIFF
--- a/octavia_f5/controller/worker/set_queue.py
+++ b/octavia_f5/controller/worker/set_queue.py
@@ -31,6 +31,9 @@ class SetQueue(Queue):
         """Add an item to the priority queue."""
         self.priority_queue.add(item)
         self.queue.discard(item)
+        # notify polling threads
+        with self.not_empty: # acquire self.mutex for self.not_empty
+            self.not_empty.notify()
 
     def _put(self, item):
         self.queue.add(item)


### PR DESCRIPTION
SetQueue does not override the put method, only the inner method _put. This means, when the put method is called, it correctly uses the self.not_empty condition object to notify polling
threads (i. e. threads that are currently blocking on a call to the get method).

The put_priority method however does not rely on the put method and so it doesn't use the self.not_empty condition object to notify polling threads when a new item has been pushed to the priority queue.

This means, blocking threads only get unblocked when the put method is called, but not when the put_priority method is called.

This commit fixes this issue by making the put_priority method explicitly use the self.not_empty condition object to notify polling threads, similar to the upstream put method.

This PR fixes #298 