### PR TITLE
Fixes for 2025.1

### DIFF
--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -26,6 +26,7 @@ from octavia_lib.common import constants as lib_consts
 from oslo_concurrency import lockutils
 from oslo_config import cfg
 from oslo_db import api as oslo_db_api
+from oslo_db.sqlalchemy import enginefacade
 from oslo_log import log as logging
 from oslo_utils import excutils, uuidutils
 from requests import HTTPError
@@ -156,7 +157,11 @@ class ControllerWorker(object):
     @periodics.periodic(60 * 60 * 24, run_immediately=CONF.f5_agent.sync_immediately)
     def cleanup_orphaned_tenants(self):
         LOG.info("Running (24h) tenant cleanup")
-        session = db_apis.get_session()
+        try:
+            session = db_apis.get_session(reader=True)
+        except enginefacade.AlreadyStartedError:
+            # handle race condition for sessions initialisation, skip one sync
+            return
         session.begin()
 
         for device in self.sync.devices():
@@ -181,7 +186,11 @@ class ControllerWorker(object):
 
     @periodics.periodic(60 * 4, run_immediately=CONF.f5_agent.sync_immediately)
     def full_sync_reappearing_devices(self):
-        session = db_apis.get_session()
+        try:
+            session = db_apis.get_session()
+        except enginefacade.AlreadyStartedError:
+            # handle race condition for sessions initialisation, skip one sync
+            return
         session.begin()
 
         # Get all pending devices
@@ -209,7 +218,11 @@ class ControllerWorker(object):
 
     @periodics.periodic(60 * 60 * 24, run_immediately=CONF.f5_agent.sync_immediately)
     def full_sync_l2(self):
-        session = db_apis.get_session()
+        try:
+            session = db_apis.get_session(reader=True)
+        except enginefacade.AlreadyStartedError:
+            # handle race condition for sessions initialisation, skip one sync
+            return
 
         # get all load balancers (of this host)
         with session.begin():
@@ -225,9 +238,12 @@ class ControllerWorker(object):
         - deletes load balancers that are PENDING_DELETE
         - executes a full sync on F5 devices that were offline but are now back online
         """
-
+        try:
+            session = db_apis.get_session(reader=True)
+        except enginefacade.AlreadyStartedError:
+            # handle race condition for sessions initialisation, skip one sync
+            return
         # delete load balancers that are PENDING_DELETE
-        session = db_apis.get_session()
         with session.begin():
             lbs_to_delete = self._loadbalancer_repo.get_all_from_host(
                 session, provisioning_status=lib_consts.PENDING_DELETE)

--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -249,7 +249,7 @@ class ControllerWorker(object):
                 session, provisioning_status=lib_consts.PENDING_DELETE)
         for lb in lbs_to_delete:
             LOG.info("Found pending deletion of lb %s", lb.id)
-            self.delete_load_balancer(lb.id)
+            self.delete_load_balancer({octavia_consts.LOADBALANCER_ID: lb.id})
 
         # Find pending loadbalancer not yet finally assigned to this host
         lbs = []

--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -158,7 +158,7 @@ class ControllerWorker(object):
     def cleanup_orphaned_tenants(self):
         LOG.info("Running (24h) tenant cleanup")
         try:
-            session = db_apis.get_session(reader=True)
+            session = db_apis.get_session()
         except enginefacade.AlreadyStartedError:
             # handle race condition for sessions initialisation, skip one sync
             return
@@ -219,7 +219,7 @@ class ControllerWorker(object):
     @periodics.periodic(60 * 60 * 24, run_immediately=CONF.f5_agent.sync_immediately)
     def full_sync_l2(self):
         try:
-            session = db_apis.get_session(reader=True)
+            session = db_apis.get_session()
         except enginefacade.AlreadyStartedError:
             # handle race condition for sessions initialisation, skip one sync
             return
@@ -239,7 +239,7 @@ class ControllerWorker(object):
         - executes a full sync on F5 devices that were offline but are now back online
         """
         try:
-            session = db_apis.get_session(reader=True)
+            session = db_apis.get_session()
         except enginefacade.AlreadyStartedError:
             # handle race condition for sessions initialisation, skip one sync
             return

--- a/octavia_f5/db/api.py
+++ b/octavia_f5/db/api.py
@@ -46,10 +46,10 @@ def get_engine():
     return context.get_engine()
 
 
-def get_session():
+def get_session(reader=False):
     """Helper method to grab session."""
-    return _get_sessionmaker()()
+    return _get_sessionmaker(reader)()
 
 
-def session():
-    return _get_sessionmaker()
+def session(reader=False):
+    return _get_sessionmaker(reader)

--- a/octavia_f5/db/api.py
+++ b/octavia_f5/db/api.py
@@ -46,10 +46,10 @@ def get_engine():
     return context.get_engine()
 
 
-def get_session(reader=False):
+def get_session():
     """Helper method to grab session."""
-    return _get_sessionmaker(reader)()
+    return _get_sessionmaker()()
 
 
-def session(reader=False):
-    return _get_sessionmaker(reader)
+def session():
+    return _get_sessionmaker()

--- a/octavia_f5/db/repositories.py
+++ b/octavia_f5/db/repositories.py
@@ -165,6 +165,5 @@ class QuotasRepository(repositories.BaseRepository):
     model_class = models.Quotas
 
     def update(self, session, project_id, **model_kwargs):  # pylint: disable=arguments-renamed
-        with session.begin(subtransactions=True):
-            session.query(self.model_class).filter_by(
-                project_id=project_id).update(model_kwargs)
+        session.query(self.model_class).filter_by(
+            project_id=project_id).update(model_kwargs)

--- a/octavia_f5/network/drivers/neutron/neutron_client.py
+++ b/octavia_f5/network/drivers/neutron/neutron_client.py
@@ -587,6 +587,9 @@ class NeutronClient(neutron_base.BaseNeutronDriver,
     def update_vip_sg(self, load_balancer, vip):
         pass
 
+    def update_aap_port_sg(self, load_balancer, amphora, vip):
+        pass
+
     def plug_aap_port(self, load_balancer, vip, amphora, subnet):
         pass
 

--- a/octavia_f5/network/drivers/neutron/neutron_client.py
+++ b/octavia_f5/network/drivers/neutron/neutron_client.py
@@ -138,7 +138,7 @@ class NeutronClient(neutron_base.BaseNeutronDriver,
                 if (port.network_id == load_balancer.vip.network_id and fixed_ip_found):
                     LOG.info('Port %s already exists. Nothing to be done.',
                              load_balancer.vip.port_id)
-                    return self._port_to_vip(port, load_balancer)[0]
+                    return self._port_to_vip(port, load_balancer)
                 LOG.error('Neutron VIP mis-match. Expected ip %s on '
                           'subnet %s in network %s. Neutron has fixed_ips %s '
                           'in network %s. Deleting and recreating the VIP '
@@ -180,7 +180,7 @@ class NeutronClient(neutron_base.BaseNeutronDriver,
                 vip_port = engine.storage.fetch("vip_port")
                 LOG.debug("Successfully allocated SelfIPs %s for VIP %s",
                           [selfip.id for selfip in selfips], vip_port.id)
-                return self._port_to_vip(vip_port, load_balancer)[0]
+                return self._port_to_vip(vip_port, load_balancer)
         except WrappedFailure as f:
             # Unwrap Allocation error and re-raise
             for e in f:

--- a/octavia_f5/tests/unit/network/drivers/neutron/test_neutron_client.py
+++ b/octavia_f5/tests/unit/network/drivers/neutron/test_neutron_client.py
@@ -184,7 +184,7 @@ class TestNeutronClient(base.TestCase):
                                       network_id=t_constants.MOCK_NETWORK_ID)
         fake_lb = data_models.LoadBalancer(id='1', vip=fake_lb_vip,
                                            project_id='test-project')
-        vip = self.driver.allocate_vip(fake_lb)
+        vip, _ = self.driver.allocate_vip(fake_lb)
         create_port.assert_has_calls([mock.call(**EXP_MOCK_NEUTRON_PORT),
                                       mock.call(**EXP_MOCK_SELFIP_PORT)],
                                      any_order=True)
@@ -302,7 +302,7 @@ class TestNeutronClient(base.TestCase):
             network_id=t_constants.MOCK_NETWORK_ID,
             ip_address=t_constants.MOCK_IP_ADDRESS)
         fake_lb = data_models.LoadBalancer(id='1', vip=fake_lb_vip)
-        vip = self.driver.allocate_vip(fake_lb)
+        vip, _ = self.driver.allocate_vip(fake_lb)
         self.assertIsInstance(vip, data_models.Vip)
         self.assertEqual(t_constants.MOCK_IP_ADDRESS, vip.ip_address)
         self.assertEqual(MOCK_SUBNET_ID, vip.subnet_id)
@@ -333,7 +333,7 @@ class TestNeutronClient(base.TestCase):
                                       octavia_owned=True)
         fake_lb = data_models.LoadBalancer(id='1', vip=fake_lb_vip,
                                            project_id='test-project')
-        vip = self.driver.allocate_vip(fake_lb)
+        vip, _ = self.driver.allocate_vip(fake_lb)
         exp_create_port_call = {
             'name': 'loadbalancer-1',
             'network_id': t_constants.MOCK_NETWORK_ID,
@@ -373,7 +373,7 @@ class TestNeutronClient(base.TestCase):
                                       port_id=t_constants.MOCK_PORT_ID)
         fake_lb = data_models.LoadBalancer(id='1', vip=fake_lb_vip,
                                            project_id='test-project')
-        vip = self.driver.allocate_vip(fake_lb)
+        vip, _ = self.driver.allocate_vip(fake_lb)
         exp_create_port_call = {
             'name': 'loadbalancer-1',
             'network_id': t_constants.MOCK_NETWORK_ID,
@@ -419,7 +419,7 @@ class TestNeutronClient(base.TestCase):
                                       network_id=t_constants.MOCK_NETWORK_ID)
         fake_lb = data_models.LoadBalancer(id='1', vip=fake_lb_vip,
                                            project_id='test-project')
-        vip = self.driver.allocate_vip(fake_lb)
+        vip, _ = self.driver.allocate_vip(fake_lb)
         exp_create_port_call = {
             'name': 'loadbalancer-1',
             'network_id': t_constants.MOCK_NETWORK_ID,
@@ -454,7 +454,7 @@ class TestNeutronClient(base.TestCase):
                                       ip_address=t_constants.MOCK_IP_ADDRESS)
         fake_lb = data_models.LoadBalancer(id='1', vip=fake_lb_vip,
                                            project_id='test-project')
-        vip = self.driver.allocate_vip(fake_lb)
+        vip, _ = self.driver.allocate_vip(fake_lb)
         exp_create_port_call = {
             'name': 'loadbalancer-1',
             'network_id': t_constants.MOCK_NETWORK_ID,
@@ -488,7 +488,7 @@ class TestNeutronClient(base.TestCase):
         fake_lb_vip = data_models.Vip(network_id=t_constants.MOCK_NETWORK_ID)
         fake_lb = data_models.LoadBalancer(id='1', vip=fake_lb_vip,
                                            project_id='test-project')
-        vip = self.driver.allocate_vip(fake_lb)
+        vip, _ = self.driver.allocate_vip(fake_lb)
         exp_create_port_call = {
             'name': 'loadbalancer-1',
             'network_id': t_constants.MOCK_NETWORK_ID,
@@ -519,7 +519,7 @@ class TestNeutronClient(base.TestCase):
                                       network_id=t_constants.MOCK_NETWORK_ID)
         fake_lb = data_models.LoadBalancer(id='1', vip=fake_lb_vip,
                                            project_id=t_constants.MOCK_PROJECT_ID)
-        vip = self.driver.allocate_vip(fake_lb)
+        vip, _ = self.driver.allocate_vip(fake_lb)
         exp_create_port_call = {
             'name': 'loadbalancer-1',
             'network_id': t_constants.MOCK_NETWORK_ID,


### PR DESCRIPTION
Fixes for runtime errors after the first deploy to QA regions:

**1. Fix for undefined class method for NeutronClient:**
```
   File "/var/lib/openstack/lib/python3.12/site-packages/stevedore/extension.py", line 206, in _load_plugins
     ext = self._load_one_plugin(ep,
           ^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/var/lib/openstack/lib/python3.12/site-packages/stevedore/named.py", line 156, in _load_one_plugin
     return super()._load_one_plugin(
            ^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/var/lib/openstack/lib/python3.12/site-packages/stevedore/extension.py", line 242, in _load_one_plugin
     obj = plugin(*invoke_args, **invoke_kwds)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 TypeError: Can't instantiate abstract class NeutronClient without an implementation for abstract method 'update_aap_port_sg'
```

**2. Additional VIP new API fail:**
```
[wsgi:error] [pid 22:tid 139705605174976] [remote 100.90.15.92:48450]
  File "/var/lib/openstack/lib/python3.12/site-packages/oslo_utils/excutils.py", line 200, in force_reraise
    raise self.value
 [wsgi:error] [pid 22:tid 139705605174976] [remote 100.90.15.92:48450]
  File "/var/lib/openstack/lib/python3.12/site-packages/octavia/api/v2/controllers/load_balancer.py", line 570, in _create_loadbalancer
    vip, add_vips = self._create_vip_port_if_not_exist(db_lb)
    ^^^^^^^^^^^^^
[wsgi:error] [pid 22:tid 139705605174976] [remote 100.90.15.92:48450]
TypeError: cannot unpack non-iterable Vip object
```

**3. Fix for TransactionFactory errors during the first start of workers (hiding this error on the first start):**
```
2025-07-10 14:46:51,130 21 ERROR futurist.periodics   File "/var/lib/openstack/src/octavia-f5-provider-driver/octavia_f5/db/api.py", line 26, in _create_facade_lazily
2025-07-10 14:46:51,130 21 ERROR futurist.periodics     enginefacade.configure(sqlite_fk=True, expire_on_commit=True)
2025-07-10 14:46:51,130 21 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/oslo_db/sqlalchemy/enginefacade.py", line 1313, in configure
2025-07-10 14:46:51,130 21 ERROR futurist.periodics     _context_manager._factory.configure(**kw)
2025-07-10 14:46:51,130 21 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/oslo_db/sqlalchemy/enginefacade.py", line 366, in configure
2025-07-10 14:46:51,130 21 ERROR futurist.periodics     self._configure(False, kw)
2025-07-10 14:46:51,130 21 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/oslo_db/sqlalchemy/enginefacade.py", line 370, in _configure
2025-07-10 14:46:51,130 21 ERROR futurist.periodics     raise AlreadyStartedError(
2025-07-10 14:46:51,130 21 ERROR futurist.periodics oslo_db.sqlalchemy.enginefacade.AlreadyStartedError: this TransactionFactory is already started
```

**4. Fix for delete_load_balancer call in driver after changing Amphora API to V2**
```
 Traceback (most recent call last):
   File "/var/lib/openstack/lib/python3.12/site-packages/futurist/periodics.py", line 290, in run
     work()
   File "/var/lib/openstack/lib/python3.12/site-packages/futurist/periodics.py", line 64, in __call__
     return self.callback(*self.args, **self.kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/var/lib/openstack/lib/python3.12/site-packages/futurist/periodics.py", line 178, in decorator
     return f(*args, **kwargs)
            ^^^^^^^^^^^^^^^^^^
   File "/var/lib/openstack/src/octavia-f5-provider-driver/octavia_f5/controller/worker/controller_worker.py", line 252, in pending_sync
     self.delete_load_balancer(lb.id)
   File "/var/lib/openstack/src/octavia-f5-provider-driver/octavia_f5/controller/worker/controller_worker.py", line 372, in delete_load_balancer
     id=load_balancer[octavia_consts.LOADBALANCER_ID])
        ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 TypeError: string indices must be integers, not 'str'
```