### PR TITLE
[l2] Fix remove_l2_flow: BigIPRestClient needed, not just hostname

### DIFF
--- a/octavia_f5/controller/worker/l2_sync_manager.py
+++ b/octavia_f5/controller/worker/l2_sync_manager.py
@@ -116,9 +116,9 @@ class L2SyncManager(BaseTaskFlowEngine):
         with tf_logging.DynamicLoggingListener(e, log=LOG):
             e.run()
 
-    def _do_remove_l2_flow(self, data: dict):
+    def _do_remove_l2_flow(self, data: list):
         remove_l2_flow = unordered_flow.Flow('remove-l2-flow-from-all-devices')
-        for flow_data in data.values():
+        for flow_data in data:
             # get existing SelfIPs and subnet routes
             e = self.taskflow_load(self._f5flows.make_get_existing_selfips_and_subnet_routes_flow(),
                                    store=flow_data['store'])
@@ -264,7 +264,7 @@ class L2SyncManager(BaseTaskFlowEngine):
 
         # run l2 flow for all devices in parallel
         fs = {}
-        remove_l2_flow_data = {}
+        remove_l2_flow_data = []
         for bigip in self._bigips:
             if device and bigip.hostname != device:
                 continue
@@ -274,13 +274,13 @@ class L2SyncManager(BaseTaskFlowEngine):
                 LOG.debug(f"Device {bigip.hostname} is unreachable for API requests.")
                 continue
 
-            remove_l2_flow_data[bigip.hostname] = {
+            remove_l2_flow_data.append({
                 'store': {'bigip': bigip, 'network': network},
-            }
+            })
 
         fs[self.executor.submit(
             self._do_remove_l2_flow,
-            data=remove_l2_flow_data)] = ','.join(remove_l2_flow_data.keys())
+            data=remove_l2_flow_data)] = self._bigips
 
         if CONF.networking.override_vcmp_guest_names:
             guest_names = CONF.networking.override_vcmp_guest_names
@@ -289,16 +289,20 @@ class L2SyncManager(BaseTaskFlowEngine):
 
         for vcmp in self._vcmps:
             store = {'bigip': vcmp, 'bigip_guest_names': guest_names, 'network': network}
-            fs[self.executor.submit(self._do_remove_vcmp_l2_flow, store=store)] = vcmp
+            fs[self.executor.submit(self._do_remove_vcmp_l2_flow, store=store)] = [vcmp]
 
         done, not_done = futures.wait(fs, timeout=CONF.networking.l2_timeout)
         for f in done | not_done:
-            bigip = fs[f]
+            bigips = fs[f]
             try:
                 f.result(0)
             except Exception as e:
-                self._metric_failed_futures.labels(bigip.hostname, 'remove_l2_flow').inc()
-                LOG.error("Failed running remove_l2_flow for host %s: %s", bigip.hostname, e)
+                hostnames = [bigip.hostname for bigip in bigips]
+                for hostname in hostnames:
+                    # consider both device flows as failed, since we don't know
+                    # which one the error originated in.
+                    self._metric_failed_futures.labels(hostname, 'remove_l2_flow').inc()
+                LOG.error(f"Failed running remove_l2_flow for hosts {', '.join(hostnames)}: {e}")
 
     def sync_l2_selfips_and_subnet_routes_flow(self, selfips: [network_models.Port], network_id: str, device=None):
         """ Runs the taskflows to sync (add/remove) SelfIPs and subnet routes on all bigip devices in parallel

--- a/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
+++ b/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
@@ -422,14 +422,15 @@ class TestL2SyncManager(base.TestCase):
     def test_remove_l2_flow_all_available(self, mock_get_network,
                             mock_l2_flow, mock_vcmp_l2_flow):
         self.manager.remove_l2_flow('test-network-id')
-        mock_l2_flow.assert_called_once_with(data={
-            'test-guest-hostname_0': {
+        mock_l2_flow.assert_called_once_with(data=[
+        {
                 'store': {'bigip': self.manager._bigips[0],
-                          'network': mock_get_network.return_value}},
-            'test-guest-hostname_1': {
+                          'network': mock_get_network.return_value}
+        },
+        {
                 'store': {'bigip': self.manager._bigips[1],
-                          'network': mock_get_network.return_value}}
-        })
+                          'network': mock_get_network.return_value}
+        }])
         self.assertEqual(mock_vcmp_l2_flow.call_count, 2)
         vcmp_l2_flow_calls = [
             mock.call(store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
@@ -451,11 +452,11 @@ class TestL2SyncManager(base.TestCase):
         self.manager.remove_l2_flow('test-network-id')
         self.manager._bigips[1].is_available.assert_called_once_with(timeout=5)
         # expect only one call for BigIP, only for available device
-        mock_l2_flow.assert_called_once_with(data={
-            'test-guest-hostname_0': {
+        mock_l2_flow.assert_called_once_with(data=[
+            {
                 'store': {'bigip': self.manager._bigips[0],
-                          'network': mock_get_network.return_value}}
-        })
+                          'network': mock_get_network.return_value}
+            }])
         self.assertEqual(mock_vcmp_l2_flow.call_count, 2)
         vcmp_l2_flow_calls = [
             mock.call(store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
@@ -484,22 +485,22 @@ class TestL2SyncManager(base.TestCase):
                 MockResponse({}, 404) for _ in range(9)]
             mock_bigips.append(mock_bigip)
         mock_bigips[0].is_active = True
-        data = {
-            mock_bigips[0].hostname: {
+        data = [
+            {
                 'store': {
                     'network': mock_network,
                     'bigip': mock_bigips[0],
                     'subnet_id': 'test-subnet-id',
                 }
             },
-            mock_bigips[1].hostname: {
+            {
                 'store': {
                     'network': mock_network,
                     'bigip': mock_bigips[1],
                     'subnet_id': 'test-subnet-id',
                 }
             }
-        }
+        ]
         self.manager._do_remove_l2_flow(data=data)
         # check thath both devices were called and REVERT tasks were not called
         self.assertEqual(mock_bigips[0].get.call_count, 7)
@@ -598,23 +599,22 @@ class TestL2SyncManager(base.TestCase):
             # VLAN delete
             MockResponse({}, 502, "something happend")
         ]
-        data = {
-            'hostname-1': {
+        data = [
+            {
                 'store': {
                     'network': mock_network,
                     'bigip': mock_bigip_1,
                     'subnet_id': 'test-subnet-id',
                 }
             },
-            'hostname-2': {
+            {
                 'store': {
                     'network': mock_network,
                     'bigip': mock_bigip_2,
                     'subnet_id': 'test-subnet-id',
                 }
             }
-        }
-        # self.manager._do_remove_l2_flow(data=data)
+        ]
         self.assertRaises(Exception, self.manager._do_remove_l2_flow, data=data)
         # check thath both devices were called and REVERT tasks were not called
         self.assertEqual(mock_bigip_1.get.call_count, 5)

--- a/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
+++ b/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
@@ -299,7 +299,7 @@ class TestL2SyncManager(base.TestCase):
             }
         ]
         self.manager._do_ensure_l2_flow(data=data)
-        # check thath both devices were called and REVERT tasks were not called
+        # check that both devices were called and REVERT tasks were not called
         self.assertEqual(mock_bigips[0].get.call_count, 9)
         self.assertEqual(mock_bigips[1].get.call_count, 9)
         self.assertEqual(mock_bigips[0].post.call_count, 5)
@@ -389,7 +389,7 @@ class TestL2SyncManager(base.TestCase):
             }
         ]
         self.assertRaises(Exception, self.manager._do_ensure_l2_flow, data=data)
-        # check thath both devices were called and REVERT tasks were also called
+        # check that both devices were called and REVERT tasks were also called
         self.assertEqual(mock_bigip_1.get.call_count, 10)
         self.assertEqual(mock_bigip_2.get.call_count, 7)
         self.assertEqual(mock_bigip_1.post.call_count, 5)
@@ -502,7 +502,7 @@ class TestL2SyncManager(base.TestCase):
             }
         ]
         self.manager._do_remove_l2_flow(data=data)
-        # check thath both devices were called and REVERT tasks were not called
+        # check that both devices were called and REVERT tasks were not called
         self.assertEqual(mock_bigips[0].get.call_count, 7)
         self.assertEqual(mock_bigips[1].get.call_count, 7)
         self.assertEqual(mock_bigips[0].post.call_count, 0)
@@ -597,7 +597,7 @@ class TestL2SyncManager(base.TestCase):
             # RouteDomain delete
             MockResponse({}, 200),
             # VLAN delete
-            MockResponse({}, 502, "something happend")
+            MockResponse({}, 502, "something happened")
         ]
         data = [
             {
@@ -616,7 +616,7 @@ class TestL2SyncManager(base.TestCase):
             }
         ]
         self.assertRaises(Exception, self.manager._do_remove_l2_flow, data=data)
-        # check thath both devices were called and REVERT tasks were not called
+        # check that both devices were called and REVERT tasks were not called
         self.assertEqual(mock_bigip_1.get.call_count, 5)
         self.assertEqual(mock_bigip_2.get.call_count, 5)
         self.assertEqual(mock_bigip_1.post.call_count, 2)


### PR DESCRIPTION
Also: Replace data dictionary with list

This is the same fix as in #291, but for remove_l2_flow


Fixes #302 
I opened #302 because I wanted to move this aside for now and concentrate on testing rSeries first, but the logs I read during testing are polluted with the error due to this bug, so I decided to quickly fix it anyway.