### PR TITLE
Fix loadbalancers stuck in PENDING when VIP was deleted

### DIFF
--- a/octavia_f5/api/drivers/f5_driver/driver.py
+++ b/octavia_f5/api/drivers/f5_driver/driver.py
@@ -14,6 +14,7 @@
 
 from octavia_lib.api.drivers import data_models as driver_dm
 from octavia_lib.api.drivers import exceptions
+from octavia_lib.common import constants as lib_consts
 from oslo_config import cfg
 from oslo_log import log as logging
 
@@ -21,6 +22,7 @@ from octavia.api.drivers.amphora_driver.v2 import driver
 from octavia.common import constants as consts
 from octavia.common import exceptions as api_exceptions
 from octavia.db import api as db_apis
+from octavia.network import base
 
 from octavia_f5.api.drivers.f5_driver import arbiter
 from octavia_f5.common import constants as f5_consts
@@ -57,7 +59,19 @@ class F5ProviderDriver(driver.AmphoraProviderDriver,
 
         # fetch scheduled server from VIP port
         network_driver = driver_utils.get_network_driver()
-        return network_driver.get_scheduled_host(loadbalancer.vip.port_id)
+        try:
+            return network_driver.get_scheduled_host(loadbalancer.vip.port_id)
+        except base.NetworkException as exc:
+            LOG.error(f"Failed to get scheduled host for LB {loadbalancer.id} "
+                      f"with error {exc}. Provisioning status for loadbalancer "
+                      "set to ERROR.")
+            with session.begin():
+                self.repositories.load_balancer.update(
+                    session, loadbalancer.id,
+                    provisioning_status=lib_consts.ERROR,
+                    force_provisioning_status=True)
+            # we have to reraise error because we need to stop processing
+            raise
 
     def loadbalancer_create(self, loadbalancer):
         if loadbalancer.flavor == driver_dm.Unset:

--- a/octavia_f5/controller/worker/controller_worker.py
+++ b/octavia_f5/controller/worker/controller_worker.py
@@ -34,6 +34,7 @@ from sqlalchemy.orm import exc as db_exceptions
 
 from octavia.common import constants as octavia_consts
 from octavia.db import repositories as repo
+from octavia.network import base
 from octavia_f5.common import constants as octavia_f5_consts
 from octavia_f5.controller.worker import status_manager, sync_manager, l2_sync_manager
 from octavia_f5.controller.worker.set_queue import SetQueue
@@ -260,10 +261,21 @@ class ControllerWorker(object):
                 show_deleted=False)[0]
         for lb in pending_create_lbs:
             # bind to loadbalancer if scheduled to this host
-            if CONF.host == self.network_driver.get_scheduled_host(lb.vip.port_id):
-                self.ensure_host_set(lb)
-                lbs.append(lb)
-
+            try:
+                if ((lb.server_group_id and CONF.host == lb.server_group_id) or
+                        (CONF.host == self.network_driver.get_scheduled_host(lb.vip.port_id))):
+                    self.ensure_host_set(lb)
+                    lbs.append(lb)
+            except base.NetworkException as exc:
+                with db_apis.session().begin() as editor_ses:
+                    self._loadbalancer_repo.update(
+                        editor_ses,
+                        id=lb.id,
+                        provisioning_status=lib_consts.ERROR,
+                        force_provisioning_status=True)
+                LOG.error(f"Failed to get scheduled host for LB {lb.id} with "
+                          f"error {exc}. Provisioning status for loadbalancer set "
+                          "to ERROR.")
         # Find pending loadbalancer
         with session.begin():
             lbs.extend(self._loadbalancer_repo.get_all_from_host(

--- a/octavia_f5/network/drivers/neutron/neutron_client.py
+++ b/octavia_f5/network/drivers/neutron/neutron_client.py
@@ -262,7 +262,15 @@ class NeutronClient(neutron_base.BaseNeutronDriver,
         :param port_id: the neutron port id
         :return: hostname of the binding host
         """
-        res = self.network_proxy.get_port(port_id)
+        try:
+            res = self.network_proxy.get_port(port_id)
+        except os_exceptions.ResourceNotFound as exc:
+            message = _(f"Port not found (port id: {port_id}).")
+            raise base.PortNotFound(message) from exc
+        except Exception as exc:
+            message = _(f"Error retrieving port (port id: {port_id}.")
+            LOG.exception(message)
+            raise base.NetworkException(message) from exc
         return res['binding:host_id']
 
     def get_network(self, network_id, context=None):


### PR DESCRIPTION
This PR contains a fix for LoadBalancers stuck in PENDING_* states when the customer removed the VIP port from Neutron.

Example of error in the logs:
```
2025-11-18 06:05:54,420 22 ERROR futurist.periodics [-] Failed to call periodic 'octavia_f5.controller.worker.controller_worker.ControllerWorker.pending_sync' (it runs every 120.00 seconds): openstack.exceptions.NotFoundException: No Port found for b7d5459e-a294-4894-911e-61680bb431a2: Client Error for url: http://neutron-server.monsoon3.svc.*********:9696/v2.0/ports/b7d5459e-a294-4894-911e-61680bb431a2, Port b7d5459e-a294-4894-911e-61680bb431a2 could not be found.
2025-11-18 06:05:54,420 22 ERROR futurist.periodics Traceback (most recent call last):
2025-11-18 06:05:54,420 22 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/futurist/periodics.py", line 290, in run
2025-11-18 06:05:54,420 22 ERROR futurist.periodics     work()
2025-11-18 06:05:54,420 22 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/futurist/periodics.py", line 64, in __call__
2025-11-18 06:05:54,420 22 ERROR futurist.periodics     return self.callback(*self.args, **self.kwargs)
2025-11-18 06:05:54,420 22 ERROR futurist.periodics            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-11-18 06:05:54,420 22 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/futurist/periodics.py", line 178, in decorator
2025-11-18 06:05:54,420 22 ERROR futurist.periodics     return f(*args, **kwargs)
2025-11-18 06:05:54,420 22 ERROR futurist.periodics            ^^^^^^^^^^^^^^^^^^
2025-11-18 06:05:54,420 22 ERROR futurist.periodics   File "/var/lib/openstack/src/octavia-f5-provider-driver/octavia_f5/controller/worker/controller_worker.py", line 263, in pending_sync
2025-11-18 06:05:54,420 22 ERROR futurist.periodics     if CONF.host == self.network_driver.get_scheduled_host(lb.vip.port_id):
2025-11-18 06:05:54,420 22 ERROR futurist.periodics                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-11-18 06:05:54,420 22 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/decorator.py", line 232, in fun
2025-11-18 06:05:54,420 22 ERROR futurist.periodics     return caller(func, *(extras + args), **kw)
2025-11-18 06:05:54,420 22 ERROR futurist.periodics            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-11-18 06:05:54,420 22 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/dogpile/cache/region.py", line 1634, in get_or_create_for_user_func
2025-11-18 06:05:54,420 22 ERROR futurist.periodics     return self.get_or_create(
2025-11-18 06:05:54,420 22 ERROR futurist.periodics            ^^^^^^^^^^^^^^^^^^^
2025-11-18 06:05:54,420 22 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/dogpile/cache/region.py", line 1094, in get_or_create
2025-11-18 06:05:54,420 22 ERROR futurist.periodics     with Lock(
2025-11-18 06:05:54,420 22 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/dogpile/lock.py", line 185, in __enter__
2025-11-18 06:05:54,420 22 ERROR futurist.periodics     return self._enter()
2025-11-18 06:05:54,420 22 ERROR futurist.periodics            ^^^^^^^^^^^^^
2025-11-18 06:05:54,420 22 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/dogpile/lock.py", line 94, in _enter
2025-11-18 06:05:54,420 22 ERROR futurist.periodics     generated = self._enter_create(value, createdtime)
2025-11-18 06:05:54,420 22 ERROR futurist.periodics                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-11-18 06:05:54,420 22 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/dogpile/lock.py", line 178, in _enter_create
2025-11-18 06:05:54,420 22 ERROR futurist.periodics     return self.creator()
2025-11-18 06:05:54,420 22 ERROR futurist.periodics            ^^^^^^^^^^^^^^
2025-11-18 06:05:54,420 22 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/dogpile/cache/region.py", line 1048, in gen_value
2025-11-18 06:05:54,420 22 ERROR futurist.periodics     created_value = creator(
2025-11-18 06:05:54,420 22 ERROR futurist.periodics                     ^^^^^^^^
2025-11-18 06:05:54,420 22 ERROR futurist.periodics   File "/var/lib/openstack/src/octavia-f5-provider-driver/octavia_f5/network/drivers/neutron/neutron_client.py", line 265, in get_scheduled_host
2025-11-18 06:05:54,420 22 ERROR futurist.periodics     res = self.network_proxy.get_port(port_id)
2025-11-18 06:05:54,420 22 ERROR futurist.periodics           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-11-18 06:05:54,420 22 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/openstack/network/v2/_proxy.py", line 2972, in get_port
2025-11-18 06:05:54,420 22 ERROR futurist.periodics     return self._get(_port.Port, port)
2025-11-18 06:05:54,420 22 ERROR futurist.periodics            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-11-18 06:05:54,420 22 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/openstack/proxy.py", line 63, in check
2025-11-18 06:05:54,420 22 ERROR futurist.periodics     return method(self, expected, actual, *args, **kwargs)
2025-11-18 06:05:54,420 22 ERROR futurist.periodics            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-11-18 06:05:54,420 22 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/openstack/proxy.py", line 716, in _get
2025-11-18 06:05:54,420 22 ERROR futurist.periodics     return res.fetch(
2025-11-18 06:05:54,420 22 ERROR futurist.periodics            ^^^^^^^^^^
2025-11-18 06:05:54,420 22 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/openstack/resource.py", line 1597, in fetch
2025-11-18 06:05:54,420 22 ERROR futurist.periodics     self._translate_response(
2025-11-18 06:05:54,420 22 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/openstack/resource.py", line 1178, in _translate_response
2025-11-18 06:05:54,420 22 ERROR futurist.periodics     exceptions.raise_from_response(response, error_message=error_message)
2025-11-18 06:05:54,420 22 ERROR futurist.periodics   File "/var/lib/openstack/lib/python3.12/site-packages/openstack/exceptions.py", line 247, in raise_from_response
2025-11-18 06:05:54,420 22 ERROR futurist.periodics     raise cls(
2025-11-18 06:05:54,420 22 ERROR futurist.periodics openstack.exceptions.NotFoundException: No Port found for b7d5459e-a294-4894-911e-61680bb431a2: Client Error for url: http://neutron-server.monsoon3.svc.******:9696/v2.0/ports/b7d5459e-a294-4894-911e-61680bb431a2, Port b7d5459e-a294-4894-911e-61680bb431a2 could not be found.
2025-11-18 06:05:54,420 22 ERROR futurist.periodics
```

This fix handles this error and sets `provisioning_status` for the LoadBalancer to ERROR. This is the only way we can fix stuck load balancers because we cannot process a load balancer without a VIP, and we can not leave it in a stuck status. `ERROR` status at least gives some information to a customer and gives abillity to change LoadBalancer. 

After this fix we will see log messages like:
```
ERROR octavia_f5.controller.worker.controller_worker [-] Failed to get scheduled host for LB 6238688f-0e1d-476d-8551-9127369bf970 with error Port not found (port id: bb3b75b9-2abd-4adf-95ef-01f358dc3521).. Provisioning status for loadbalancer set to ERROR.: octavia.network.base.PortNotFound: Port not found (port id: bb3b75b9-2abd-4adf-95ef-01f358dc3521).
```
everytime when we hit this problem, VIP was removed.