### PR TITLE
Fix availability check: Treat non-existing devices as unavailable

### DIFF
--- a/octavia_f5/controller/worker/l2_sync_manager.py
+++ b/octavia_f5/controller/worker/l2_sync_manager.py
@@ -206,9 +206,9 @@ class L2SyncManager(BaseTaskFlowEngine):
             if device and bigip.hostname != device:
                 continue
 
-            # Check if device available by symple GET request
+            # skip unavailable devices
             if not bigip.is_available(timeout=CONF.status_manager.failover_timeout):
-                LOG.debug(f"Device {bigip.hostname} is unreachable for API requests.")
+                LOG.warning(f"ensure_l2_flow: Skipping unavailable device {bigip.hostname}")
                 continue
 
             selfips_for_host = [selfip for selfip in selfips if bigip.hostname in selfip.name]
@@ -362,6 +362,12 @@ class L2SyncManager(BaseTaskFlowEngine):
         executor = futures.ThreadPoolExecutor(max_workers=1)
         fs = []
         for bigip in self._bigips:
+
+            # skip unavailable devices
+            if not bigip.is_available(timeout=CONF.status_manager.failover_timeout):
+                LOG.warning(f"full_sync: Skipping unavailable device {bigip.hostname}")
+                continue
+
             """ 1. Delete all orphaned routes """
             res = bigip.get(path='/mgmt/tm/net/route')
             res.raise_for_status()

--- a/octavia_f5/restclient/bigip/bigip_restclient.py
+++ b/octavia_f5/restclient/bigip/bigip_restclient.py
@@ -83,8 +83,9 @@ class BigIPRestClient(requests.Session):
         Check if BigIP device is available for communications.
         """
         try:
-            requests.get(self.url.scheme + '://' + self.url.hostname, timeout=timeout, verify=False)
-            LOG.info(f'Found device with URL {self.url.hostname}')
+            # we don't need a response body, so HTTP HEAD suffices
+            requests.head(self.url.scheme + '://' + self.url.hostname, timeout=timeout, verify=False)
+            LOG.info(f"Found device with URL {self.url.hostname}")
             return True
         except requests.exceptions.Timeout:
             # This catches both connection timeouts and read timeouts

--- a/octavia_f5/restclient/bigip/bigip_restclient.py
+++ b/octavia_f5/restclient/bigip/bigip_restclient.py
@@ -82,14 +82,16 @@ class BigIPRestClient(requests.Session):
         """
         Check if BigIP device is available for communications.
         """
-        available = True
         try:
             requests.get(self.url.scheme + '://' + self.url.hostname, timeout=timeout, verify=False)
             LOG.info(f'Found device with URL {self.url.hostname}')
+            return True
         except requests.exceptions.Timeout:
-            LOG.info(f'Device timed out, considering it unavailable. Timeout: {timeout}s Hostname: {self.url.hostname}')
-            available = False
-        return available
+            # This catches both connection timeouts and read timeouts
+            LOG.warning(f"Device {self.url.hostname} timed out after {timeout}s, considering it unavailable.")
+        except requests.exceptions.ConnectionError:
+            LOG.warning(f"Device {self.url.hostname} cannot be connected to, considering it unavailable.")
+        return False
 
     def update_status(self):
         """ Update status if device is active or not

--- a/octavia_f5/restclient/bigip/bigip_restclient.py
+++ b/octavia_f5/restclient/bigip/bigip_restclient.py
@@ -110,7 +110,7 @@ class BigIPRestClient(requests.Session):
             LOG.error("F5 status response is empty, return cached status")
             return self._active or False
         if len(statuses) < 2:
-            LOG.error("F5 status response contain less than 2 devices: %s", statuses)
+            LOG.warning("F5 status response contains less than 2 devices: %s", statuses)
         statuses = {d['name']: d['failoverState'] == 'active' for d in statuses}
         LOG.debug("got F5 devices statuses: %s", statuses)
         if not any(statuses.values()):


### PR DESCRIPTION
The availability check in the `is_available` function only accounts for connection timeouts and read timeouts, but not for other connection failures like when a device hostname can't even be resolved. This leads to `is_available` passing such an exception further up the call stack, which leads to syncs failing before they even begin.

This PR
- fixes `is_available`
  - to account for `ConnectionError` exceptions
  - implements the early return pattern
  - replaces HTTP `GET` with `HEAD`, since we're not interested in content, but only in whether we get a response at all
- adds the missing check for unavailable devices to `full_sync` (it existed only in `ensure_l2_flow`)
- upgrades the unreachable device message in `ensure_l2_flow` from `debug` to `warning`, since we're always interested in whether a worker's devices are reachable or skipped
- downgrades the "F5 status response contain less than 2 devices" log message from `error` to `warning`, since we can have cases where we're okay with only one device existing for a given worker