### PR TITLE
Add option for AS3 logging level

### DIFF
--- a/octavia_f5/controller/worker/sync_manager.py
+++ b/octavia_f5/controller/worker/sync_manager.py
@@ -188,6 +188,13 @@ class SyncManager(object):
         if CONF.f5_agent.dry_run:
             decl.set_action('dry-run')
 
+        for lb in loadbalancers:
+            if 'as3_declaration_debug' in lb.tags:
+                LOG.info("AS3 declaration logging was set to debug level because "
+                         f"loadbalancer {lb.id} tagged with 'as3_declaration_debug'")
+                decl.set_log_level('debug')
+                break
+
         # No config syncing if we are in migration mode or specifically syncing one device
         if not CONF.f5_agent.migration and not device and CONF.f5_agent.sync_to_group:
             decl.set_sync_to_group(CONF.f5_agent.sync_to_group)

--- a/octavia_f5/restclient/as3classes.py
+++ b/octavia_f5/restclient/as3classes.py
@@ -117,6 +117,9 @@ class AS3(BaseDescription):
     def set_target_tokens(self, tokens):
         setattr(self, 'targetTokens', tokens)
 
+    def set_log_level(self, level):
+        setattr(self, 'logLevel', level)
+
 
 class ADC(BaseDescription):
     def __init__(self, schemaVersion='3.19.0', updateMode='selective', **kwargs):  # noqa

--- a/octavia_f5/tests/unit/controller/worker/test_sync_manager.py
+++ b/octavia_f5/tests/unit/controller/worker/test_sync_manager.py
@@ -58,6 +58,7 @@ class TestSyncManager(base.TestCase):
             network_models.FixedIP(ip_address='1.2.3.4')])]
 
         mock_lb = mock.Mock(spec=models.LoadBalancer)
+        mock_lb.tags = []
         loadbalancer_repo.get_all_by_network.return_value = [mock_lb]
         with mock.patch('octavia_f5.db.api.session'):
             manager.tenant_update('test-net-id', selfips=selfips)


### PR DESCRIPTION
This PR adds the ability to enable AS3 internal declaration debug for specific tenants without changing the configuration. To enable this debug, you have to set the tag `as3_declaration_debug` to loadbalancer.

‼️It can sound a bit dangerous because we give external customer abbility to control this feature, but it is still less dangerous than enabling Debug logging globally for the whole region, and any customer can already load badly our API anyway without knowing this specific tag.‼️