### PR TITLE
[as3restclient] Truncate logs: Don't show certificate private keys

### DIFF
--- a/octavia_f5/restclient/as3logging.py
+++ b/octavia_f5/restclient/as3logging.py
@@ -26,8 +26,12 @@ def truncate_as3_secrets(as3_json_decl):
     """
 
     for net in as3_json_decl:
+        if not net.startswith(constants.PREFIX_NETWORK):
+            continue
         net_obj = as3_json_decl.get(net)
         for lb in net_obj:
+            if not lb.startswith(constants.PREFIX_LOADBALANCER):
+                continue
             lb_obj = net_obj.get(lb)
             for lb_key in lb_obj:
                 # remove private keys from certificate declarations
@@ -57,7 +61,7 @@ def get_response_log(response):
     if request.body:
         try:
             parsed = json.loads(request.body)
-            truncate_as3_secrets(parsed)
+            truncate_as3_secrets(parsed['declaration'])
             msg += json.dumps(parsed, sort_keys=True, indent=4)
         except ValueError:
             # No json, just dump

--- a/octavia_f5/restclient/as3logging.py
+++ b/octavia_f5/restclient/as3logging.py
@@ -13,15 +13,39 @@
 # under the License.
 
 from urllib import parse
-
 import json
+
+from octavia_f5.common import constants
+
+
+def truncate_as3_secrets(as3_json_decl):
+    """ Remove or truncate sensitive material from an AS3 declaration.
+    Changes are made in-place.
+
+    :param as3_json_decl: A parsed JSON object constructed with json.load or json.loads
+    """
+
+    for net in as3_json_decl:
+        net_obj = as3_json_decl.get(net)
+        for lb in net_obj:
+            lb_obj = net_obj.get(lb)
+            for lb_key in lb_obj:
+                # remove private keys from certificate declarations
+                if not lb_key.startswith(constants.PREFIX_CERTIFICATE):
+                    continue
+                cert_obj = lb_obj.get(lb_key)
+                for cert_key in cert_obj:
+                    if cert_key == 'privateKey':
+                        cert_priv = cert_obj.get(cert_key)
+                        # keep the first line so that the type of key is still
+                        # recognizable
+                        cert_obj[cert_key] = cert_priv.split("\n")[0] + "\n(...)"
 
 
 def get_response_log(response):
     """ Formats AS3 requests response and prints them pretty
 
     :param response: requests response
-    :param error: boolean, true if log to error, else debug
     """
 
     request = response.request
@@ -33,6 +57,7 @@ def get_response_log(response):
     if request.body:
         try:
             parsed = json.loads(request.body)
+            truncate_as3_secrets(parsed)
             msg += json.dumps(parsed, sort_keys=True, indent=4)
         except ValueError:
             # No json, just dump

--- a/octavia_f5/tests/unit/restclient/test_as3logging.py
+++ b/octavia_f5/tests/unit/restclient/test_as3logging.py
@@ -1,0 +1,52 @@
+# Copyright 2018 SAP SE
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from octavia.tests.unit import base
+from octavia_f5.restclient import as3logging
+
+
+class TestAS3Logging(base.TestCase):
+
+    def test_as3logging_truncates_secret(self):
+        privkey = '-----BEGIN RSA PRIVATE KEY-----\nprivate key data that should be stripped\n-----END RSA PRIVATE KEY-----'
+        as3_decl = {
+            'other_key': 'should_not_be_modified',
+            'net_test_net': {
+                'other_key': 'should_not_be_modified',
+                'lb_test_lb': {
+                    'other_key': 'should_not_be_modified',
+                    'cert_test_cert': {
+                        'name': 'my-cert',
+                        'privateKey': privkey,
+                        'certificate': '-----BEGIN CERTIFICATE-----\ncert data\n-----END CERTIFICATE-----'
+                    }
+                }
+            }
+        }
+
+        # backup declaration, then truncating it
+        as3_decl_backup = as3_decl.copy()
+        as3logging.truncate_as3_secrets(as3_decl)
+
+        # verify that the private key was truncated
+        truncated_key = as3_decl['net_test_net']['lb_test_lb']['cert_test_cert']['privateKey']
+        expected_truncated = privkey.split('\n')[0] + '\n(...)'
+        self.assertEqual(truncated_key, expected_truncated)
+
+        # verify that other certificate fields were not modified
+        # by setting the private key to the same value and comparing
+        override = {'net_test_net': {'lb_test_lb': {'cert_test_cert': {'privateKey': None}}}}
+        as3_decl_backup_no_key = as3_decl_backup | override
+        as3_decl_no_key = as3_decl | override
+        self.assertEqual(as3_decl_backup_no_key, as3_decl_no_key)


### PR DESCRIPTION
Don't omit them fully, just print their first line (e.g. "-----BEGIN RSA PRIVATE KEY-----") so that their type is still clear.