### PR TITLE
Handle invalid l7rule compare_type / type

### DIFF
--- a/octavia_f5/api/drivers/f5_driver/driver.py
+++ b/octavia_f5/api/drivers/f5_driver/driver.py
@@ -25,7 +25,6 @@ from octavia.db import api as db_apis
 from octavia_f5.api.drivers.f5_driver import arbiter
 from octavia_f5.common import constants as f5_consts
 from octavia_f5.utils import driver_utils
-from octavia_f5.restclient.as3objects import policy_endpoint
 
 CONF = cfg.CONF
 CONF.import_group('oslo_messaging', 'octavia.common.config')
@@ -231,11 +230,11 @@ class F5ProviderDriver(driver.AmphoraProviderDriver,
 
     # L7 Rule
     def _validate_l7rule(self, l7rule):
-        if l7rule.compare_type and l7rule.compare_type not in policy_endpoint.COMPARE_TYPE_MAP:
+        if l7rule.compare_type and l7rule.compare_type not in f5_consts.POLICY_COMPARE_TYPE_MAP:
             raise exceptions.UnsupportedOptionError(
                 user_fault_string=f'Unsupported compare type {l7rule.compare_type}')
 
-        if l7rule.type and l7rule.type not in policy_endpoint.COND_TYPE_MAP:
+        if l7rule.type and l7rule.type not in f5_consts.POLICY_COND_TYPE_MAP:
             raise exceptions.UnsupportedOptionError(
                 user_fault_string=f'Unsupported type {l7rule.type}')
 

--- a/octavia_f5/api/drivers/f5_driver/driver.py
+++ b/octavia_f5/api/drivers/f5_driver/driver.py
@@ -25,6 +25,7 @@ from octavia.db import api as db_apis
 from octavia_f5.api.drivers.f5_driver import arbiter
 from octavia_f5.common import constants as f5_consts
 from octavia_f5.utils import driver_utils
+from octavia_f5.restclient.as3objects import policy_endpoint
 
 CONF = cfg.CONF
 CONF.import_group('oslo_messaging', 'octavia.common.config')
@@ -229,7 +230,18 @@ class F5ProviderDriver(driver.AmphoraProviderDriver,
         client.cast({}, 'update_l7policy', **payload)
 
     # L7 Rule
+    def _validate_l7rule(self, l7rule):
+        if l7rule.compare_type and l7rule.compare_type not in policy_endpoint.COMPARE_TYPE_MAP:
+            raise exceptions.UnsupportedOptionError(
+                user_fault_string=f'Unsupported compare type {l7rule.compare_type}')
+
+        if l7rule.type and l7rule.type not in policy_endpoint.COND_TYPE_MAP:
+            raise exceptions.UnsupportedOptionError(
+                user_fault_string=f'Unsupported type {l7rule.type}')
+
     def l7rule_create(self, l7rule):
+        self._validate_l7rule(l7rule)
+
         with db_apis.session().begin() as session:
             db_l7 = self.repositories.l7policy.get(session, id=l7rule.l7policy_id)
 
@@ -246,6 +258,8 @@ class F5ProviderDriver(driver.AmphoraProviderDriver,
         client.cast({}, 'delete_l7rule', **payload)
 
     def l7rule_update(self, old_l7rule, new_l7rule):
+        self._validate_l7rule(new_l7rule)
+
         with db_apis.session().begin() as session:
             db_l7 = self.repositories.l7policy.get(session, id=old_l7rule.l7policy_id)
 

--- a/octavia_f5/common/constants.py
+++ b/octavia_f5/common/constants.py
@@ -12,6 +12,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from octavia_lib.common import constants
+
 PROJECT_ID = 'project_id'
 
 BIGIP = 'bigip'
@@ -90,3 +92,33 @@ HEALTH_MONITOR_DELAY_MAX = 3600
 
 # The list of required ciphers for HTTP2
 CIPHERS_HTTP2 = ['ECDHE-RSA-AES128-GCM-SHA256']
+
+POLICY_COMPARE_TYPE_MAP = {
+    'STARTS_WITH': 'starts-with',
+    'ENDS_WITH': 'ends-with',
+    'CONTAINS': 'contains',
+    'EQUAL_TO': 'equals'
+}
+POLICY_COMPARE_TYPE_INVERT_MAP = {
+    'STARTS_WITH': 'does-not-start-with',
+    'ENDS_WITH': 'does-not-end-with',
+    'CONTAINS': 'does-not-contain',
+    'EQUAL_TO': 'does-not-equal'
+}
+POLICY_COND_TYPE_MAP = {
+    # constants.L7RULE_TYPE_HOST_NAME: {'match_key': 'host', 'type': 'httpUri'},
+    # Workaround for https://github.com/F5Networks/f5-appsvcs-extension/issues/229, match Host in httpHeader
+    constants.L7RULE_TYPE_HOST_NAME: {'match_key': 'all', 'type': 'httpHeader', 'key_name': 'name',
+                                      'override_key': 'Host'},
+    constants.L7RULE_TYPE_PATH: {'match_key': 'path', 'type': 'httpUri'},
+    constants.L7RULE_TYPE_FILE_TYPE: {'match_key': 'extension', 'type': 'httpUri'},
+    constants.L7RULE_TYPE_HEADER: {'match_key': 'all', 'type': 'httpHeader', 'key_name': 'name'},
+    constants.L7RULE_TYPE_SSL_DN_FIELD: {'match_key': 'serverName', 'type': 'sslExtension'},
+    constants.L7RULE_TYPE_COOKIE: {'match_key': 'all', 'type': 'httpCookie', 'key_name': 'name'},
+}
+POLICY_SUPPORTED_ACTION_TYPE = [
+    constants.L7POLICY_ACTION_REDIRECT_TO_POOL,
+    constants.L7POLICY_ACTION_REDIRECT_TO_URL,
+    constants.L7POLICY_ACTION_REDIRECT_PREFIX,
+    constants.L7POLICY_ACTION_REJECT
+]

--- a/octavia_f5/restclient/as3objects/policy_endpoint.py
+++ b/octavia_f5/restclient/as3objects/policy_endpoint.py
@@ -21,36 +21,6 @@ from octavia_f5.restclient.as3classes import Policy_Compare_String, Policy_Condi
 from octavia_f5.restclient.as3objects import pool
 from octavia_f5.utils.exceptions import PolicyTypeNotSupported, CompareTypeNotSupported, PolicyActionNotSupported
 
-COMPARE_TYPE_MAP = {
-    'STARTS_WITH': 'starts-with',
-    'ENDS_WITH': 'ends-with',
-    'CONTAINS': 'contains',
-    'EQUAL_TO': 'equals'
-}
-COMPARE_TYPE_INVERT_MAP = {
-    'STARTS_WITH': 'does-not-start-with',
-    'ENDS_WITH': 'does-not-end-with',
-    'CONTAINS': 'does-not-contain',
-    'EQUAL_TO': 'does-not-equal'
-}
-COND_TYPE_MAP = {
-    # constants.L7RULE_TYPE_HOST_NAME: {'match_key': 'host', 'type': 'httpUri'},
-    # Workaround for https://github.com/F5Networks/f5-appsvcs-extension/issues/229, match Host in httpHeader
-    constants.L7RULE_TYPE_HOST_NAME: {'match_key': 'all', 'type': 'httpHeader', 'key_name': 'name',
-                                      'override_key': 'Host'},
-    constants.L7RULE_TYPE_PATH: {'match_key': 'path', 'type': 'httpUri'},
-    constants.L7RULE_TYPE_FILE_TYPE: {'match_key': 'extension', 'type': 'httpUri'},
-    constants.L7RULE_TYPE_HEADER: {'match_key': 'all', 'type': 'httpHeader', 'key_name': 'name'},
-    constants.L7RULE_TYPE_SSL_DN_FIELD: {'match_key': 'serverName', 'type': 'sslExtension'},
-    constants.L7RULE_TYPE_COOKIE: {'match_key': 'all', 'type': 'httpCookie', 'key_name': 'name'},
-}
-SUPPORTED_ACTION_TYPE = [
-    constants.L7POLICY_ACTION_REDIRECT_TO_POOL,
-    constants.L7POLICY_ACTION_REDIRECT_TO_URL,
-    constants.L7POLICY_ACTION_REDIRECT_PREFIX,
-    constants.L7POLICY_ACTION_REJECT
-]
-
 
 def get_name(policy_id):
     return f"{f5_const.PREFIX_POLICY}{policy_id}"
@@ -61,19 +31,19 @@ def get_wrapper_name(listener_id):
 
 
 def _get_condition(l7rule):
-    if l7rule.type not in COND_TYPE_MAP:
+    if l7rule.type not in f5_const.POLICY_COND_TYPE_MAP:
         raise PolicyTypeNotSupported(
             f"l7policy-id={l7rule.l7policy_id}, l7rule-id={l7rule.id}, type={l7rule.type}")
-    if l7rule.compare_type not in COMPARE_TYPE_MAP:
+    if l7rule.compare_type not in f5_const.POLICY_COMPARE_TYPE_MAP:
         raise CompareTypeNotSupported(
             f"l7policy-id={l7rule.l7policy_id}, l7rule-id={l7rule.id}, type={l7rule.compare_type}")
 
     args = {}
     if l7rule.invert:
-        operand = COMPARE_TYPE_INVERT_MAP[l7rule.compare_type]
+        operand = f5_const.POLICY_COMPARE_TYPE_INVERT_MAP[l7rule.compare_type]
     else:
-        operand = COMPARE_TYPE_MAP[l7rule.compare_type]
-    condition = COND_TYPE_MAP[l7rule.type]
+        operand = f5_const.POLICY_COMPARE_TYPE_MAP[l7rule.compare_type]
+    condition = f5_const.POLICY_COND_TYPE_MAP[l7rule.type]
     values = [l7rule.value]
     compare_string = Policy_Compare_String(operand=operand, values=values)
     args[condition['match_key']] = compare_string
@@ -87,7 +57,7 @@ def _get_condition(l7rule):
 
 
 def _get_action(l7policy):
-    if l7policy.action not in SUPPORTED_ACTION_TYPE:
+    if l7policy.action not in f5_const.POLICY_SUPPORTED_ACTION_TYPE:
         raise PolicyActionNotSupported()
 
     args = {}

--- a/octavia_f5/tests/unit/api/drivers/f5_provider_driver/test_f5_driver.py
+++ b/octavia_f5/tests/unit/api/drivers/f5_provider_driver/test_f5_driver.py
@@ -18,6 +18,7 @@ from oslo_config import fixture as oslo_fixture
 
 from octavia.common import constants as consts
 from octavia.common import exceptions
+from octavia_lib.api.drivers import exceptions as driver_exceptions
 from octavia.tests.unit import base
 from octavia.tests.common import sample_data_models
 from octavia_f5.api.drivers.f5_driver import driver
@@ -290,6 +291,26 @@ class TestF5Driver(base.TestRpc):
         mock_cast.assert_called_with({}, 'create_l7rule', **payload)
 
     @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_l7rule_create_with_invalid_compare_type(self, mock_cast):
+        provider_l7rule = driver_dm.L7Rule(
+            l7rule_id=self.sample_data.l7rule1_id,
+            compare_type='REGEX')
+
+        with self.assertRaisesRegex(driver_exceptions.UnsupportedOptionError,
+                                    "Unsupported compare type REGEX"):
+            self.amp_driver.l7rule_create(provider_l7rule)
+
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_l7rule_create_with_invalid_type(self, mock_cast):
+        provider_l7rule = driver_dm.L7Rule(
+            l7rule_id=self.sample_data.l7rule1_id,
+            type='everything')
+
+        with self.assertRaisesRegex(driver_exceptions.UnsupportedOptionError,
+                                    "Unsupported type everything"):
+            self.amp_driver.l7rule_create(provider_l7rule)
+
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
     def test_l7rule_delete(self, mock_cast):
         provider_l7rule = driver_dm.L7Rule(
             l7rule_id=self.sample_data.l7rule1_id)
@@ -318,3 +339,13 @@ class TestF5Driver(base.TestRpc):
         payload = {consts.ORIGINAL_L7RULE: {'l7rule_id': self.sample_data.l7rule1_id},
                    consts.L7RULE_UPDATES: {}}
         mock_cast.assert_called_with({}, 'update_l7rule', **payload)
+
+    @mock.patch('oslo_messaging.rpc.client._BaseCallContext.cast')
+    def test_l7rule_update_invalid_type(self, mock_cast):
+        old_provider_l7rule = driver_dm.L7Rule(
+            l7rule_id=self.sample_data.l7rule1_id)
+        provider_l7rule = driver_dm.L7Rule(
+            l7rule_id=self.sample_data.l7rule1_id, type="invalid-type")
+        with self.assertRaisesRegex(driver_exceptions.UnsupportedOptionError,
+                                    "Unsupported type invalid-type"):
+            self.amp_driver.l7rule_update(old_provider_l7rule, provider_l7rule)


### PR DESCRIPTION
Users can create l7rules in Octavia that are later rejected by the octavia-f5-provider-driver. In this case we might see an error as such:

octavia_f5.utils.exceptions.CompareTypeNotSupported: l7policy-id=..., l7rule-id=..., type=REGEX

This only happens when we try to configure the loadbalancer on the f5 device. To prevent this we validate the compare_type and type of a rule by doing the same check that is done inside
as3objects/policy_endpoint.py.

This results in the following error presented to the user:

Provider 'f5' does not support a requested option: Unsupported compare type REGEX (HTTP 501)

Semantically this should be a 400 BAD REQUEST, as the request done by the user is invalid in the context of our loadbalancer, but it looks like we can't throw an API exception from within the driver. All exceptions are caught by call_provider() and all of them lead to a 500 error in one way or the other. By using the well documented UnsupportedOptionError, which is later transformed into a ProviderUnsupportedOptionError, we can at least present a proper error message to our user.