### PR TITLE
Hotfix for Amphora creation for a new workers

### DIFF
--- a/octavia_f5/controller/statusmanager/status_manager.py
+++ b/octavia_f5/controller/statusmanager/status_manager.py
@@ -366,14 +366,13 @@ class StatusManager(object):
                 else:
                     amp_dict['role'] = constants.ROLE_BACKUP
 
-                # generate ID for the object if needed
-                # it is required after SQLalchemy upgrade
-                # https://github.com/sapcc/octavia/commit/b15a6e8c7dcdcb83adb5545b7016d0400c2221d1
-                if not amp_dict.get('id'):
-                    amp_dict['id'] = uuidutils.generate_uuid()
-
                 # create/modify entry
                 if not device_entry:
+                    # generate ID for the object if needed
+                    # it is required after SQLalchemy upgrade
+                    # https://github.com/sapcc/octavia/commit/b15a6e8c7dcdcb83adb5545b7016d0400c2221d1
+                    if not amp_dict.get('id'):
+                        amp_dict['id'] = uuidutils.generate_uuid()
                     self.amp_repo.create(session, **amp_dict)
                 else:
                     self.amp_repo.update(session, device_entry.id, **amp_dict)

--- a/octavia_f5/controller/statusmanager/status_manager.py
+++ b/octavia_f5/controller/statusmanager/status_manager.py
@@ -21,7 +21,7 @@ import prometheus_client as prometheus
 from oslo_config import cfg
 from oslo_db import exception as db_exc
 from oslo_log import log as logging
-from oslo_utils import excutils
+from oslo_utils import excutils, uuidutils
 
 from octavia.common import constants as o_const
 from octavia.common import rpc
@@ -365,6 +365,12 @@ class StatusManager(object):
                     amp_dict['role'] = constants.ROLE_MASTER
                 else:
                     amp_dict['role'] = constants.ROLE_BACKUP
+
+                # generate ID for the object if needed
+                # it is required after SQLalchemy upgrade
+                # https://github.com/sapcc/octavia/commit/b15a6e8c7dcdcb83adb5545b7016d0400c2221d1
+                if not amp_dict.get('id'):
+                    amp_dict['id'] = uuidutils.generate_uuid()
 
                 # create/modify entry
                 if not device_entry:


### PR DESCRIPTION
This PR contains hotfix for the issue with amphora creation when the worker did not exist:
```
 ERROR futurist.periodics [-] Failed to call immediate 'octavia_f5.cmd.status_manager.main.<locals>.periodic_status' (it runs every 120.00 seconds): TypeError: can only concatenate str (not "NoneType") to str
 ERROR futurist.periodics Traceback (most recent call last):
 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/futurist/periodics.py", line 290, in run
 ERROR futurist.periodics     work()
 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/futurist/periodics.py", line 64, in __call__
 ERROR futurist.periodics     return self.callback(*self.args, **self.kwargs)
 ERROR futurist.periodics            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/futurist/periodics.py", line 178, in decorator
 ERROR futurist.periodics     return f(*args, **kwargs)
 ERROR futurist.periodics            ^^^^^^^^^^^^^^^^^^
 ERROR futurist.periodics   File "/var/lib/openstack/src/octavia-f5-provider-driver/octavia_f5/cmd/status_manager.py", line 72, in periodic_status
 ERROR futurist.periodics     sm.heartbeat()
 ERROR futurist.periodics   File "<decorator-gen-7>", line 2, in heartbeat
 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/prometheus_client/context_managers.py", line 31, in wrapped
 ERROR futurist.periodics     return func(*args, **kwargs)
 ERROR futurist.periodics            ^^^^^^^^^^^^^^^^^^^^^
 ERROR futurist.periodics   File "<decorator-gen-6>", line 2, in heartbeat
 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/prometheus_client/context_managers.py", line 80, in wrapped
 ERROR futurist.periodics     return func(*args, **kwargs)
 ERROR futurist.periodics            ^^^^^^^^^^^^^^^^^^^^^
 ERROR futurist.periodics   File "/var/lib/openstack/src/octavia-f5-provider-driver/octavia_f5/controller/statusmanager/status_manager.py", line 216, in heartbeat
 ERROR futurist.periodics     self.availability_check()
 ERROR futurist.periodics   File "/var/lib/openstack/src/octavia-f5-provider-driver/octavia_f5/controller/statusmanager/status_manager.py", line 200, in availability_check
 ERROR futurist.periodics     self.update_availability()
 ERROR futurist.periodics   File "/var/lib/openstack/src/octavia-f5-provider-driver/octavia_f5/controller/statusmanager/status_manager.py", line 344, in update_availability
 ERROR futurist.periodics     with DatabaseLockSession() as session:
 ERROR futurist.periodics   File "/var/lib/openstack/src/octavia-f5-provider-driver/octavia_f5/controller/statusmanager/status_manager.py", line 63, in __exit__
 ERROR futurist.periodics     with excutils.save_and_reraise_exception():
 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/oslo_utils/excutils.py", line 227, in __exit__
 ERROR futurist.periodics     self.force_reraise()
 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/oslo_utils/excutils.py", line 200, in force_reraise
 ERROR futurist.periodics     raise self.value
 ERROR futurist.periodics   File "/var/lib/openstack/src/octavia-f5-provider-driver/octavia_f5/controller/statusmanager/status_manager.py", line 371, in update_availability
 ERROR futurist.periodics     self.amp_repo.create(session, **amp_dict)
 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/octavia/db/repositories.py", line 84, in create
 ERROR futurist.periodics     return model.to_data_model()
 ERROR futurist.periodics            ^^^^^^^^^^^^^^^^^^^^^
 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/octavia/db/base_models.py", line 102, in to_data_model
 ERROR futurist.periodics     dm_key = self._get_unique_key(dm_self)
 ERROR futurist.periodics              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/octavia/db/base_models.py", line 41, in _get_unique_key
 ERROR futurist.periodics     return obj.__class__.__name__ + obj.id
 ERROR futurist.periodics            ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
 ERROR futurist.periodics TypeError: can only concatenate str (not "NoneType") to str
 ERROR futurist.periodics
```

This problem related to this change https://github.com/sapcc/octavia/commit/b15a6e8c7dcdcb83adb5545b7016d0400c2221d1 in upstream and to fix that they use wrappers: https://github.com/sapcc/octavia/blame/b15a6e8c7dcdcb83adb5545b7016d0400c2221d1/octavia/db/prepare.py#L28 but we did not.