### PR TITLE
Fix SetQueue: put_priority doesn't honor maxsize

### DIFF
--- a/octavia_f5/controller/worker/set_queue.py
+++ b/octavia_f5/controller/worker/set_queue.py
@@ -12,7 +12,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from queue import Queue
+from queue import Queue, Full
+import time
 
 
 class SetQueue(Queue):
@@ -30,14 +31,35 @@ class SetQueue(Queue):
         self.queue = []
         self.priority_queue = []
 
-    def put_priority(self, item):
-        """Add an item to the priority queue."""
-        if item not in self.priority_queue:
-            self.priority_queue.append(item)
-        if item in self.queue:
-            self.queue.remove(item)
-        # notify polling threads
-        with self.not_empty:  # acquire self.mutex for self.not_empty
+    def put_priority(self, item, block=True, timeout=None):
+        """Add an item to the priority queue, respecting maxsize and blocking like
+        Queue.put.
+        """
+        with self.not_full:
+            # honor maxsize semantics from queue.Queue.put
+            if self.maxsize > 0:
+                if not block:
+                    if self._qsize() >= self.maxsize:
+                        raise Full
+                elif timeout is None:
+                    while self._qsize() >= self.maxsize:
+                        self.not_full.wait()
+                else:
+                    endtime = time.time() + timeout
+                    while self._qsize() >= self.maxsize:
+                        remaining = endtime - time.time()
+                        if remaining <= 0.0:
+                            raise Full
+                        self.not_full.wait(remaining)
+
+            # insert the priority item if it's not already present
+            if item not in self.priority_queue:
+                self.priority_queue.append(item)
+            if item in self.queue:
+                self.queue.remove(item)
+
+            # notify polling threads; notify() requires the lock to be held,
+            # which it already is via self.not_full, so call notify() directly.
             self.not_empty.notify()
 
     def _put(self, item):

--- a/octavia_f5/tests/unit/controller/worker/test_set_queue.py
+++ b/octavia_f5/tests/unit/controller/worker/test_set_queue.py
@@ -133,3 +133,40 @@ class TestSetQueue(base.TestCase):
                 assert item > last_item, \
                     f"After getting {items_gotten} items: SetQueue is not FIFO"
             last_item = item
+
+    def test_put_and_put_priority_respect_maxsize(self):
+        """Ensure both put and put_priority respect maxsize and block when full."""
+        import threading
+        import time
+
+        q = SetQueue(maxsize=1)
+        # fill the queue
+        q.put('a')
+
+        done = threading.Event()
+
+        def waiter():
+            # This should block until space is available
+            q.put_priority('b')
+            done.set()
+
+        t = threading.Thread(target=waiter)
+        t.start()
+
+        # Give the thread a moment to attempt the put_priority
+        time.sleep(0.1)
+
+        # The waiter should still be blocked and not have set the event
+        self.assertFalse(done.is_set(), "put_priority inserted item into full queue")
+        self.assertTrue(t.is_alive())
+
+        # Free up space
+        q.get()
+
+        # Wait for waiter to finish
+        t.join(timeout=1)
+        self.assertTrue(done.wait(timeout=1))
+
+        # The queue should now contain the priority item
+        self.assertEqual(q.qsize(), 1)
+        self.assertEqual(q.get(), 'b')


### PR DESCRIPTION
`put_priority` does not honor `self.maxsize` and doesn't block, allowing priority items to be inserted even when the queue is full.

- Add unit test that demonstrates this behavior by checking that both `put` and `put_priority` block when queue is full.
- Implement same `self.maxsize` check and block/timeout semantics as `Queue.put` using the same `not_full`/`not_empty` coordination (with predicate loops to handle spurious wakeups).