### PR TITLE
Fix listener statistics update with empty data.

### DIFF
--- a/octavia_f5/controller/statusmanager/legacy_healthmanager/health_drivers/update_db.py
+++ b/octavia_f5/controller/statusmanager/legacy_healthmanager/health_drivers/update_db.py
@@ -535,6 +535,11 @@ class UpdateStatsDb(update_base.StatsUpdateBase, stats.StatsMixin):
             listeners = health_message['listeners']
             for listener_id, listener in listeners.items():
                 listener_stats = listener.get('stats')
+                # set statistics to 0 if there are no data because
+                # Octavia's DB does not allow NULL values
+                for val in ['rx', 'tx', 'conns', 'totconns', 'ereq']:
+                    if listener_stats[val] is None:
+                        listener_stats[val] = 0
                 stats_args = {'bytes_in': listener_stats['rx'], 'bytes_out': listener_stats['tx'],
                               'active_connections': listener_stats['conns'],
                               'total_connections': listener_stats['totconns'],


### PR DESCRIPTION
When we deploy a new release or when the listener is not used, we do not get any values for statistics, and it can cause an error:
```
 Traceback (most recent call last):
   File "/var/lib/openstack/src/octavia-f5-provider-driver/octavia_f5/controller/statusmanager/legacy_healthmanager/health_drivers/update_db.py", line 493, in update_stats
     self._update_stats(health_message, srcaddr)
   File "/var/lib/openstack/src/octavia-f5-provider-driver/octavia_f5/controller/statusmanager/legacy_healthmanager/health_drivers/update_db.py", line 548, in _update_stats
     self.listener_stats_repo.replace(session, stats_obj)
   File "/var/lib/openstack/lib/python3.12/site-packages/octavia/db/repositories.py", line 1277, in replace
     amphora_id=stats_obj.amphora_id).update(
                                      ^^^^^^^
   File "/var/lib/openstack/lib/python3.12/site-packages/sqlalchemy/orm/query.py", line 3295, in update
     result: CursorResult[Any] = self.session.execute(
                                 ^^^^^^^^^^^^^^^^^^^^^
   File "/var/lib/openstack/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 2365, in execute
     return self._execute_internal(
            ^^^^^^^^^^^^^^^^^^^^^^^
   File "/var/lib/openstack/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 2251, in _execute_internal
     result: Result[Any] = compile_state_cls.orm_execute_statement(
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/var/lib/openstack/lib/python3.12/site-packages/sqlalchemy/orm/bulk_persistence.py", line 1648, in orm_execute_statement
     return super().orm_execute_statement(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/var/lib/openstack/lib/python3.12/site-packages/sqlalchemy/orm/context.py", line 305, in orm_execute_statement
     result = conn.execute(
              ^^^^^^^^^^^^^
   File "/var/lib/openstack/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1416, in execute
     return meth(
            ^^^^^
   File "/var/lib/openstack/lib/python3.12/site-packages/sqlalchemy/sql/elements.py", line 516, in _execute_on_connection
     return connection._execute_clauseelement(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/var/lib/openstack/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1638, in _execute_clauseelement
     ret = self._execute_context(
           ^^^^^^^^^^^^^^^^^^^^^^
   File "/var/lib/openstack/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1843, in _execute_context
     return self._exec_single_context(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/var/lib/openstack/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1983, in _exec_single_context
     self._handle_dbapi_exception(
   File "/var/lib/openstack/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 2349, in _handle_dbapi_exception
     raise newraise.with_traceback(exc_info[2]) from e
   File "/var/lib/openstack/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1964, in _exec_single_context
     self.dialect.do_execute(
   File "/var/lib/openstack/lib/python3.12/site-packages/sqlalchemy/engine/default.py", line 942, in do_execute
     cursor.execute(statement, parameters)
   File "/var/lib/openstack/lib/python3.12/site-packages/pymysql/cursors.py", line 153, in execute
     result = self._query(query)
              ^^^^^^^^^^^^^^^^^^
   File "/var/lib/openstack/lib/python3.12/site-packages/pymysql/cursors.py", line 322, in _query
     conn.query(q)
   File "/var/lib/openstack/lib/python3.12/site-packages/pymysql/connections.py", line 563, in query
     self._affected_rows = self._read_query_result(unbuffered=unbuffered)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/var/lib/openstack/lib/python3.12/site-packages/pymysql/connections.py", line 825, in _read_query_result
     result.read()
   File "/var/lib/openstack/lib/python3.12/site-packages/pymysql/connections.py", line 1199, in read
     first_packet = self.connection._read_packet()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/var/lib/openstack/lib/python3.12/site-packages/pymysql/connections.py", line 775, in _read_packet
     packet.raise_for_error()
   File "/var/lib/openstack/lib/python3.12/site-packages/pymysql/protocol.py", line 219, in raise_for_error
     err.raise_mysql_exception(self._data)
   File "/var/lib/openstack/lib/python3.12/site-packages/pymysql/err.py", line 150, in raise_mysql_exception
     raise errorclass(errno, errval)
 oslo_db.exception.DBError: (pymysql.err.IntegrityError) (1048, "Column 'bytes_in' cannot be null")
 [SQL: UPDATE listener_statistics SET bytes_in=%(bytes_in)s, bytes_out=%(bytes_out)s, active_connections=%(active_connections)s, total_connections=%(total_connections)s, request_errors=%(request_errors)s WHERE listener_statistics.listener_id = %(listener_id_1)s AND listener_statistics.amphora_id = %(amphora_id_1)s]
```

This fix sets a zero value if there is no actual data for the statistics because the [database schema of Octavia does not allow](https://github.com/sapcc/octavia/blob/stable/2025.1-m3/octavia/db/models.py#L162-L166) `NULL` values. 