### PR TITLE
[L2] Add rSeries compatibility for L2 code #306

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ The worker uses the driver-agent API, but it hooks more deeply into Octavia (sim
 
 ## F5-specific configuration
 
+### Naming conventions
+Some naming conventions are a bit different between the F5 provider driver and the BigIP devices it can provision. This is partly due to the fact that naming conventions changed between i-Series BigIP vCMP host devices and the newer r-Series BigIP vCMP host devices. E.&nbsp;g. in the i-Series, the term *tenant* is used to refer to partitions within vCMP guests (this provider driver maps one Neutron network to one such partition), so we use that term in the code as well. In the r-Series however the term *tenant* is also used to refer to a whole vCMP guest. To avoid confusion, we keep the old i-Series naming conventions.
+
 ### F5-specific config options
 There are lots of F5-specific configuration options. They can be found in `octavia_f5/common/config.py`.
 - If `agent_scheduler` in the `[networking]` section of the configuration is set to `loadbalancer`, new load balancers are scheduled to the device with the least amount of load balancers. This is the default. If it is set to `listener`, new load balancers are scheduled to the device with the least amount of listeners.

--- a/octavia_f5/common/config.py
+++ b/octavia_f5/common/config.py
@@ -206,6 +206,10 @@ f5_networking_opts = [
                 item_type=cfg.types.URI(schemes=['http', 'https']),
                 default=[],
                 help=_('The URL of the bigip vcmp host devices')),
+    cfg.BoolOpt('vcmp_rseries',
+                default=False,
+                help=_("Whether the BigIP vcmp host device belongs to the "
+                       "r-Series and thus uses the F5OS-A API")),
     cfg.ListOpt('override_vcmp_guest_names',
                 default=[],
                 help=_('List of vcmp guest names to use for identifying the '

--- a/octavia_f5/controller/worker/flows/f5_flows_iseries.py
+++ b/octavia_f5/controller/worker/flows/f5_flows_iseries.py
@@ -11,20 +11,23 @@
 #  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #  License for the specific language governing permissions and limitations
 #  under the License.
-from typing import List
-
 from oslo_log import log as logging
 from taskflow import flow
 from taskflow.patterns import unordered_flow, linear_flow
 
 from octavia.network import data_models as network_models
-from octavia_f5.controller.worker.tasks import f5_tasks
+from octavia_f5.controller.worker.tasks import f5_tasks_iseries
+from octavia_f5.utils import driver_utils
 
 LOG = logging.getLogger(__name__)
 
 
 class F5Flows(object):
-    def make_ensure_l2_flow(self, selfips: List[network_models.Port], store: dict) -> flow.Flow:
+
+    def __init__(self, tasks=f5_tasks_iseries):
+        self.tasks = tasks
+
+    def make_ensure_l2_flow(self, selfips: [network_models.Port], store: dict) -> flow.Flow:
         """
         Construct and return a flow to ensure complete L2 configuration for a new partition.
         The flow assumes that no L2 objects exist yet for the network so nothing is cleaned up.
@@ -39,7 +42,7 @@ class F5Flows(object):
         ensure_selfips_subflow = unordered_flow.Flow(
             f'ensure-selfips-subflow-{bigip_hostname}')
         for selfip_port in selfips:
-            ensure_selfip_task = f5_tasks.EnsureSelfIP(
+            ensure_selfip_task = self.tasks.EnsureSelfIP(
                 name=f'ensure-selfip-{bigip_hostname}-{selfip_port.id}',
                 inject={
                     # store data should come first because it also contains port data
@@ -52,14 +55,14 @@ class F5Flows(object):
         # create subnet routes for all subnets that don't have a SelfIP
         network = store['network']
         subnets_to_create_routes_for = [subnet for subnet in network.subnets
-                                        if not f5_tasks.selfip_for_subnet_exists(subnet, selfips)]
+                                        if not driver_utils.selfip_for_subnet_exists(subnet, selfips)]
         ensure_subnet_routes_subflow = unordered_flow.Flow(
             f'ensure-subnet-routes-subflow-{bigip_hostname}')
 
         # make subnet route creation subflow
         for subnet_id in subnets_to_create_routes_for:
-            subnet_route_name = f5_tasks.get_subnet_route_name(network.id, subnet_id)
-            ensure_subnet_route_task = f5_tasks.EnsureSubnetRoute(
+            subnet_route_name = driver_utils.get_subnet_route_name(network.id, subnet_id)
+            ensure_subnet_route_task = self.tasks.EnsureSubnetRoute(
                 name=f'ensure-subnet-route-{bigip_hostname}-{subnet_route_name}',
                 inject={
                     # store data should come first because it also contains subnet_id
@@ -69,19 +72,19 @@ class F5Flows(object):
             )
             ensure_subnet_routes_subflow.add(ensure_subnet_route_task)
 
-        get_existing_route_domain = f5_tasks.GetExistingRouteDomain(
+        get_existing_route_domain = self.tasks.GetExistingRouteDomain(
             name=f'get-existing-route-domain-{bigip_hostname}',
             inject=store)
-        ensure_route_domain = f5_tasks.EnsureRouteDomain(
+        ensure_route_domain = self.tasks.EnsureRouteDomain(
             name=f'ensure-route-domain-{bigip_hostname}',
             inject=store)
-        ensure_default_route = f5_tasks.EnsureDefaultRoute(
+        ensure_default_route = self.tasks.EnsureDefaultRoute(
             name=f'ensure-default-route-{bigip_hostname}',
             inject=store)
-        get_existing_vlan = f5_tasks.GetExistingVLAN(
+        get_existing_vlan = self.tasks.GetExistingVLAN(
             name=f'get-existing-vlan-{bigip_hostname}',
             inject=store)
-        ensure_vlan = f5_tasks.EnsureVLAN(
+        ensure_vlan = self.tasks.EnsureVLAN(
             name=f'ensure-vlan-{bigip_hostname}',
             inject=store)
 
@@ -114,7 +117,7 @@ class F5Flows(object):
         remove_subnet_routes_subflow = unordered_flow.Flow(
             f'remove-subnet-routes-subflow-{bigip_hostname}')
         for subnet_route in existing_subnet_routes:
-            remove_subnet_route_task = f5_tasks.RemoveSubnetRoute(
+            remove_subnet_route_task = self.tasks.RemoveSubnetRoute(
                 name=f"remove-subnet-route-{bigip_hostname}-{subnet_route['name']}",
                 inject={
                     **store,
@@ -126,7 +129,7 @@ class F5Flows(object):
         # remove SelfIPs
         remove_selfips_subflow = unordered_flow.Flow(f'remove-selfips-subflow-{bigip_hostname}')
         for selfip in existing_selfips:
-            remove_selfip_task = f5_tasks.RemoveSelfIP(
+            remove_selfip_task = self.tasks.RemoveSelfIP(
                 name=f"remove-selfip-{bigip_hostname}-{selfip['port_id']}",
                 inject={
                     **store,
@@ -136,19 +139,19 @@ class F5Flows(object):
             remove_selfips_subflow.add(remove_selfip_task)
 
         # remove other L2 objects
-        remove_default_route_task = f5_tasks.RemoveDefaultRoute(
+        remove_default_route_task = self.tasks.RemoveDefaultRoute(
             name=f'remove-defult-route-{bigip_hostname}',
             inject=store)
-        get_existing_route_domain = f5_tasks.GetExistingRouteDomain(
+        get_existing_route_domain = self.tasks.GetExistingRouteDomain(
             name=f'get-existing-route-domain-{bigip_hostname}',
             inject=store)
-        remove_route_domain_task = f5_tasks.RemoveRouteDomain(
+        remove_route_domain_task = self.tasks.RemoveRouteDomain(
             name=f'remove-route-domain-{bigip_hostname}',
             inject=store)
-        get_existing_vlan = f5_tasks.GetExistingVLAN(
+        get_existing_vlan = self.tasks.GetExistingVLAN(
             name=f'get-existing-vlan-{bigip_hostname}',
             inject=store)
-        remove_vlan_task = f5_tasks.RemoveVLAN(
+        remove_vlan_task = self.tasks.RemoveVLAN(
             name=f'remove-vlan-{bigip_hostname}',
             inject=store)
 
@@ -201,7 +204,7 @@ class F5Flows(object):
         existing_subnet_routes = store['existing_subnet_routes']
 
         # remove subnet routes that are existing but don't belong to one of the subnets that need routes
-        subnet_route_network_part = f5_tasks.get_subnet_route_name(network.id, '')
+        subnet_route_network_part = driver_utils.get_subnet_route_name(network.id, '')
         subnet_routes_to_remove = [r for r in existing_subnet_routes
                                    if r['name'].startswith(subnet_route_network_part) and
                                    r['name'][len(subnet_route_network_part):] not in subnets_that_need_routes]
@@ -211,8 +214,8 @@ class F5Flows(object):
         # make subnet routes removal subflow
         remove_subnet_routes_subflow = unordered_flow.Flow('remove-subnet-routes-subflow')
         for subnet_route in subnet_routes_to_remove:
-            remove_subnet_route_task = f5_tasks.RemoveSubnetRoute(name=f"remove-subnet-route-{subnet_route['name']}",
-                                                                  inject={'subnet_route': subnet_route})
+            remove_subnet_route_task = self.tasks.RemoveSubnetRoute(name=f"remove-subnet-route-{subnet_route['name']}",
+                                                                    inject={'subnet_route': subnet_route})
             remove_subnet_routes_subflow.add(remove_subnet_route_task)
 
         # remove SelfIPs that are existing but not needed
@@ -222,8 +225,8 @@ class F5Flows(object):
         # make SelfIPs removal subflow
         remove_selfips_subflow = unordered_flow.Flow('remove-selfips-subflow')
         for selfip in selfips_to_remove:
-            remove_selfip = f5_tasks.RemoveSelfIP(name=f"remove-selfip-{selfip['port_id']}",
-                                                  inject={'selfip': selfip})
+            remove_selfip = self.tasks.RemoveSelfIP(name=f"remove-selfip-{selfip['port_id']}",
+                                                    inject={'selfip': selfip})
             remove_selfips_subflow.add(remove_selfip)
 
         # make and return flow
@@ -252,13 +255,13 @@ class F5Flows(object):
         # make SelfIP creation subflow
         ensure_selfips_subflow = unordered_flow.Flow('ensure-selfips-subflow')
         for selfip_port in selfips_to_create:
-            ensure_selfip_task = f5_tasks.EnsureSelfIP(
+            ensure_selfip_task = self.tasks.EnsureSelfIP(
                 name=f'ensure-selfip-{store["bigip"].hostname}-{selfip_port.id}',
                 inject={'port': selfip_port})
             ensure_selfips_subflow.add(ensure_selfip_task)
 
         # find subnet routes for subnets that need them but don't have any yet
-        subnet_route_network_part = f5_tasks.get_subnet_route_name(network.id, '')
+        subnet_route_network_part = driver_utils.get_subnet_route_name(network.id, '')
         subnets_of_preexisting_subnet_routes = [
             r['name'][len(subnet_route_network_part):] for r in preexisting_subnet_routes
             if r['name'].startswith(subnet_route_network_part)
@@ -271,9 +274,9 @@ class F5Flows(object):
         # make subnet route creation subflow
         ensure_subnet_routes_subflow = unordered_flow.Flow('ensure-subnet-routes-subflow')
         for subnet_id in subnets_to_create_routes_for:
-            subnet_route_name = f5_tasks.get_subnet_route_name(network.id, subnet_id)
-            ensure_subnet_route_task = f5_tasks.EnsureSubnetRoute(name=f"ensure-subnet-route-{subnet_route_name}",
-                                                                  inject={'subnet_id': subnet_id})
+            subnet_route_name = driver_utils.get_subnet_route_name(network.id, subnet_id)
+            ensure_subnet_route_task = self.tasks.EnsureSubnetRoute(name=f"ensure-subnet-route-{subnet_route_name}",
+                                                                    inject={'subnet_id': subnet_id})
             ensure_subnet_routes_subflow.add(ensure_subnet_route_task)
 
         # make and return flow
@@ -286,8 +289,8 @@ class F5Flows(object):
         """Return a flow that gets all SelfIPs and subnet routes that currently
         exist on a particular device for a particular network."""
 
-        get_selfips_task = f5_tasks.GetExistingSelfIPsForVLAN(name='get-existing-selfips')
-        get_subnet_routes_task = f5_tasks.GetExistingSubnetRoutesForNetwork(name='get-existing-subnet-routes')
+        get_selfips_task = self.tasks.GetExistingSelfIPsForVLAN(name='get-existing-selfips')
+        get_subnet_routes_task = self.tasks.GetExistingSubnetRoutesForNetwork(name='get-existing-subnet-routes')
 
         get_existing_sip_sr_flow = unordered_flow.Flow('get-existing-selfips-and-subnet-routes-flow')
         get_existing_sip_sr_flow.add(get_selfips_task)
@@ -296,10 +299,10 @@ class F5Flows(object):
         return get_existing_sip_sr_flow
 
     def make_ensure_vcmp_l2_flow(self) -> flow.Flow:
-        get_existing_vlan = f5_tasks.GetExistingVLAN()
-        ensure_vlan = f5_tasks.EnsureVLAN()
-        ensure_vlan_interface = f5_tasks.EnsureVLANInterface()
-        ensure_guest_vlan = f5_tasks.EnsureGuestVLAN()
+        get_existing_vlan = self.tasks.GetExistingVLAN()
+        ensure_vlan = self.tasks.EnsureVLAN()
+        ensure_vlan_interface = self.tasks.EnsureVLANInterface()
+        ensure_guest_vlan = self.tasks.EnsureGuestVLAN()
 
         ensure_vcmp_l2_flow = linear_flow.Flow('ensure-vcmp-l2-flow')
         ensure_vcmp_l2_flow.add(get_existing_vlan,
@@ -309,12 +312,14 @@ class F5Flows(object):
         return ensure_vcmp_l2_flow
 
     def make_remove_vcmp_l2_flow(self) -> flow.Flow:
-        get_vcmp_guests = f5_tasks.GetVCMPGuests()
-        remove_guest_vlan = f5_tasks.RemoveGuestVLAN()
-        remove_vlan_if_not_owned_by_guest = f5_tasks.RemoveVLANIfNotOwnedByGuest()
+        get_vcmp_guests = self.tasks.GetVCMPGuests()
+        remove_guest_vlan = self.tasks.RemoveGuestVLAN()
+        remove_vlan_interface = self.tasks.RemoveVLANInterface()
+        remove_vlan_if_not_owned_by_guest = self.tasks.RemoveVLANIfNotOwnedByGuest()
 
         remove_vcmp_l2_flow = linear_flow.Flow('remove-vcmp-l2-flow')
         remove_vcmp_l2_flow.add(get_vcmp_guests,
                                 remove_guest_vlan,
+                                remove_vlan_interface,
                                 remove_vlan_if_not_owned_by_guest)
         return remove_vcmp_l2_flow

--- a/octavia_f5/controller/worker/flows/f5_flows_rseries.py
+++ b/octavia_f5/controller/worker/flows/f5_flows_rseries.py
@@ -1,0 +1,26 @@
+#  Copyright 2022 SAP SE
+#
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License. You may obtain
+#  a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+
+from oslo_log import log as logging
+from octavia_f5.controller.worker.flows import f5_flows_iseries
+from octavia_f5.controller.worker.tasks import f5_tasks_rseries
+
+LOG = logging.getLogger(__name__)
+
+
+class F5Flows(f5_flows_iseries.F5Flows):
+    """Class that configures flows to use tasks specific to rSeries devices."""
+
+    def __init__(self):
+        super(F5Flows, self).__init__(tasks=f5_tasks_rseries)

--- a/octavia_f5/controller/worker/l2_sync_manager.py
+++ b/octavia_f5/controller/worker/l2_sync_manager.py
@@ -28,8 +28,7 @@ from octavia.common.base_taskflow import BaseTaskFlowEngine
 from octavia.network import base
 from octavia.network import data_models as network_models
 from octavia_f5.common import constants
-from octavia_f5.controller.worker.flows import f5_flows
-from octavia_f5.controller.worker.tasks import f5_tasks
+from octavia_f5.controller.worker.flows import f5_flows_iseries, f5_flows_rseries
 from octavia_f5.restclient.bigip import bigip_auth
 from octavia_f5.restclient.bigip.bigip_restclient import BigIPRestClient
 from octavia_f5.utils import driver_utils, decorators, exceptions
@@ -47,12 +46,16 @@ class L2SyncManager(BaseTaskFlowEngine):
     def __init__(self):
         super().__init__()
         self._bigips = list(self.initialize_bigips(CONF.f5_agent.bigip_urls))
-        self._vcmps = list(self.initialize_bigips(CONF.networking.vcmp_urls))
-        self._f5flows = f5_flows.F5Flows()
+        self._vcmps = list(self.initialize_bigips(CONF.networking.vcmp_urls,
+                                                  r_series_vcmp_host=CONF.networking.vcmp_rseries))
+        # since (for rSeries) host and guest might use different APIs, we need
+        # two f5flows objects - one for host, one for guest
+        self._f5flows_host = f5_flows_rseries.F5Flows() if CONF.networking.vcmp_rseries else f5_flows_iseries.F5Flows()
+        self._f5flows_guest = f5_flows_iseries.F5Flows()
         self._network_driver = driver_utils.get_network_driver()
         self.executor = futures.ThreadPoolExecutor(max_workers=CONF.networking.max_workers)
 
-    def initialize_bigips(self, bigip_urls: List[str]):
+    def initialize_bigips(self, bigip_urls: [str], r_series_vcmp_host=False):
         if CONF.f5_agent.dry_run:
             return []
 
@@ -64,11 +67,11 @@ class L2SyncManager(BaseTaskFlowEngine):
                       'verify': CONF.f5_agent.bigip_verify}
 
             if CONF.f5_agent.bigip_token:
-                kwargs['auth'] = bigip_auth.BigIPTokenAuth(bigip_url)
+                kwargs['auth'] = bigip_auth.BigIPTokenAuth(bigip_url, f5os_a=r_series_vcmp_host)
             else:
                 kwargs['auth'] = bigip_auth.BigIPBasicAuth(bigip_url)
 
-            instance = BigIPRestClient(**kwargs)
+            instance = BigIPRestClient(**kwargs, f5os_a=r_series_vcmp_host)
             instances.append(instance)
         return instances
 
@@ -90,7 +93,7 @@ class L2SyncManager(BaseTaskFlowEngine):
         for flow_data in data:
             # get existing SelfIPs and subnet routes - they are needed to determine,
             # which ones have to be created and which already exist
-            e = self.taskflow_load(self._f5flows.make_get_existing_selfips_and_subnet_routes_flow(),
+            e = self.taskflow_load(self._f5flows_guest.make_get_existing_selfips_and_subnet_routes_flow(),
                                    store=flow_data['store'])
             with tf_logging.LoggingListener(e, log=LOG):
                 e.run()
@@ -101,7 +104,7 @@ class L2SyncManager(BaseTaskFlowEngine):
             flow_data['store']['existing_subnet_routes'] = e.storage.get('get-existing-subnet-routes')
 
             ensure_l2_flow.add(
-                self._f5flows.make_ensure_l2_flow(
+                self._f5flows_guest.make_ensure_l2_flow(
                     flow_data['selfips'], store=flow_data['store']))
 
         # We have to inject all required variables to each flow/task because these flows will
@@ -113,7 +116,7 @@ class L2SyncManager(BaseTaskFlowEngine):
             e.run()
 
     def _do_ensure_vcmp_l2_flow(self, store: dict):
-        e = self.taskflow_load(self._f5flows.make_ensure_vcmp_l2_flow(), store=store)
+        e = self.taskflow_load(self._f5flows_host.make_ensure_vcmp_l2_flow(), store=store)
         with tf_logging.DynamicLoggingListener(e, log=LOG):
             e.run()
 
@@ -121,7 +124,7 @@ class L2SyncManager(BaseTaskFlowEngine):
         remove_l2_flow = unordered_flow.Flow('remove-l2-flow-from-all-devices')
         for flow_data in data:
             # get existing SelfIPs and subnet routes
-            e = self.taskflow_load(self._f5flows.make_get_existing_selfips_and_subnet_routes_flow(),
+            e = self.taskflow_load(self._f5flows_guest.make_get_existing_selfips_and_subnet_routes_flow(),
                                    store=flow_data['store'])
             with tf_logging.LoggingListener(e, log=LOG):
                 e.run()
@@ -131,7 +134,7 @@ class L2SyncManager(BaseTaskFlowEngine):
             flow_data['store']['existing_selfips'] = e.storage.get('get-existing-selfips')
             flow_data['store']['existing_subnet_routes'] = e.storage.get('get-existing-subnet-routes')
 
-            remove_l2_flow.add(self._f5flows.make_remove_l2_flow(store=flow_data['store']))
+            remove_l2_flow.add(self._f5flows_guest.make_remove_l2_flow(store=flow_data['store']))
 
         e = self.taskflow_load(remove_l2_flow)
         with tf_logging.LoggingListener(e, log=LOG):
@@ -145,7 +148,7 @@ class L2SyncManager(BaseTaskFlowEngine):
         before creation."""
 
         # get existing SelfIPs and subnet routes
-        e = self.taskflow_load(self._f5flows.make_get_existing_selfips_and_subnet_routes_flow(), store=store)
+        e = self.taskflow_load(self._f5flows_guest.make_get_existing_selfips_and_subnet_routes_flow(), store=store)
         with tf_logging.LoggingListener(e, log=LOG):
             e.run()
         existing_selfips = e.storage.get('get-existing-selfips')
@@ -154,7 +157,7 @@ class L2SyncManager(BaseTaskFlowEngine):
         # subnet routes that must exist (subnets with SelfIPs already have routes)
         network = store['network']
         subnets_that_need_routes = [subnet for subnet in network.subnets if
-                                    not f5_tasks.selfip_for_subnet_exists(subnet, needed_selfips)]
+                                    not driver_utils.selfip_for_subnet_exists(subnet, needed_selfips)]
 
         # log the current and desired state
         hostname = store['bigip'].hostname
@@ -169,14 +172,14 @@ class L2SyncManager(BaseTaskFlowEngine):
         # get and run the sync flow
         store['existing_selfips'] = existing_selfips
         store['existing_subnet_routes'] = existing_subnet_routes
-        sync_flow = self._f5flows.make_sync_selfips_and_subnet_routes_flow(
+        sync_flow = self._f5flows_guest.make_sync_selfips_and_subnet_routes_flow(
             needed_selfips, subnets_that_need_routes, store)
         e = self.taskflow_load(sync_flow, store=store)
         with tf_logging.LoggingListener(e, log=LOG):
             e.run()
 
     def _do_remove_vcmp_l2_flow(self, store: dict):
-        e = self.taskflow_load(self._f5flows.make_remove_vcmp_l2_flow(), store=store)
+        e = self.taskflow_load(self._f5flows_host.make_remove_vcmp_l2_flow(), store=store)
         with tf_logging.DynamicLoggingListener(e, log=LOG):
             e.run()
 
@@ -218,7 +221,7 @@ class L2SyncManager(BaseTaskFlowEngine):
             self._do_ensure_l2_flow,
             data=ensure_l2_flow_data)] = self._bigips
 
-        # run VCMP l2 flow for all VCMPs in parallel
+        # run VCMP l2 flow for all VCMP hosts in parallel
         for vcmp in self._vcmps:
             store = {'bigip': vcmp, 'network': network}
             if CONF.networking.override_vcmp_guest_names:
@@ -384,7 +387,7 @@ class L2SyncManager(BaseTaskFlowEngine):
                 needed_subnet_routes = []
                 for net, subs in [(n, networks[n].subnets) for n in networks]:
                     # lb_subnets is the list of subnets that don't have subnet routes but SelfIPs
-                    needed_subnet_routes.extend([f5_tasks.get_subnet_route_name(net, sub)
+                    needed_subnet_routes.extend([driver_utils.get_subnet_route_name(net, sub)
                                                  for sub in subs if sub not in lb_subnets])
                 if route['name'] in needed_subnet_routes:
                     continue

--- a/octavia_f5/controller/worker/tasks/f5_tasks_iseries.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks_iseries.py
@@ -22,25 +22,12 @@ from taskflow import task
 from taskflow.types import failure
 
 from octavia.network import data_models as network_models
-from octavia_f5.common import constants
 from octavia_f5.network import data_models as f5_network_models
 from octavia_f5.restclient.bigip import bigip_restclient
 from octavia_f5.utils import driver_utils, decorators
 
 LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
-
-
-def selfip_for_subnet_exists(subnet_id, selfips):
-    for selfip in selfips:
-        for fixed_ip in selfip.fixed_ips:
-            if fixed_ip.subnet_id == subnet_id:
-                return True
-    return False
-
-
-def get_subnet_route_name(network_id, subnet_id):
-    return f"{constants.PREFIX_NETWORK}{network_id}_{constants.PREFIX_SUBNET}{subnet_id}"
 
 
 class EnsureVLAN(task.Task):
@@ -73,6 +60,7 @@ class EnsureVLAN(task.Task):
             res.raise_for_status()
             return res.json()
 
+        # patch VLAN if it differs (<= is a subset operator here)
         if not vlan.items() <= existing_vlan.items():
             res = bigip.patch(path=f"/mgmt/tm/net/vlan/~Common~{vlan['name']}",
                               json=vlan)
@@ -114,7 +102,7 @@ class EnsureVLANInterface(task.Task):
             }]
         }
 
-        # Create vlan interface if not existing or not correct
+        # Create VLAN interface if not existing or not correct
         device_vlan_interfaces = device_vlan['interfacesReference'].get('items')
         if not device_vlan_interfaces or not interface.items() <= device_vlan_interfaces[0].items():
             res = bigip.patch(
@@ -123,12 +111,20 @@ class EnsureVLANInterface(task.Task):
             res.raise_for_status()
             return res.json()
 
+        # VLAN interface exists and is correct
         return None
 
 
-class EnsureGuestVLAN(task.Task):
-    default_provides = 'device_guest'
+class RemoveVLANInterface(task.Task):
+    """ Task to remove VLAN interface attachment """
 
+    def execute(self):
+        # we don't need to remove the VLAN interface attachment on iSeries devices, because they're automatically
+        # removed when the VLAN is deleted.
+        pass
+
+
+class EnsureGuestVLAN(task.Task):
     """ Task to assign correct vlan to vcmp guest """
 
     @decorators.RaisesIControlRestError()
@@ -137,7 +133,6 @@ class EnsureGuestVLAN(task.Task):
                 bigip_guest_names: List[str],
                 device_vlan: dict):
 
-        device_guest = None
         device_response = bigip.get(path='/mgmt/tm/vcmp/guest')
         device_response.raise_for_status()
         guests = device_response.json()
@@ -146,8 +141,7 @@ class EnsureGuestVLAN(task.Task):
             if guest['name'] not in bigip_guest_names:
                 continue
 
-            device_guest = guest
-
+            # Check if the VLAN is already configured on the guest
             if device_vlan['name'] in ['/Common/' + vlan for vlan in guest['vlans']]:
                 continue
 
@@ -155,10 +149,6 @@ class EnsureGuestVLAN(task.Task):
                 path=f"/mgmt/tm/vcmp/guest/{guest['name']}",
                 json={'vlans': guest['vlans'] + [f"/Common/{device_vlan['name']}"]})
             res.raise_for_status()
-            return res.json()
-
-        # No Changes needed
-        return device_guest
 
 
 class EnsureRouteDomain(task.Task):
@@ -335,7 +325,7 @@ class GetExistingSubnetRoutesForNetwork(task.Task):
         routes = response.get('items', [])
 
         # filter for only the subnet routes belonging to this network
-        subnet_route_network_part = get_subnet_route_name(network.id, '')
+        subnet_route_network_part = driver_utils.get_subnet_route_name(network.id, '')
         return [r for r in routes if r['name'].startswith(subnet_route_network_part)]
 
 
@@ -397,7 +387,7 @@ class EnsureSubnetRoute(task.Task):
             return
 
         # payload
-        subnet_route_name = get_subnet_route_name(network.id, subnet_id)
+        subnet_route_name = driver_utils.get_subnet_route_name(network.id, subnet_id)
         network_driver = driver_utils.get_network_driver()
         subnet = network_driver.get_subnet(subnet_id)
         subnet_cidr = IPNetwork(subnet.cidr)
@@ -430,7 +420,7 @@ class EnsureSubnetRoute(task.Task):
                network: f5_network_models.Network,
                subnet_id, existing_subnet_routes,
                *args, **kwargs):
-        subnet_route_name = get_subnet_route_name(network.id, subnet_id)
+        subnet_route_name = driver_utils.get_subnet_route_name(network.id, subnet_id)
         # Don't remove the route if it existed before this task was executed
         if subnet_route_name in [r['name'] for r in existing_subnet_routes]:
             LOG.warning("Reverting EnsureSubnetRoute: Not deleting route, since it existed before the task was run: "

--- a/octavia_f5/controller/worker/tasks/f5_tasks_rseries.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks_rseries.py
@@ -1,0 +1,279 @@
+#  Copyright 2022 SAP SE
+#
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License. You may obtain
+#  a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+
+import requests
+import tenacity
+from oslo_config import cfg
+from oslo_log import log as logging
+from taskflow import task
+
+from octavia_f5.network import data_models as f5_network_models
+from octavia_f5.restclient.bigip import bigip_restclient
+from octavia_f5.utils import driver_utils, decorators
+
+# import all tasks and override only those that are different for rSeries devices
+from .f5_tasks_iseries import *  # noqa: F403,F401
+
+LOG = logging.getLogger(__name__)
+CONF = cfg.CONF
+
+
+class EnsureVLAN(task.Task):
+
+    """ Task to create or update VLAN if needed """
+
+    @decorators.RaisesF5osaError()
+    @tenacity.retry(
+        retry=tenacity.retry_if_exception_type(requests.HTTPError),
+        wait=tenacity.wait_fixed(2),
+        stop=tenacity.stop_after_attempt(3)
+    )
+    def execute(self,
+                bigip: bigip_restclient.BigIPRestClient,
+                existing_vlan: dict,
+                network: f5_network_models.Network):
+        vlan_id = network.vlan_id
+        vlan_payload = {
+            "vlan-id": vlan_id,
+            "config": {
+                "vlan-id": vlan_id,
+                "name": f"vlan-{vlan_id}",
+            }
+        }
+        payload = {'openconfig-vlan:vlan': [vlan_payload]}
+
+        # return if VLAN already exists
+        if existing_vlan:
+            return existing_vlan
+
+        # contrary to the EnsureVLAN task for iSeries devices, we don't need to patch the VLAN in this task,
+        # because it only contains the VLAN ID. In fact, comparing the existing_vlan dictionary with the payload
+        # would be misleading, since existing_vlan may also include the "members" key, which can change pretty
+        # much arbitrarily.
+
+        # create missing VLAN
+        res = bigip.put(path=f"/api/data/openconfig-vlan:vlans/vlan={vlan_id}", json=payload)
+        res.raise_for_status()
+
+    @decorators.RaisesF5osaError()
+    def revert(self, network: f5_network_models.Network,
+               bigip: bigip_restclient.BigIPRestClient,
+               existing_vlan, *args, **kwargs):
+        vlan_id = network.vlan_id
+        if existing_vlan is not None:
+            LOG.warning(f"EnsureVLAN revert: Not deleting VLAN {vlan_id}, since it existed before "
+                        f"the task was run: {existing_vlan}")
+            return
+        res = bigip.delete(path=f"/api/data/openconfig-vlan:vlans/vlan={vlan_id}")
+        if not res.ok:
+            LOG.warning("EnsureVLAN revert: Failed removing VLAN on the device %s for "
+                        "vlan_id=%s: %s", bigip.hostname, vlan_id, res.content)
+        res.raise_for_status()
+
+
+class GetExistingVLAN(task.Task):
+    default_provides = 'existing_vlan'
+
+    @decorators.RaisesF5osaError()
+    def execute(self,
+                bigip: bigip_restclient.BigIPRestClient,
+                network: f5_network_models.Network):
+        vlan_id = network.vlan_id
+        res = bigip.get(path=f"/api/data/openconfig-vlan:vlans/vlan={vlan_id}")
+        if res.status_code == 404:
+            return None
+        res.raise_for_status()
+
+        # get and return VLAN dict from response json
+        vlan_list = res.json()["openconfig-vlan:vlan"]
+        if len(vlan_list) > 1:
+            LOG.warning(f"GetExistingVLAN: Got multiple VLANs for ID {vlan_id}: {vlan_list} - only using the first one")
+        return vlan_list[0]
+
+
+class EnsureVLANInterface(task.Task):
+    """ Task to create or update VLAN interface/LAG attachment if needed"""
+
+    @decorators.RaisesF5osaError()
+    def execute(self,
+                bigip: bigip_restclient.BigIPRestClient,
+                network: f5_network_models.Network):
+        vlan_id = network.vlan_id
+        network_driver = driver_utils.get_network_driver()
+        lag_name = network_driver.physical_interface
+        payload = {'openconfig-vlan:trunk-vlans': [vlan_id]}
+
+        # Create VLAN interface if not existing or not correct
+        path = f"/api/data/openconfig-interfaces:interfaces/interface={lag_name}" \
+               f"/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config/trunk-vlans={vlan_id}"
+        res = bigip.put(path=path, json=payload)
+        res.raise_for_status()
+
+
+class EnsureGuestVLAN(task.Task):
+    """ Task to assign correct vlan to vcmp guest """
+
+    @decorators.RaisesF5osaError()
+    def execute(self,
+                bigip: bigip_restclient.BigIPRestClient,
+                bigip_guest_names: [str],
+                network: f5_network_models.Network):
+        vlan_id = network.vlan_id
+
+        # the guests are called tenant in the F5OS-A API
+        device_response = bigip.get(path='/api/data/f5-tenants:tenants')
+        device_response.raise_for_status()
+        guests = device_response.json()["f5-tenants:tenants"]["tenant"]
+
+        # assign the VLAN to each managed guest
+        for guest in guests:
+            guest_name = guest['name']
+
+            # Check if it's a managed guest.
+            # F5OS-A API only gives the host part of the name, so we have to check with startswith. We have to
+            # check against the guest name with a dot appended, so that partial guest names don't match.
+            if not any(name.startswith(guest_name + ".") for name in bigip_guest_names):
+                continue
+
+            # Check if the VLAN is already configured on the guest
+            if vlan_id in guest['config']['vlans']:
+                continue
+
+            res = bigip.put(
+                path=f"/api/data/f5-tenants:tenants/tenant={guest_name}/config/vlans={vlan_id}",
+                json={'f5-tenants:vlans': [vlan_id]})
+            res.raise_for_status()
+
+
+class GetVCMPGuests(task.Task):
+    default_provides = 'device_guests'
+
+    """ Provides guests dict of a VCMP host """
+
+    @decorators.RaisesF5osaError()
+    def execute(self,
+                bigip: bigip_restclient.BigIPRestClient):
+        device_response = bigip.get(path='/api/data/f5-tenants:tenants')
+        device_response.raise_for_status()
+        return device_response.json()["f5-tenants:tenants"]["tenant"]
+
+
+class RemoveGuestVLAN(task.Task):
+    """ Removes vlan assignment of a VCMP Guest """
+    @decorators.RaisesF5osaError()
+    def execute(self,
+                bigip: bigip_restclient.BigIPRestClient,
+                bigip_guest_names: [str],
+                device_guests: list,
+                network: f5_network_models.Network):
+        vlan_id = network.vlan_id
+        for guest in device_guests:
+            guest_name = guest['name']
+
+            # Check if it's a managed guest.
+            # F5OS-A API only gives the host part of the name, so we have to check with startswith. We have to
+            # check against the guest name with a dot appended, so that partial guest names don't match.
+            if not any(name.startswith(guest_name + ".") for name in bigip_guest_names):
+                continue
+
+            # Already removed?
+            if vlan_id not in guest['config']['vlans']:
+                return
+
+            res = bigip.delete(
+                path=f"/api/data/f5-tenants:tenants/tenant={guest_name}/config/vlans={vlan_id}")
+            if not res.ok:
+                LOG.warning("%s: Failed removing guest VLAN for vlan_id=%s: %s",
+                            bigip.hostname, network.vlan_id, res.content)
+            res.raise_for_status()
+
+
+class RemoveVLANInterface(task.Task):
+    """ Task to remove VLAN interface attachment """
+
+    @decorators.RaisesF5osaError()
+    def execute(self,
+                bigip: bigip_restclient.BigIPRestClient,
+                network: f5_network_models.Network):
+        network_driver = driver_utils.get_network_driver()
+        lag_name = network_driver.physical_interface
+        vlan_id = network.vlan_id
+
+        path = f"/api/data/openconfig-interfaces:interfaces/interface={lag_name}" \
+               f"/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config/trunk-vlans={vlan_id}"
+        res = bigip.delete(path=path)
+
+        if res.status_code == 404:
+            LOG.warning(f"Can't detach VLAN {vlan_id} from LAG {lag_name} for host {bigip.hostname}. Already detached?")
+            return
+        res.raise_for_status()
+
+
+class RemoveVLANIfNotOwnedByGuest(task.Task):
+
+    @decorators.RaisesF5osaError()
+    # This backoff-retry mechanism is needed due to known F5 bug 1759761.
+    # - KB article about the bug: https://my.f5.com/s/article/K000149152
+    # - F5-internal case for SAP instance of the bug: 00888515
+    # FIXME remove backoff-retry when bug is fixed (should be the case with F5OS 2.0).
+    @tenacity.retry(
+        retry=tenacity.retry_if_exception_type(requests.HTTPError),
+        wait=tenacity.wait_exponential(),
+        stop=tenacity.stop_after_attempt(3)
+    )
+    def execute(self,
+                bigip: bigip_restclient.BigIPRestClient,
+                bigip_guest_names: [str],
+                device_guests: list,
+                network: f5_network_models.Network):
+        """ Task to delete VLAN on a VCMP Host  """
+        vlan_id = network.vlan_id
+
+        for guest in device_guests:
+            # skip own guest
+            # bigip_guest_names contain the whole domain, but the guest knows only its hostname
+            if any(guest_name.startswith(guest['name'] + '.') for guest_name in bigip_guest_names):
+                continue
+
+            # if vlan is in use by other guest, don't delete it
+            if vlan_id in guest['config']['vlans']:
+                return
+
+        res = bigip.delete(path=f"/api/data/openconfig-vlan:vlans/vlan={vlan_id}")
+        if not res.ok:
+            LOG.warning("%s: Failed RemoveVLANIfNotOwnedByGuest for vlan_id=%s: %s",
+                        bigip.hostname, network.vlan_id, res.content)
+
+        # There is another bug (not F5 bug 1759761 noted above, which is the
+        # one for which we retry) - where VLAN detachment from the guest comes
+        # back with HTTP 200 even though it's not finished yet. And if it then
+        # ends up failing, because there are still objects on the guest that
+        # depend on the VLAN, the vlan-listener object will still exist and
+        # block VLAN deletion, even though the device config says the VLAN is
+        # detached from the guest. vlan-listeners cannot be deleted.
+        # The only fix is to attach and detach the VLAN to/from the guest
+        # again. But since this incurs a performance penalty and the issue does
+        # not impede LB configuration, we instead simply ignore failed VLAN
+        # deletion. The VLAN can safely be reused later - a subsequent creation
+        # request for it yields HTTP 201. This is the easiest option that
+        # doesn't cause problems.
+        # Note that this effectively disables the tenacity backoff-retry
+        # mechanism on this method, since this method will never raise an
+        # exception. That's okay, since orphaned VLANs are okay (see above).
+        # But the retry code must not be removed, because when this bug is
+        # fixed, bug 1759761 might still be around. They have to be treated
+        # separately.
+        # FIXME reenable raise_for_status when this bug is fixed or when guest
+        # cleanup code is guaranteed to finish before host cleanup code.
+        # res.raise_for_status()

--- a/octavia_f5/restclient/bigip/bigip_auth.py
+++ b/octavia_f5/restclient/bigip/bigip_auth.py
@@ -19,9 +19,11 @@ import tenacity
 from requests.auth import HTTPBasicAuth, AuthBase
 
 BIGIP_TOKEN_HEADER = 'X-F5-Auth-Token'
+BIGIP_TOKEN_HEADER_F5OS_A = 'X-Auth-Token'
 BIGIP_TOKEN_MAX_TIMEOUT = '36000'
 BIGIP_TOKENS_PATH = '/mgmt/shared/authz/tokens'
 BIGIP_LOGIN_PATH = '/mgmt/shared/authn/login'
+BIGIP_LOGIN_PATH_F5OS_A = '/api/data/openconfig-system:system/aaa'
 
 
 class BigIPBasicAuth(HTTPBasicAuth):
@@ -36,21 +38,28 @@ class BigIPBasicAuth(HTTPBasicAuth):
 class BigIPTokenAuth(AuthBase):
     """ A requests custom Auth provider that installs a response hook to detect authentication
         responses and acquires a BigIP authentication token for follow up http requests. """
-    def __init__(self, url):
+
+    def __init__(self, url, f5os_a=False):
+        """The f5os_a parameter defines whether we're talking to a F5OS-A API, which is used on rSeries devices. It
+        must be supplied by the caller, because this class is instantiated for both, communication with BigIP guests
+        and hosts, and they might use different APIs."""
         self.url = url
         parse_result = parse.urlparse(url, allow_fragments=False)
         self.username = parse_result.username
         self.password = parse.unquote(parse_result.password)
+        self.f5os_a = f5os_a
         # Use single global token
         self.token = None
+        self._token_endpoint = BIGIP_LOGIN_PATH if not f5os_a else BIGIP_LOGIN_PATH_F5OS_A
+        self._token_header = BIGIP_TOKEN_HEADER if not f5os_a else BIGIP_TOKEN_HEADER_F5OS_A
 
     def handle_401(self, r, **kwargs):
         """ This response hook will fetch a fresh token if encountered an 401 response code.
-            It's loosly based on requests digest auth
+            It's loosely based on requests digest auth.
 
         :return: requests.Response
         """
-        if not r.status_code == 401:
+        if r.status_code != 401:
             return r
 
         # Consume content and release the original connection
@@ -60,7 +69,7 @@ class BigIPTokenAuth(AuthBase):
         r.content
         r.raw.release_conn()
         prep = r.request.copy()
-        prep.headers[BIGIP_TOKEN_HEADER] = self.get_token()
+        prep.headers[self._token_header] = self.get_token()
 
         _r = r.connection.send(prep, **kwargs)
         _r.history.append(r)
@@ -71,7 +80,7 @@ class BigIPTokenAuth(AuthBase):
     def __call__(self, r):
         # No token, no fun
         if self.token:
-            r.headers[BIGIP_TOKEN_HEADER] = self.token
+            r.headers[self._token_header] = self.token
 
         # handle 401 case
         r.register_hook('response', self.handle_401)
@@ -85,30 +94,44 @@ class BigIPTokenAuth(AuthBase):
         """ Get F5-Auth-Token
             https://clouddocs.f5.com/products/extensions/f5-declarative-onboarding/latest/authentication.html
         """
+
         credentials = {
             "username": self.username,
             "password": self.password,
-            "loginProviderName": "tmos"
         }
+        if not self.f5os_a:
+            credentials["loginProviderName"] = "tmos"
         auth = (self.username, self.password)
 
-        r = requests.post(parse.urljoin(self.url, BIGIP_LOGIN_PATH),
-                          json=credentials, auth=auth, timeout=10, verify=False)
+        token_request_args = [parse.urljoin(self.url, self._token_endpoint)]
+        token_request_kwargs = {"json": credentials, "auth": auth, "timeout": 10, "verify": False}
+        if self.f5os_a:
+            r = requests.head(*token_request_args, **token_request_kwargs)
+        else:
+            r = requests.post(*token_request_args, **token_request_kwargs)
 
         # Handle maximum active login tokens condition
-        if r.status_code == 400 and 'maximum active login tokens' in r.text:
+        if not self.f5os_a and r.status_code == 400 and 'maximum active login tokens' in r.text:
             # Delete all existing tokens
             requests.delete(parse.urljoin(self.url, BIGIP_TOKENS_PATH), auth=auth, timeout=10, verify=False)
-            r = requests.post(parse.urljoin(self.url, BIGIP_LOGIN_PATH), json=credentials,
+            r = requests.post(parse.urljoin(self.url, self._token_endpoint), json=credentials,
                               auth=auth, timeout=10, verify=False)
 
+        # Check response code
         r.raise_for_status()
-        token = r.json()['token']['token']
 
-        self.token = token
+        # extract token from response
+        if self.f5os_a:
+            token = r.headers[self._token_header]
+        else:
+            token = r.json()['token']['token']
 
         # Increase timeout to max of 10 hours
-        patch_timeout = {"timeout": BIGIP_TOKEN_MAX_TIMEOUT}
-        requests.patch(f"{parse.urljoin(self.url, BIGIP_TOKENS_PATH)}/{token}",
-                       auth=auth, json=patch_timeout, timeout=10, verify=False)
+        if not self.f5os_a:
+            patch_timeout = {"timeout": BIGIP_TOKEN_MAX_TIMEOUT}
+            requests.patch(f"{parse.urljoin(self.url, BIGIP_TOKENS_PATH)}/{token}",
+                           auth=auth, json=patch_timeout, timeout=10, verify=False)
+
+        # Store and return token
+        self.token = token
         return token

--- a/octavia_f5/restclient/bigip/bigip_restclient.py
+++ b/octavia_f5/restclient/bigip/bigip_restclient.py
@@ -39,7 +39,7 @@ class BigIPRestClient(requests.Session):
     _metric_delete_exceptions = prometheus.metrics.Counter(
         'octavia_bigip_delete_exceptions', 'Number of exceptions at DELETE request sent to Big IP')
 
-    def __init__(self, bigip_url, verify=True, auth=None):
+    def __init__(self, bigip_url, verify=True, auth=None, f5os_a=False):
         super().__init__()
         self.url = parse.urlparse(bigip_url, allow_fragments=False)
 
@@ -53,6 +53,7 @@ class BigIPRestClient(requests.Session):
         self.verify = verify
         self.auth = auth
         self._active = None
+        self.f5os_a = f5os_a
 
     def get_url(self, url):
         """Create the URL based off this partial path."""
@@ -122,6 +123,13 @@ class BigIPRestClient(requests.Session):
         if 'path' in kwargs:
             url = self.get_url(kwargs.pop('path'))
 
+        # add F5OS-A headers if needed
+        if self.f5os_a:
+            headers = kwargs.get('headers', {})
+            headers['Content-Type'] = 'application/yang-data+json'
+            headers['Accept'] = 'application/yang-data+json'
+            kwargs['headers'] = headers
+
         return super().get(url, **kwargs)
 
     @_metric_post_exceptions.count_exceptions()
@@ -130,6 +138,13 @@ class BigIPRestClient(requests.Session):
         """
         if 'path' in kwargs:
             url = self.get_url(kwargs.pop('path'))
+
+        # add F5OS-A headers if needed
+        if self.f5os_a:
+            headers = kwargs.get('headers', {})
+            headers['Content-Type'] = 'application/yang-data+json'
+            headers['Accept'] = 'application/yang-data+json'
+            kwargs['headers'] = headers
 
         return super().post(url, **kwargs)
 
@@ -140,6 +155,13 @@ class BigIPRestClient(requests.Session):
         if 'path' in kwargs:
             url = self.get_url(kwargs.pop('path'))
 
+        # add F5OS-A headers if needed
+        if self.f5os_a:
+            headers = kwargs.get('headers', {})
+            headers['Content-Type'] = 'application/yang-data+json'
+            headers['Accept'] = 'application/yang-data+json'
+            kwargs['headers'] = headers
+
         return super().delete(url, **kwargs)
 
     @_metric_patch_exceptions.count_exceptions()
@@ -149,6 +171,13 @@ class BigIPRestClient(requests.Session):
         if 'path' in kwargs:
             url = self.get_url(kwargs.pop('path'))
 
+        # add F5OS-A headers if needed
+        if self.f5os_a:
+            headers = kwargs.get('headers', {})
+            headers['Content-Type'] = 'application/yang-data+json'
+            headers['Accept'] = 'application/yang-data+json'
+            kwargs['headers'] = headers
+
         return super().patch(url, **kwargs)
 
     @_metric_put_exceptions.count_exceptions()
@@ -157,6 +186,13 @@ class BigIPRestClient(requests.Session):
         """
         if 'path' in kwargs:
             url = self.get_url(kwargs.pop('path'))
+
+        # add F5OS-A headers if needed
+        if self.f5os_a:
+            headers = kwargs.get('headers', {})
+            headers['Content-Type'] = 'application/yang-data+json'
+            headers['Accept'] = 'application/yang-data+json'
+            kwargs['headers'] = headers
 
         return super().put(url, **kwargs)
 

--- a/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
+++ b/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
@@ -24,7 +24,7 @@ from octavia.common import constants
 from octavia.network import data_models as network_models
 # pylint: disable=unused-import
 from octavia_f5.common import config  # noqa
-from octavia_f5.controller.worker.flows import f5_flows
+from octavia_f5.controller.worker.flows import f5_flows_iseries, f5_flows_rseries
 from octavia_f5.network import data_models as f5_network_models
 from octavia_f5.restclient import as3restclient
 
@@ -90,7 +90,7 @@ class TestF5Flows(base.TestCase):
                                       empty_response(), empty_response(),
                                       empty_response(), empty_response(),
                                       MockResponse({'items': []}, status_code=200)]
-        f5flows = f5_flows.F5Flows()
+        f5flows = f5_flows_iseries.F5Flows()
 
         store = {'network': mock_network,
                  'bigip': mock_bigip,
@@ -174,7 +174,7 @@ class TestF5Flows(base.TestCase):
                                       mock_selfip_response,
                                       mock_route_response,
                                       MockResponse({'items': []}, status_code=200)]
-        f5flows = f5_flows.F5Flows()
+        f5flows = f5_flows_iseries.F5Flows()
 
         store = {'network': mock_network,
                  'bigip': mock_bigip,
@@ -222,7 +222,7 @@ class TestF5Flows(base.TestCase):
                  'existing_subnet_routes': []}
         needed_selfips = [selfip_port]
         subnets_that_need_routes = []
-        f5flows = f5_flows.F5Flows()
+        f5flows = f5_flows_iseries.F5Flows()
         ensure_selfips_and_subnet_routes_flow = f5flows.make_ensure_selfips_and_subnet_routes_flow(
             needed_selfips, subnets_that_need_routes, store=store)
         engines.run(ensure_selfips_and_subnet_routes_flow, store=store)
@@ -262,7 +262,7 @@ class TestF5Flows(base.TestCase):
                  'existing_subnet_routes': []}
         needed_selfips = []
         subnets_that_need_routes = [mock_subnet_id]
-        f5flows = f5_flows.F5Flows()
+        f5flows = f5_flows_iseries.F5Flows()
         ensure_selfips_and_subnet_routes_flow = f5flows.make_ensure_selfips_and_subnet_routes_flow(
             needed_selfips, subnets_that_need_routes, store=store)
         engines.run(ensure_selfips_and_subnet_routes_flow, store=store)
@@ -296,7 +296,7 @@ class TestF5Flows(base.TestCase):
                  'existing_subnet_routes': []}
         needed_selfips = []
         subnets_that_need_routes = []
-        f5flows = f5_flows.F5Flows()
+        f5flows = f5_flows_iseries.F5Flows()
         ensure_selfips_and_subnet_routes_flow = f5flows.make_remove_selfips_and_subnet_routes_flow(
             needed_selfips, subnets_that_need_routes, store=store)
         engines.run(ensure_selfips_and_subnet_routes_flow, store=store)
@@ -329,7 +329,7 @@ class TestF5Flows(base.TestCase):
                  'existing_subnet_routes': [subnet_route]}
         needed_selfips = []
         subnets_that_need_routes = []
-        f5flows = f5_flows.F5Flows()
+        f5flows = f5_flows_iseries.F5Flows()
         ensure_selfips_and_subnet_routes_flow = f5flows.make_remove_selfips_and_subnet_routes_flow(
             needed_selfips, subnets_that_need_routes, store=store)
         engines.run(ensure_selfips_and_subnet_routes_flow, store=store)
@@ -375,7 +375,7 @@ class TestF5Flows(base.TestCase):
                  'existing_subnet_routes': []}
         needed_selfips = []
         subnets_that_need_routes = [mock_subnet_id]
-        f5flows = f5_flows.F5Flows()
+        f5flows = f5_flows_iseries.F5Flows()
         sync_selfips_and_subnet_routes_flow = f5flows.make_sync_selfips_and_subnet_routes_flow(
             needed_selfips, subnets_that_need_routes, store=store)
         engines.run(sync_selfips_and_subnet_routes_flow, store=store)
@@ -434,7 +434,7 @@ class TestF5Flows(base.TestCase):
                  'existing_subnet_routes': [subnet_route]}
         needed_selfips = [selfip_port]
         subnets_that_need_routes = []
-        f5flows = f5_flows.F5Flows()
+        f5flows = f5_flows_iseries.F5Flows()
         sync_selfips_and_subnet_routes_flow = f5flows.make_sync_selfips_and_subnet_routes_flow(
             needed_selfips, subnets_that_need_routes, store=store)
         engines.run(sync_selfips_and_subnet_routes_flow, store=store)
@@ -456,7 +456,7 @@ class TestF5Flows(base.TestCase):
         )
         mock_bigip.patch.assert_not_called()
 
-    def test_ensure_vcmp_l2_flow(self):
+    def test_ensure_vcmp_l2_flow_iseries(self):
         """Check that the ensure_vcmp_l2_flow flow correctly configures the VLAN"""
 
         mock_network_id = 'test-network-id'
@@ -483,7 +483,7 @@ class TestF5Flows(base.TestCase):
                                      mock_guests_response,
                                      mock_vlan_response]
         mock_vcmp.patch.side_effect = empty_response
-        f5flows = f5_flows.F5Flows()
+        f5flows = f5_flows_iseries.F5Flows()
 
         store = {'network': mock_network,
                  'bigip': mock_vcmp,
@@ -513,7 +513,78 @@ class TestF5Flows(base.TestCase):
             path='/mgmt/tm/net/vlan'
         )
 
-    def test_remove_vcmp_l2_flow(self):
+    def test_ensure_vcmp_l2_flow_rseries(self):
+        """Check that the ensure_vcmp_l2_flow flow correctly configures the VLAN on an rSeries host"""
+
+        mock_network_id = 'test-network-id'
+        mock_subnet_id = 'test-subnet-id'
+        mock_network = f5_network_models.Network(
+            mtu=9000, id=mock_network_id, subnets=[mock_subnet_id],
+            segments=[{'provider:physical_network': 'physnet',
+                       'provider:segmentation_id': 1234}]
+        )
+
+        mock_guests_response = MockResponse({}, 200)
+        mock_vlan_get_response = MockResponse({
+            'ietf-restconf:errors': {
+                'error': [{
+                    "error-type": "application",
+                    "error-tag": "invalid-value",
+                    "error-message": "uri keypath not found",
+                }]
+            }
+        }, 404)
+        mock_tenants_response = MockResponse({
+            "f5-tenants:tenants": {
+                "tenant": [
+                    {
+                        "name": "test-host-1",
+                        "config": {
+                            "vlans": [],  # VLAN not yet configured
+                        }
+                    }
+                ]
+            }
+        }, 200)
+        mock_vlan_put_response = MockResponse({}, 201)
+        mock_interface_response = MockResponse({}, 201)
+        mock_vcmp = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_vcmp.get.side_effect = [mock_vlan_get_response,
+                                     mock_tenants_response]
+        mock_vcmp.put.side_effect = [mock_vlan_put_response,
+                                     mock_interface_response,
+                                     mock_guests_response,
+                                     mock_guests_response]
+        f5flows = f5_flows_rseries.F5Flows()
+
+        store = {'network': mock_network,
+                 'bigip': mock_vcmp,
+                 # since F5OS-A API tenant endpoint yields only the hostname and not the whole domain (as
+                 # iControlREST does), we check it via startswith and a dot appended. But the hostname attribute of
+                 # the BigIPRestClient instance always contains the domain, so it has to be contained here as well.
+                 'bigip_guest_names': ['test-host-1.some.domain']
+                 }
+        ensure_vcmp_l2_flow = f5flows.make_ensure_vcmp_l2_flow()
+        engines.run(ensure_vcmp_l2_flow, store=store)
+
+        get_calls = [
+            mock.call(path='/api/data/openconfig-vlan:vlans/vlan=1234'),
+        ]
+        put_calls = [
+            mock.call(path="/api/data/openconfig-vlan:vlans/vlan=1234",
+                      json={'openconfig-vlan:vlan': [{
+                          'vlan-id': 1234, 'config': {'vlan-id': 1234, 'name': 'vlan-1234'}}
+                      ]}),
+            mock.call(path="/api/data/openconfig-interfaces:interfaces/interface=portchannel1/openconfig-if-aggregate"
+                           ":aggregation/openconfig-vlan:switched-vlan/config/trunk-vlans=1234",
+                      json={'openconfig-vlan:trunk-vlans': [1234]}),
+            mock.call(path="/api/data/f5-tenants:tenants/tenant=test-host-1/config/vlans=1234",
+                      json={'f5-tenants:vlans': [1234]}),
+        ]
+        mock_vcmp.get.assert_has_calls(get_calls)
+        mock_vcmp.put.assert_has_calls(put_calls)
+
+    def test_remove_vcmp_l2_flow_iseries(self):
         """Check correct L2 configuration on L2 removal"""
 
         mock_network_id = 'test-network-id'
@@ -534,7 +605,7 @@ class TestF5Flows(base.TestCase):
 
         mock_vcmp = mock.Mock(spec=as3restclient.AS3RestClient)
         mock_vcmp.get.side_effect = [mock_guests_response]
-        f5flows = f5_flows.F5Flows()
+        f5flows = f5_flows_iseries.F5Flows()
 
         store = {'network': mock_network,
                  'bigip': mock_vcmp,
@@ -547,7 +618,51 @@ class TestF5Flows(base.TestCase):
         mock_vcmp.patch.assert_called_with(json={'vlans': []},
                                            path='/mgmt/tm/vcmp/guest/test-host-1')
 
-    def test_remove_vcmp_l2_flow_vlan_in_use(self):
+    def test_remove_vcmp_l2_flow_rseries(self):
+        """Check correct L2 configuration on L2 removal on rSeries hosts"""
+
+        mock_network_id = 'test-network-id'
+        mock_subnet_id = 'test-subnet-id'
+        mock_network = f5_network_models.Network(
+            mtu=9000, id=mock_network_id, subnets=[mock_subnet_id],
+            segments=[{'provider:physical_network': 'physnet',
+                       'provider:segmentation_id': 1234}]
+        )
+
+        mock_guests_response = MockResponse(
+            {'f5-tenants:tenants': {'tenant': [
+                {'name': 'test-host-1',
+                 'config': {'vlans': [1234]}},
+            ]}},
+            200)
+        mock_delete_response = MockResponse({}, 204)
+        delete_calls = [
+            mock.call(path='/api/data/f5-tenants:tenants/tenant=test-host-1/config/vlans=1234'),
+            mock.call(path=("/api/data/openconfig-interfaces:interfaces/interface=portchannel1/openconfig-if-aggregate:"
+                            "aggregation/openconfig-vlan:switched-vlan/config/trunk-vlans=1234")),
+            mock.call(path="/api/data/openconfig-vlan:vlans/vlan=1234"),
+        ]
+
+        mock_vcmp = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_vcmp.get.side_effect = [mock_guests_response]
+        mock_vcmp.delete.side_effect = [mock_delete_response,
+                                        mock_delete_response,
+                                        mock_delete_response]
+        f5flows = f5_flows_rseries.F5Flows()
+
+        store = {'network': mock_network,
+                 'bigip': mock_vcmp,
+                 # since F5OS-A API tenant endpoint yields only the hostname and not the whole domain (as
+                 # iControlREST does), we check it via startswith and a dot appended. But the hostname attribute of
+                 # the BigIPRestClient instance always contains the domain, so it has to be contained here as well.
+                 'bigip_guest_names': ['test-host-1.some.domain']}
+        remove_vcmp_l2_flow = f5flows.make_remove_vcmp_l2_flow()
+        engines.run(remove_vcmp_l2_flow, store=store)
+
+        mock_vcmp.get.assert_called_with(path='/api/data/f5-tenants:tenants')
+        mock_vcmp.delete.assert_has_calls(delete_calls)
+
+    def test_remove_vcmp_l2_flow_vlan_in_use_iseries(self):
         """Check that the remove_vcmp_l2_flow does not delete a VLAN in use by another guest"""
 
         mock_network_id = 'test-network-id'
@@ -566,7 +681,7 @@ class TestF5Flows(base.TestCase):
             ]}, 200)
         mock_vcmp = mock.Mock(spec=as3restclient.AS3RestClient)
         mock_vcmp.get.side_effect = [mock_guests_response]
-        f5flows = f5_flows.F5Flows()
+        f5flows = f5_flows_iseries.F5Flows()
 
         remove_vcmp_l2_flow = f5flows.make_remove_vcmp_l2_flow()
         store = {'network': mock_network,
@@ -578,3 +693,49 @@ class TestF5Flows(base.TestCase):
         mock_vcmp.delete.assert_not_called()
         mock_vcmp.patch.assert_called_with(json={'vlans': []},
                                            path='/mgmt/tm/vcmp/guest/test-host-1')
+
+    def test_remove_vcmp_l2_flow_vlan_in_use_rseries(self):
+        """Check that the remove_vcmp_l2_flow does not delete a VLAN in use by another guest"""
+
+        mock_network_id = 'test-network-id'
+        mock_subnet_id = 'test-subnet-id'
+        mock_network = f5_network_models.Network(
+            mtu=9000, id=mock_network_id, subnets=[mock_subnet_id],
+            segments=[{'provider:physical_network': 'physnet',
+                       'provider:segmentation_id': 1234}]
+        )
+
+        mock_guests_response = MockResponse(
+            {'f5-tenants:tenants': {'tenant': [
+                {'name': 'test-host-1',
+                 'config': {'vlans': [1234]}},
+                # other guest using the same VLAN
+                {'name': 'test-host-2',
+                 'config': {'vlans': [1234]}},
+            ]}},
+            200)
+        mock_delete_response = MockResponse({}, 204)
+        delete_calls = [
+            mock.call(path='/api/data/f5-tenants:tenants/tenant=test-host-1/config/vlans=1234'),
+            mock.call(path=("/api/data/openconfig-interfaces:interfaces/interface=portchannel1/openconfig-if-aggregate:"
+                            "aggregation/openconfig-vlan:switched-vlan/config/trunk-vlans=1234")),
+            # no VLAN deletion call
+        ]
+
+        mock_vcmp = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_vcmp.get.side_effect = [mock_guests_response]
+        mock_vcmp.delete.side_effect = [mock_delete_response,
+                                        mock_delete_response]
+        f5flows = f5_flows_rseries.F5Flows()
+
+        store = {'network': mock_network,
+                 'bigip': mock_vcmp,
+                 # since F5OS-A API tenant endpoint yields only the hostname and not the whole domain (as
+                 # iControlREST does), we check it via startswith and a dot appended. But the hostname attribute of
+                 # the BigIPRestClient instance always contains the domain, so it has to be contained here as well.
+                 'bigip_guest_names': ['test-host-1.some.domain']}
+        remove_vcmp_l2_flow = f5flows.make_remove_vcmp_l2_flow()
+        engines.run(remove_vcmp_l2_flow, store=store)
+
+        mock_vcmp.get.assert_called_with(path='/api/data/f5-tenants:tenants')
+        mock_vcmp.delete.assert_has_calls(delete_calls)

--- a/octavia_f5/tests/unit/controller/worker/tasks/test_f5_tasks.py
+++ b/octavia_f5/tests/unit/controller/worker/tasks/test_f5_tasks.py
@@ -24,7 +24,7 @@ import octavia.tests.unit.base as base
 from octavia.network import data_models as network_models
 # pylint: disable=unused-import
 from octavia_f5.common import config  # noqa
-from octavia_f5.controller.worker.tasks import f5_tasks
+from octavia_f5.controller.worker.tasks import f5_tasks_iseries
 from octavia_f5.network import data_models as f5_network_models
 from octavia_f5.restclient import as3restclient
 from octavia_f5.tests.unit.controller.worker.flows import test_f5_flows
@@ -63,7 +63,7 @@ class TestF5Tasks(base.TestCase):
         mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
         mock_bigip.get.return_value = mock_route_response
 
-        engines.run(f5_tasks.EnsureDefaultRoute(),
+        engines.run(f5_tasks_iseries.EnsureDefaultRoute(),
                     store={'network': mock_network,
                            'bigip': mock_bigip,
                            'subnet_id': 'test-subnet-id'})
@@ -96,7 +96,7 @@ class TestF5Tasks(base.TestCase):
         mock_bigip.get.side_effect = [test_f5_flows.MockResponse({}, 404),
                                       mock_route_response]
 
-        engines.run(f5_tasks.EnsureDefaultRoute(),
+        engines.run(f5_tasks_iseries.EnsureDefaultRoute(),
                     store={'network': mock_network,
                            'bigip': mock_bigip,
                            'subnet_id': 'test-subnet-id'})
@@ -134,7 +134,7 @@ class TestF5Tasks(base.TestCase):
         # Patch should fail
         mock_bigip.patch.side_effect = test_f5_flows.empty_response
 
-        engines.run(f5_tasks.EnsureDefaultRoute(),
+        engines.run(f5_tasks_iseries.EnsureDefaultRoute(),
                     store={'network': mock_network,
                            'bigip': mock_bigip,
                            'subnet_id': 'test-subnet-id'})
@@ -185,7 +185,7 @@ class TestF5Tasks(base.TestCase):
             'port': selfip_port,
             'existing_selfips': [],
         }
-        engines.run(f5_tasks.EnsureSelfIP(), store=store)
+        engines.run(f5_tasks_iseries.EnsureSelfIP(), store=store)
         mock_bigip.delete.assert_not_called()
         mock_bigip.get.assert_called_with(
             path=f"/mgmt/tm/net/self/{selfip_name}")
@@ -204,7 +204,7 @@ class TestF5Tasks(base.TestCase):
             test_f5_flows.MockResponse({'name': selfip_name}, 200),
         ]
         store['bigip'] = mock_bigip
-        engines.run(f5_tasks.EnsureSelfIP(), store=store)
+        engines.run(f5_tasks_iseries.EnsureSelfIP(), store=store)
         mock_bigip.delete.assert_not_called()
         mock_bigip.get.assert_called_with(
             path=f"/mgmt/tm/net/self/{selfip_name}")
@@ -244,7 +244,7 @@ class TestF5Tasks(base.TestCase):
             'subnet_id': mock_subnet.id,
             'existing_subnet_routes': [],
         }
-        engines.run(f5_tasks.EnsureSubnetRoute(), store=store)
+        engines.run(f5_tasks_iseries.EnsureSubnetRoute(), store=store)
         mock_bigip.delete.assert_not_called()
         mock_bigip.get.assert_called_with(
             path=f"/mgmt/tm/net/route/~Common~{subnet_route_name}")
@@ -263,7 +263,7 @@ class TestF5Tasks(base.TestCase):
             test_f5_flows.MockResponse({'name': subnet_route_name}, 200),
         ]
         store['bigip'] = mock_bigip
-        engines.run(f5_tasks.EnsureSubnetRoute(), store=store)
+        engines.run(f5_tasks_iseries.EnsureSubnetRoute(), store=store)
         mock_bigip.delete.assert_not_called()
         mock_bigip.get.assert_called_with(
             path=f"/mgmt/tm/net/route/~Common~{subnet_route_name}")
@@ -308,7 +308,7 @@ class TestF5Tasks(base.TestCase):
             'port': selfip_port,
             'existing_selfips': [],
         }
-        self.assertRaises(TestException, engines.run, f5_tasks.EnsureSelfIP(), store=store)
+        self.assertRaises(TestException, engines.run, f5_tasks_iseries.EnsureSelfIP(), store=store)
         mock_bigip.get.assert_called_with(path=f"/mgmt/tm/net/self/{selfip_name}")
         # delete is always called during rollback, ignoring 404
         mock_bigip.delete.assert_called_with(
@@ -346,7 +346,7 @@ class TestF5Tasks(base.TestCase):
             'subnet_id': mock_subnet_id,
             'existing_subnet_routes': [],
         }
-        self.assertRaises(TestException, engines.run, f5_tasks.EnsureSubnetRoute(), store=store)
+        self.assertRaises(TestException, engines.run, f5_tasks_iseries.EnsureSubnetRoute(), store=store)
         mock_bigip.get.assert_called_with(path=f"/mgmt/tm/net/route/~Common~{subnet_route_name}")
         # delete is always called during rollback, ignoring 404
         mock_bigip.delete.assert_called_with(
@@ -402,7 +402,7 @@ class TestF5Tasks(base.TestCase):
         mock_bigip.get.side_effect = [test_f5_flows.MockResponse({}, 404)]
         store['bigip'] = mock_bigip
         store['existing_selfips'] = [selfip_port_dict]
-        self.assertRaises(TestException, engines.run, f5_tasks.RemoveSelfIP(), store=store)
+        self.assertRaises(TestException, engines.run, f5_tasks_iseries.RemoveSelfIP(), store=store)
         # calls in execute()
         mock_bigip.delete.assert_called_with(path=f"/mgmt/tm/net/self/{selfip_name}")
         # calls in revert()
@@ -424,7 +424,7 @@ class TestF5Tasks(base.TestCase):
         mock_bigip.get.side_effect = [test_f5_flows.MockResponse({}, 404)]
         store['bigip'] = mock_bigip
         store['existing_selfips'] = []
-        self.assertRaises(TestException, engines.run, f5_tasks.RemoveSelfIP(), store=store)
+        self.assertRaises(TestException, engines.run, f5_tasks_iseries.RemoveSelfIP(), store=store)
         # calls in execute()
         mock_bigip.delete.assert_called_with(path=f"/mgmt/tm/net/self/{selfip_name}")
         # calls in revert()
@@ -439,7 +439,7 @@ class TestF5Tasks(base.TestCase):
         mock_bigip.get.side_effect = [test_f5_flows.MockResponse({}, 200)]  # only HTTP code matters
         store['bigip'] = mock_bigip
         store['existing_selfips'] = [selfip_port_dict]
-        self.assertRaises(TestException, engines.run, f5_tasks.RemoveSelfIP(), store=store)
+        self.assertRaises(TestException, engines.run, f5_tasks_iseries.RemoveSelfIP(), store=store)
         # calls in execute()
         mock_bigip.delete.assert_called_with(path=f"/mgmt/tm/net/self/{selfip_name}")
         # calls in revert()
@@ -489,7 +489,7 @@ class TestF5Tasks(base.TestCase):
         mock_bigip.get.side_effect = [test_f5_flows.MockResponse({}, 404)]
         store['bigip'] = mock_bigip
         store['existing_subnet_routes'] = [subnet_route]
-        self.assertRaises(TestException, engines.run, f5_tasks.RemoveSubnetRoute(), store=store)
+        self.assertRaises(TestException, engines.run, f5_tasks_iseries.RemoveSubnetRoute(), store=store)
         # calls in execute()
         mock_bigip.delete.assert_called_with(path=f"/mgmt/tm/net/route/~Common~{subnet_route_name}")
         # calls in revert()
@@ -511,7 +511,7 @@ class TestF5Tasks(base.TestCase):
         mock_bigip.get.side_effect = [test_f5_flows.MockResponse({}, 404)]
         store['bigip'] = mock_bigip
         store['existing_subnet_routes'] = []
-        self.assertRaises(TestException, engines.run, f5_tasks.RemoveSubnetRoute(), store=store)
+        self.assertRaises(TestException, engines.run, f5_tasks_iseries.RemoveSubnetRoute(), store=store)
         # calls in execute()
         mock_bigip.delete.assert_called_with(path=f"/mgmt/tm/net/route/~Common~{subnet_route_name}")
         # calls in revert()
@@ -526,7 +526,7 @@ class TestF5Tasks(base.TestCase):
         mock_bigip.get.side_effect = [test_f5_flows.MockResponse({}, 200)]  # only HTTP code matters
         store['bigip'] = mock_bigip
         store['existing_subnet_routes'] = [subnet_route]
-        self.assertRaises(TestException, engines.run, f5_tasks.RemoveSubnetRoute(), store=store)
+        self.assertRaises(TestException, engines.run, f5_tasks_iseries.RemoveSubnetRoute(), store=store)
         # calls in execute()
         mock_bigip.delete.assert_called_with(path=f"/mgmt/tm/net/route/~Common~{subnet_route_name}")
         # calls in revert()

--- a/octavia_f5/utils/decorators.py
+++ b/octavia_f5/utils/decorators.py
@@ -18,7 +18,7 @@ from urllib.parse import urlparse
 
 from requests import HTTPError
 
-from octavia_f5.utils.exceptions import IControlRestException
+from octavia_f5.utils.exceptions import IControlRestException, F5osaException
 
 
 class RunHookOnException(object):
@@ -38,21 +38,48 @@ class RunHookOnException(object):
         return wrapper
 
 
-class RaisesIControlRestError(ContextDecorator):
+class RaisesApiError(ContextDecorator):
+
+    def __init__(self):
+        self.exception_class = Exception
+
     def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc_val, traceback):
         if exc_type == HTTPError:
             parsed = urlparse(exc_val.request.url)
-            redacted = parsed._replace(netloc=f"{parsed.username}:???@{parsed.hostname}")
+
+            # if a username is present, display it, but hide the password,
+            # otherwise just display the hostname
+            if parsed.username:
+                redacted = parsed._replace(netloc=f"{parsed.username}:???@{parsed.hostname}").geturl()
+            else:
+                redacted = parsed.hostname
+
+            # get error message from response
             try:
-                message = exc_val.response.json()
-                if 'message' in message:
-                    message = message['message']
+                err_msg = exc_val.response.json()
+                if 'message' in err_msg:
+                    err_msg = err_msg['message']
             except Exception:
-                message = exc_val.response.content
-            raise IControlRestException(
-                f"HTTP {exc_val.response.status_code} for {exc_val.request.method} {redacted.geturl()}: {message}"
+                err_msg = exc_val.response.content
+
+            # raise exception
+            raise self.exception_class(
+                f"HTTP {exc_val.response.status_code} for {exc_val.request.method} {redacted}: {err_msg}"
             )
+
         return False
+
+
+class RaisesIControlRestError(RaisesApiError):
+    def __init__(self):
+        super().__init__()
+        self.exception_class = IControlRestException
+
+
+class RaisesF5osaError(RaisesApiError):
+    def __init__(self):
+        super().__init__()
+        self.exception_class = F5osaException

--- a/octavia_f5/utils/driver_utils.py
+++ b/octavia_f5/utils/driver_utils.py
@@ -12,11 +12,14 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from octavia_lib.api.drivers import data_models
-from octavia_lib.common import constants
 from oslo_config import cfg
 from oslo_log import log as logging
 from stevedore import driver
+
+from octavia_lib.api.drivers import data_models
+from octavia_lib.common import constants
+
+from octavia_f5.common import constants as f5_constants
 
 
 CONF = cfg.CONF
@@ -54,3 +57,15 @@ def lb_to_vip_obj(lb):
         vip_obj.qos_policy_id = lb.vip_qos_policy_id
     vip_obj.load_balancer = lb
     return vip_obj
+
+
+def selfip_for_subnet_exists(subnet_id, selfips):
+    for selfip in selfips:
+        for fixed_ip in selfip.fixed_ips:
+            if fixed_ip.subnet_id == subnet_id:
+                return True
+    return False
+
+
+def get_subnet_route_name(network_id, subnet_id):
+    return f"{f5_constants.PREFIX_NETWORK}{network_id}_{f5_constants.PREFIX_SUBNET}{subnet_id}"

--- a/octavia_f5/utils/exceptions.py
+++ b/octavia_f5/utils/exceptions.py
@@ -33,6 +33,10 @@ class IControlRestException(ProviderDriverException):
     pass
 
 
+class F5osaException(ProviderDriverException):
+    pass
+
+
 class PolicyHasNoRules(AS3Exception):
     pass
 


### PR DESCRIPTION
Contains:
- Implement vCMP host tasks for rSeries F5OS-A API
- Add BigIPRestClient support for rSeries F5OS-A API
- Ignore failed VLAN deletion due to bug - VLAN can safely be reused
- Add rSeries flow tests