### PR TITLE
[L2] Fix make_remove_vcmp_l2_flow: Skip interface/LAG unassignment

### DIFF
--- a/octavia_f5/controller/worker/flows/f5_flows_iseries.py
+++ b/octavia_f5/controller/worker/flows/f5_flows_iseries.py
@@ -314,12 +314,12 @@ class F5Flows(object):
     def make_remove_vcmp_l2_flow(self) -> flow.Flow:
         get_vcmp_guests = self.tasks.GetVCMPGuests()
         remove_guest_vlan = self.tasks.RemoveGuestVLAN()
-        remove_vlan_interface = self.tasks.RemoveVLANInterface()
+        # no need to unassign the VLAN from the interface/LAG, because that is
+        # going to happen at VLAN deletioni anyway.
         remove_vlan_if_not_owned_by_guest = self.tasks.RemoveVLANIfNotOwnedByGuest()
 
         remove_vcmp_l2_flow = linear_flow.Flow('remove-vcmp-l2-flow')
         remove_vcmp_l2_flow.add(get_vcmp_guests,
                                 remove_guest_vlan,
-                                remove_vlan_interface,
                                 remove_vlan_if_not_owned_by_guest)
         return remove_vcmp_l2_flow

--- a/octavia_f5/controller/worker/tasks/f5_tasks_iseries.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks_iseries.py
@@ -115,15 +115,6 @@ class EnsureVLANInterface(task.Task):
         return None
 
 
-class RemoveVLANInterface(task.Task):
-    """ Task to remove VLAN interface attachment """
-
-    def execute(self):
-        # we don't need to remove the VLAN interface attachment on iSeries devices, because they're automatically
-        # removed when the VLAN is deleted.
-        pass
-
-
 class EnsureGuestVLAN(task.Task):
     """ Task to assign correct vlan to vcmp guest """
 

--- a/octavia_f5/controller/worker/tasks/f5_tasks_rseries.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks_rseries.py
@@ -199,27 +199,6 @@ class RemoveGuestVLAN(task.Task):
             res.raise_for_status()
 
 
-class RemoveVLANInterface(task.Task):
-    """ Task to remove VLAN interface attachment """
-
-    @decorators.RaisesF5osaError()
-    def execute(self,
-                bigip: bigip_restclient.BigIPRestClient,
-                network: f5_network_models.Network):
-        network_driver = driver_utils.get_network_driver()
-        lag_name = network_driver.physical_interface
-        vlan_id = network.vlan_id
-
-        path = f"/api/data/openconfig-interfaces:interfaces/interface={lag_name}" \
-               f"/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config/trunk-vlans={vlan_id}"
-        res = bigip.delete(path=path)
-
-        if res.status_code == 404:
-            LOG.warning(f"Can't detach VLAN {vlan_id} from LAG {lag_name} for host {bigip.hostname}. Already detached?")
-            return
-        res.raise_for_status()
-
-
 class RemoveVLANIfNotOwnedByGuest(task.Task):
 
     @decorators.RaisesF5osaError()

--- a/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
+++ b/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
@@ -638,8 +638,6 @@ class TestF5Flows(base.TestCase):
         mock_delete_response = MockResponse({}, 204)
         delete_calls = [
             mock.call(path='/api/data/f5-tenants:tenants/tenant=test-host-1/config/vlans=1234'),
-            mock.call(path=("/api/data/openconfig-interfaces:interfaces/interface=portchannel1/openconfig-if-aggregate:"
-                            "aggregation/openconfig-vlan:switched-vlan/config/trunk-vlans=1234")),
             mock.call(path="/api/data/openconfig-vlan:vlans/vlan=1234"),
         ]
 
@@ -717,8 +715,6 @@ class TestF5Flows(base.TestCase):
         mock_delete_response = MockResponse({}, 204)
         delete_calls = [
             mock.call(path='/api/data/f5-tenants:tenants/tenant=test-host-1/config/vlans=1234'),
-            mock.call(path=("/api/data/openconfig-interfaces:interfaces/interface=portchannel1/openconfig-if-aggregate:"
-                            "aggregation/openconfig-vlan:switched-vlan/config/trunk-vlans=1234")),
             # no VLAN deletion call
         ]
 


### PR DESCRIPTION
Skip unassigning the VLAN from an interface/LAG.  This operation was already a NOP for iSeries. But it was implemented for rSeries. But due to the bug on rSeries hosts that makes VLAN deletion impossible sometimes (see the long explanation comment in f5_tasks_rseries.py), we have to skip LAG unassignment, because in the case of this bug the non-deleted VLAN has to stay assigned to the LAG, so that when it's reused by a future LB, it will still have connectivity.