### PR TITLE
Fix vlan creation RC

### DIFF
--- a/octavia_f5/controller/worker/flows/f5_flows_iseries.py
+++ b/octavia_f5/controller/worker/flows/f5_flows_iseries.py
@@ -27,7 +27,7 @@ class F5Flows(object):
     def __init__(self, tasks=f5_tasks_iseries):
         self.tasks = tasks
 
-    def make_ensure_l2_flow(self, selfips: [network_models.Port], store: dict) -> flow.Flow:
+    def make_ensure_l2_guest_flow(self, selfips: [network_models.Port], store: dict) -> flow.Flow:
         """
         Construct and return a flow to ensure complete L2 configuration for a new partition.
         The flow assumes that no L2 objects exist yet for the network so nothing is cleaned up.
@@ -88,8 +88,8 @@ class F5Flows(object):
             name=f'ensure-vlan-{bigip_hostname}',
             inject=store)
 
-        ensure_l2_flow = linear_flow.Flow(f'ensure-l2-flow-{bigip_hostname}')
-        ensure_l2_flow.add(get_existing_vlan,
+        ensure_l2_guest_flow = linear_flow.Flow(f'ensure-l2-guest-flow-{bigip_hostname}')
+        ensure_l2_guest_flow.add(get_existing_vlan,
                            ensure_vlan,
                            get_existing_route_domain,
                            ensure_route_domain,
@@ -97,7 +97,7 @@ class F5Flows(object):
                            ensure_selfips_subflow,
                            ensure_default_route,
                            ensure_subnet_routes_subflow)
-        return ensure_l2_flow
+        return ensure_l2_guest_flow
 
     def make_remove_l2_flow(self, store: dict) -> flow.Flow:
         """
@@ -155,7 +155,7 @@ class F5Flows(object):
             name=f'remove-vlan-{bigip_hostname}',
             inject=store)
 
-        remove_l2_flow = linear_flow.Flow(f'remove-l2-flow-{bigip_hostname}')
+        remove_l2_flow = linear_flow.Flow(f'remove-l2-guest-flow-{bigip_hostname}')
         remove_l2_flow.add(remove_subnet_routes_subflow,
                            remove_default_route_task,
                            # SelfIPs must be deleted after routes, otherwise a route would be unreachable
@@ -298,20 +298,20 @@ class F5Flows(object):
 
         return get_existing_sip_sr_flow
 
-    def make_ensure_vcmp_l2_flow(self) -> flow.Flow:
+    def make_ensure_l2_host_flow(self) -> flow.Flow:
         get_existing_vlan = self.tasks.GetExistingVLAN()
         ensure_vlan = self.tasks.EnsureVLAN()
         ensure_vlan_interface = self.tasks.EnsureVLANInterface()
         ensure_vlan_guest_assignment = self.tasks.EnsureVLANGuestAssignment()
 
-        ensure_vcmp_l2_flow = linear_flow.Flow('ensure-vcmp-l2-flow')
-        ensure_vcmp_l2_flow.add(get_existing_vlan,
+        ensure_l2_host_flow = linear_flow.Flow('ensure-vcmp-l2-flow')
+        ensure_l2_host_flow.add(get_existing_vlan,
                                 ensure_vlan,
                                 ensure_vlan_interface,
                                 ensure_vlan_guest_assignment)
-        return ensure_vcmp_l2_flow
+        return ensure_l2_host_flow
 
-    def make_remove_vcmp_l2_flow(self) -> flow.Flow:
+    def make_remove_l2_host_flow(self) -> flow.Flow:
         get_vcmp_guests = self.tasks.GetVCMPGuests()
         remove_vlan_guest_assignment = self.tasks.RemoveVLANGuestAssignment()
         # Don't unassign the VLAN from the interface/LAG. It's going to happen
@@ -319,8 +319,8 @@ class F5Flows(object):
         # succeeds.
         remove_vlan_if_not_owned_by_other_guest = self.tasks.RemoveVLANIfNotOwnedByOtherGuest()
 
-        remove_vcmp_l2_flow = linear_flow.Flow('remove-vcmp-l2-flow')
-        remove_vcmp_l2_flow.add(get_vcmp_guests,
+        remove_l2_host_flow = linear_flow.Flow('remove-vcmp-l2-flow')
+        remove_l2_host_flow.add(get_vcmp_guests,
                                 remove_vlan_guest_assignment,
                                 remove_vlan_if_not_owned_by_other_guest)
-        return remove_vcmp_l2_flow
+        return remove_l2_host_flow

--- a/octavia_f5/controller/worker/l2_sync_manager.py
+++ b/octavia_f5/controller/worker/l2_sync_manager.py
@@ -249,10 +249,10 @@ class L2SyncManager(BaseTaskFlowEngine):
         # raise error only if all pairs failed
         if self._bigips and all(bigip in failed_bigips for bigip in self._bigips):
             raise exceptions.ProviderDriverException(
-                f"Failed ensure_l2_flow for all bigip devices of network_id={network_id}")
+                f"Failed ensure_l2_flow for all bigip guests of network_id={network_id}")
         if self._vcmps and all(vcmp in failed_bigips for vcmp in self._vcmps):
             raise exceptions.ProviderDriverException(
-                f"Failed ensure_l2_flow for all vcmp devices of network_id={network_id}")
+                f"Failed ensure_l2_flow for all bigip hosts of network_id={network_id}")
 
     def remove_l2_flow(self, network_id: str, device=None):
         """ Runs the taskflows for cleanup of l2 configuration on all bigip devices in parallel

--- a/octavia_f5/controller/worker/l2_sync_manager.py
+++ b/octavia_f5/controller/worker/l2_sync_manager.py
@@ -88,8 +88,8 @@ class L2SyncManager(BaseTaskFlowEngine):
         for bigip in self._bigips:
             bigip.update_status()
 
-    def _do_ensure_l2_flow(self, data: list):
-        ensure_l2_flow = unordered_flow.Flow('ensure-l2-flow-from-all-devices')
+    def _do_ensure_l2_guest_flow(self, data: list):
+        ensure_l2_guest_flow = unordered_flow.Flow('ensure-l2-guest-flow-from-all-devices')
         for flow_data in data:
             # get existing SelfIPs and subnet routes - they are needed to determine,
             # which ones have to be created and which already exist
@@ -103,25 +103,25 @@ class L2SyncManager(BaseTaskFlowEngine):
             flow_data['store']['existing_selfips'] = e.storage.get('get-existing-selfips')
             flow_data['store']['existing_subnet_routes'] = e.storage.get('get-existing-subnet-routes')
 
-            ensure_l2_flow.add(
-                self._f5flows_guest.make_ensure_l2_flow(
+            ensure_l2_guest_flow.add(
+                self._f5flows_guest.make_ensure_l2_guest_flow(
                     flow_data['selfips'], store=flow_data['store']))
 
         # We have to inject all required variables to each flow/task because these flows will
         # be running as part of Graph flow and storage contains equal variables but for two F5
         # devices, their variables' names overlap. Also in graph flow, every subflow/task should
         # have a unique name that's why we have to add BigIP hostname.
-        e = self.taskflow_load(ensure_l2_flow)
+        e = self.taskflow_load(ensure_l2_guest_flow)
         with tf_logging.DynamicLoggingListener(e, log=LOG):
             e.run()
 
-    def _do_ensure_vcmp_l2_flow(self, store: dict):
-        e = self.taskflow_load(self._f5flows_host.make_ensure_vcmp_l2_flow(), store=store)
+    def _do_ensure_l2_host_flow(self, store: dict):
+        e = self.taskflow_load(self._f5flows_host.make_ensure_l2_host_flow(), store=store)
         with tf_logging.DynamicLoggingListener(e, log=LOG):
             e.run()
 
     def _do_remove_l2_flow(self, data: list):
-        remove_l2_flow = unordered_flow.Flow('remove-l2-flow-from-all-devices')
+        remove_l2_flow = unordered_flow.Flow('remove-l2-guest-flow-from-all-devices')
         for flow_data in data:
             # get existing SelfIPs and subnet routes
             e = self.taskflow_load(self._f5flows_guest.make_get_existing_selfips_and_subnet_routes_flow(),
@@ -178,8 +178,8 @@ class L2SyncManager(BaseTaskFlowEngine):
         with tf_logging.LoggingListener(e, log=LOG):
             e.run()
 
-    def _do_remove_vcmp_l2_flow(self, store: dict):
-        e = self.taskflow_load(self._f5flows_host.make_remove_vcmp_l2_flow(), store=store)
+    def _do_remove_l2_host_flow(self, store: dict):
+        e = self.taskflow_load(self._f5flows_host.make_remove_l2_host_flow(), store=store)
         with tf_logging.DynamicLoggingListener(e, log=LOG):
             e.run()
 
@@ -201,7 +201,7 @@ class L2SyncManager(BaseTaskFlowEngine):
 
         # run l2 flow for all devices in parallel
         fs = {}
-        ensure_l2_flow_data = []
+        ensure_l2_guest_flow_data = []
         for bigip in self._bigips:
             if device and bigip.hostname != device:
                 continue
@@ -213,13 +213,13 @@ class L2SyncManager(BaseTaskFlowEngine):
 
             selfips_for_host = [selfip for selfip in selfips if bigip.hostname in selfip.name]
             subnet_ids = set(sip.fixed_ips[0].subnet_id for sip in selfips_for_host)
-            ensure_l2_flow_data.append({
+            ensure_l2_guest_flow_data.append({
                 'store': {'bigip': bigip, 'network': network, 'subnet_id': subnet_ids.pop()},
                 'selfips': selfips_for_host,
             })
         fs[self.executor.submit(
-            self._do_ensure_l2_flow,
-            data=ensure_l2_flow_data)] = self._bigips
+            self._do_ensure_l2_guest_flow,
+            data=ensure_l2_guest_flow_data)] = self._bigips
 
         # run VCMP l2 flow for all VCMP hosts in parallel
         for vcmp in self._vcmps:
@@ -228,7 +228,7 @@ class L2SyncManager(BaseTaskFlowEngine):
                 store['bigip_guest_names'] = CONF.networking.override_vcmp_guest_names
             else:
                 store['bigip_guest_names'] = [bigip.hostname for bigip in self._bigips]
-            fs[self.executor.submit(self._do_ensure_vcmp_l2_flow, store=store)] = [vcmp]
+            fs[self.executor.submit(self._do_ensure_l2_host_flow, store=store)] = [vcmp]
 
         # wait for all flows to finish
         failed_bigips = []
@@ -282,7 +282,7 @@ class L2SyncManager(BaseTaskFlowEngine):
 
         for vcmp in self._vcmps:
             store = {'bigip': vcmp, 'bigip_guest_names': guest_names, 'network': network}
-            fs[self.executor.submit(self._do_remove_vcmp_l2_flow, store=store)] = [vcmp]
+            fs[self.executor.submit(self._do_remove_l2_host_flow, store=store)] = [vcmp]
 
         # Execute tasks for host and wait until it's done, because we have to be sure
         # that VLAN assignment was removed before we remove VLAN on the guest.
@@ -322,7 +322,7 @@ class L2SyncManager(BaseTaskFlowEngine):
                     # consider both device flows as failed, since we don't know
                     # which one the error originated in.
                     self._metric_failed_futures.labels(hostname, 'remove_l2_flow').inc()
-                LOG.error(f"Failed running remove_l2_flow for hosts {', '.join(hostnames)}: {e}")
+                LOG.error(f"Failed running remove_l2_flow for devices {', '.join(hostnames)}: {e}")
 
     def sync_l2_selfips_and_subnet_routes_flow(self, selfips: List[network_models.Port], network_id: str, device=None):
         """ Runs the taskflows to sync (add/remove) SelfIPs and subnet routes on all bigip devices in parallel

--- a/octavia_f5/controller/worker/l2_sync_manager.py
+++ b/octavia_f5/controller/worker/l2_sync_manager.py
@@ -199,8 +199,36 @@ class L2SyncManager(BaseTaskFlowEngine):
             raise exceptions.ProviderDriverException(
                 f"Failed ensure_l2_flow for network_id={network_id}: No segment bound")
 
-        # run l2 flow for all devices in parallel
+        # run vCMP L2 flow for all VCMP hosts in parallel
         fs = {}
+        for vcmp in self._vcmps:
+            store = {'bigip': vcmp, 'network': network}
+            if CONF.networking.override_vcmp_guest_names:
+                store['bigip_guest_names'] = CONF.networking.override_vcmp_guest_names
+            else:
+                store['bigip_guest_names'] = [bigip.hostname for bigip in self._bigips]
+            fs[self.executor.submit(self._do_ensure_l2_host_flow, store=store)] = [vcmp]
+
+        # wait for vCMP L2 flows to finish
+        failed_bigips = []
+        done, not_done = futures.wait(fs, timeout=CONF.networking.l2_timeout)
+        for f in done | not_done:
+            bigips = fs[f]
+            try:
+                f.result(0)
+            except Exception as e:
+                hostnames = [bigip.hostname for bigip in bigips]
+                for hostname in hostnames:
+                    self._metric_failed_futures.labels(hostname, 'ensure_l2_flow').inc()
+                    failed_bigips.append(hostname)
+                LOG.error(f"Failed running ensure_l2_flow for hosts {', '.join(hostnames)}: {e}")
+
+        # raise error only if all hosts failed
+        if self._vcmps and all(vcmp in failed_bigips for vcmp in self._vcmps):
+            raise exceptions.ProviderDriverException(
+                f"Failed ensure_l2_flow for all bigip hosts of network_id={network_id}")
+
+        # run l2 flow for all guests in parallel
         ensure_l2_guest_flow_data = []
         for bigip in self._bigips:
             if device and bigip.hostname != device:
@@ -217,42 +245,26 @@ class L2SyncManager(BaseTaskFlowEngine):
                 'store': {'bigip': bigip, 'network': network, 'subnet_id': subnet_ids.pop()},
                 'selfips': selfips_for_host,
             })
-        fs[self.executor.submit(
-            self._do_ensure_l2_guest_flow,
-            data=ensure_l2_guest_flow_data)] = self._bigips
 
-        # run VCMP l2 flow for all VCMP hosts in parallel
-        for vcmp in self._vcmps:
-            store = {'bigip': vcmp, 'network': network}
-            if CONF.networking.override_vcmp_guest_names:
-                store['bigip_guest_names'] = CONF.networking.override_vcmp_guest_names
-            else:
-                store['bigip_guest_names'] = [bigip.hostname for bigip in self._bigips]
-            fs[self.executor.submit(self._do_ensure_l2_host_flow, store=store)] = [vcmp]
+        guest_future = self.executor.submit(self._do_ensure_l2_guest_flow, data=ensure_l2_guest_flow_data)
 
-        # wait for all flows to finish
+        # wait for guest L2 flows to finish
         failed_bigips = []
-        done, not_done = futures.wait(fs, timeout=CONF.networking.l2_timeout)
+        done, not_done = futures.wait({guest_future: self._bigips}, timeout=CONF.networking.l2_timeout)
         for f in done | not_done:
-            bigips = fs[f]
+            bigips = self._bigips
             try:
                 f.result(0)
             except Exception as e:
-                hostnames = [bigip.hostname for bigip in bigips]
-                for hostname in hostnames:
-                    # consider both device flows as failed, since we don't know
-                    # which one the error originated in.
-                    self._metric_failed_futures.labels(hostname, 'ensure_l2_flow').inc()
-                    failed_bigips.append(hostname)
-                LOG.error(f"Failed running ensure_l2_flow for hosts {', '.join(hostnames)}: {e}")
+                for bigip in bigips:
+                    self._metric_failed_futures.labels(bigip.hostname, 'ensure_l2_flow').inc()
+                    failed_bigips.append(bigip)
+                LOG.error(f"Failed running ensure_l2_flow for guests {', '.join([b.hostname for b in bigips])}: {e}")
 
-        # raise error only if all pairs failed
+        # raise error only if all guests failed
         if self._bigips and all(bigip in failed_bigips for bigip in self._bigips):
             raise exceptions.ProviderDriverException(
                 f"Failed ensure_l2_flow for all bigip guests of network_id={network_id}")
-        if self._vcmps and all(vcmp in failed_bigips for vcmp in self._vcmps):
-            raise exceptions.ProviderDriverException(
-                f"Failed ensure_l2_flow for all bigip hosts of network_id={network_id}")
 
     def remove_l2_flow(self, network_id: str, device=None):
         """ Runs the taskflows for cleanup of l2 configuration on all bigip devices in parallel

--- a/octavia_f5/controller/worker/l2_sync_manager.py
+++ b/octavia_f5/controller/worker/l2_sync_manager.py
@@ -183,6 +183,24 @@ class L2SyncManager(BaseTaskFlowEngine):
         with tf_logging.DynamicLoggingListener(e, log=LOG):
             e.run()
 
+    def _wait_for_futures(self, fs, timeout, metric_task_name):
+        """Wait for futures, collect failed hostnames and increment metrics."""
+        failed = []
+        done, not_done = futures.wait(fs, timeout=timeout)
+        for f in done | not_done:
+            bigips = fs[f]
+            # normalize to list
+            bigips_list = bigips if isinstance(bigips, (list, tuple, set)) else [bigips]
+            try:
+                f.result(0)
+            except Exception as e:
+                hostnames = [bigip.hostname for bigip in bigips_list]
+                for hostname in hostnames:
+                    self._metric_failed_futures.labels(hostname, metric_task_name).inc()
+                    failed.append(hostname)
+                LOG.error(f"Failed running {metric_task_name} for hosts {', '.join(hostnames)}: {e}")
+        return failed
+
     def ensure_l2_flow(self, selfips: List[network_models.Port], network_id: str, device=None):
         """ Runs the taskflows for ensuring correct l2 configuration on all bigip devices in parallel
 
@@ -210,18 +228,7 @@ class L2SyncManager(BaseTaskFlowEngine):
             fs[self.executor.submit(self._do_ensure_l2_host_flow, store=store)] = [vcmp]
 
         # wait for vCMP L2 flows to finish
-        failed_bigips = []
-        done, not_done = futures.wait(fs, timeout=CONF.networking.l2_timeout)
-        for f in done | not_done:
-            bigips = fs[f]
-            try:
-                f.result(0)
-            except Exception as e:
-                hostnames = [bigip.hostname for bigip in bigips]
-                for hostname in hostnames:
-                    self._metric_failed_futures.labels(hostname, 'ensure_l2_flow').inc()
-                    failed_bigips.append(hostname)
-                LOG.error(f"Failed running ensure_l2_flow for hosts {', '.join(hostnames)}: {e}")
+        failed_bigips = self._wait_for_futures(fs, timeout=CONF.networking.l2_timeout, metric_task_name='ensure_l2_flow')
 
         # raise error only if all hosts failed
         if self._vcmps and all(vcmp in failed_bigips for vcmp in self._vcmps):
@@ -249,17 +256,7 @@ class L2SyncManager(BaseTaskFlowEngine):
         guest_future = self.executor.submit(self._do_ensure_l2_guest_flow, data=ensure_l2_guest_flow_data)
 
         # wait for guest L2 flows to finish
-        failed_bigips = []
-        done, not_done = futures.wait({guest_future: self._bigips}, timeout=CONF.networking.l2_timeout)
-        for f in done | not_done:
-            bigips = self._bigips
-            try:
-                f.result(0)
-            except Exception as e:
-                for bigip in bigips:
-                    self._metric_failed_futures.labels(bigip.hostname, 'ensure_l2_flow').inc()
-                    failed_bigips.append(bigip)
-                LOG.error(f"Failed running ensure_l2_flow for guests {', '.join([b.hostname for b in bigips])}: {e}")
+        failed_bigips = self._wait_for_futures({guest_future: self._bigips}, timeout=CONF.networking.l2_timeout, metric_task_name='ensure_l2_flow')
 
         # raise error only if all guests failed
         if self._bigips and all(bigip in failed_bigips for bigip in self._bigips):

--- a/octavia_f5/controller/worker/l2_sync_manager.py
+++ b/octavia_f5/controller/worker/l2_sync_manager.py
@@ -202,7 +202,12 @@ class L2SyncManager(BaseTaskFlowEngine):
         return failed
 
     def ensure_l2_flow(self, selfips: List[network_models.Port], network_id: str, device=None):
-        """ Runs the taskflows for ensuring correct l2 configuration on all bigip devices in parallel
+        """ Runs the taskflows for ensuring correct l2 configuration on all
+        bigip devices in parallel, first on the vCMP hosts, then on the guests.
+        When guest flows fail, only they are reverted, but not the host flows,
+        since L2 objects on the host are still needed for the eventually
+        succeeding guest l2 flows. They are only deleted at LB deletion in the
+        corresponding L2 removal method.
 
         :param selfips: Neutron SelfIP ports
         :param network_id: Neutron Network ID

--- a/octavia_f5/controller/worker/tasks/f5_tasks_iseries.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks_iseries.py
@@ -132,7 +132,7 @@ class EnsureVLANGuestAssignment(task.Task):
             if guest['name'] not in bigip_guest_names:
                 continue
 
-            # Check if the VLAN is already configured on the guest
+            # Check whether the VLAN is already assigned to the guest
             if device_vlan['name'] in ['/Common/' + vlan for vlan in guest['vlans']]:
                 continue
 

--- a/octavia_f5/controller/worker/tasks/f5_tasks_rseries.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks_rseries.py
@@ -43,6 +43,12 @@ class EnsureVLAN(task.Task):
                 bigip: bigip_restclient.BigIPRestClient,
                 existing_vlan: dict,
                 network: f5_network_models.Network):
+
+        # return if VLAN already exists
+        if existing_vlan:
+            return existing_vlan
+
+        # create payload
         vlan_id = network.vlan_id
         vlan_payload = {
             "vlan-id": vlan_id,
@@ -52,10 +58,6 @@ class EnsureVLAN(task.Task):
             }
         }
         payload = {'openconfig-vlan:vlan': [vlan_payload]}
-
-        # return if VLAN already exists
-        if existing_vlan:
-            return existing_vlan
 
         # contrary to the EnsureVLAN task for iSeries devices, we don't need to
         # patch the VLAN in this task, because it only contains the VLAN ID. In

--- a/octavia_f5/controller/worker/tasks/f5_tasks_rseries.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks_rseries.py
@@ -57,10 +57,11 @@ class EnsureVLAN(task.Task):
         if existing_vlan:
             return existing_vlan
 
-        # contrary to the EnsureVLAN task for iSeries devices, we don't need to patch the VLAN in this task,
-        # because it only contains the VLAN ID. In fact, comparing the existing_vlan dictionary with the payload
-        # would be misleading, since existing_vlan may also include the "members" key, which can change pretty
-        # much arbitrarily.
+        # contrary to the EnsureVLAN task for iSeries devices, we don't need to
+        # patch the VLAN in this task, because it only contains the VLAN ID. In
+        # fact, comparing the existing_vlan dictionary with the payload would
+        # be misleading, since existing_vlan may also include the "members"
+        # key, which can change pretty much arbitrarily.
 
         # create missing VLAN
         res = bigip.put(path=f"/api/data/openconfig-vlan:vlans/vlan={vlan_id}", json=payload)
@@ -140,13 +141,14 @@ class EnsureVLANGuestAssignment(task.Task):
         for guest in guests:
             guest_name = guest['name']
 
-            # Check if it's a managed guest.
-            # F5OS-A API only gives the host part of the name, so we have to check with startswith. We have to
-            # check against the guest name with a dot appended, so that partial guest names don't match.
+            # Check if it's a managed guest. F5OS-A API only gives the host
+            # part of the name, so we have to check with startswith. We have to
+            # check against the guest name with a dot appended, so that partial
+            # guest names don't match.
             if not any(name.startswith(guest_name + ".") for name in bigip_guest_names):
                 continue
 
-            # Check if the VLAN is already configured on the guest
+            # Check whether the VLAN is already assigned to the guest
             if vlan_id in guest['config']['vlans']:
                 continue
 

--- a/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
+++ b/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
@@ -97,7 +97,7 @@ class TestF5Flows(base.TestCase):
                  'subnet_id': mock_subnet_id,
                  'existing_selfips': []}
         needed_selfips = [selfip_port]
-        ensure_l2_flow = f5flows.make_ensure_l2_flow(needed_selfips, store=store)
+        ensure_l2_flow = f5flows.make_ensure_l2_guest_flow(needed_selfips, store=store)
         engines.run(ensure_l2_flow, store=store)
 
         # check that VLAN, RD, SelfIP, and default route have been created
@@ -181,7 +181,7 @@ class TestF5Flows(base.TestCase):
                  'subnet_id': mock_subnet_id,
                  'existing_selfips': []}
         needed_selfips = [selfip_port]
-        ensure_l2_flow = f5flows.make_ensure_l2_flow(needed_selfips, store=store)
+        ensure_l2_flow = f5flows.make_ensure_l2_guest_flow(needed_selfips, store=store)
         engines.run(ensure_l2_flow, store=store)
 
         mock_bigip.get.assert_called()
@@ -488,7 +488,7 @@ class TestF5Flows(base.TestCase):
         store = {'network': mock_network,
                  'bigip': mock_vcmp,
                  'bigip_guest_names': ['test-host-1']}
-        ensure_vcmp_l2_flow = f5flows.make_ensure_vcmp_l2_flow()
+        ensure_vcmp_l2_flow = f5flows.make_ensure_l2_host_flow()
         engines.run(ensure_vcmp_l2_flow, store=store)
 
         get_calls = [
@@ -564,7 +564,7 @@ class TestF5Flows(base.TestCase):
                  # the BigIPRestClient instance always contains the domain, so it has to be contained here as well.
                  'bigip_guest_names': ['test-host-1.some.domain']
                  }
-        ensure_vcmp_l2_flow = f5flows.make_ensure_vcmp_l2_flow()
+        ensure_vcmp_l2_flow = f5flows.make_ensure_l2_host_flow()
         engines.run(ensure_vcmp_l2_flow, store=store)
 
         get_calls = [
@@ -610,7 +610,7 @@ class TestF5Flows(base.TestCase):
         store = {'network': mock_network,
                  'bigip': mock_vcmp,
                  'bigip_guest_names': ['test-host-1']}
-        remove_vcmp_l2_flow = f5flows.make_remove_vcmp_l2_flow()
+        remove_vcmp_l2_flow = f5flows.make_remove_l2_host_flow()
         engines.run(remove_vcmp_l2_flow, store=store)
 
         mock_vcmp.get.assert_called_with(path='/mgmt/tm/vcmp/guest')
@@ -654,7 +654,7 @@ class TestF5Flows(base.TestCase):
                  # iControlREST does), we check it via startswith and a dot appended. But the hostname attribute of
                  # the BigIPRestClient instance always contains the domain, so it has to be contained here as well.
                  'bigip_guest_names': ['test-host-1.some.domain']}
-        remove_vcmp_l2_flow = f5flows.make_remove_vcmp_l2_flow()
+        remove_vcmp_l2_flow = f5flows.make_remove_l2_host_flow()
         engines.run(remove_vcmp_l2_flow, store=store)
 
         mock_vcmp.get.assert_called_with(path='/api/data/f5-tenants:tenants')
@@ -681,7 +681,7 @@ class TestF5Flows(base.TestCase):
         mock_vcmp.get.side_effect = [mock_guests_response]
         f5flows = f5_flows_iseries.F5Flows()
 
-        remove_vcmp_l2_flow = f5flows.make_remove_vcmp_l2_flow()
+        remove_vcmp_l2_flow = f5flows.make_remove_l2_host_flow()
         store = {'network': mock_network,
                  'bigip': mock_vcmp,
                  'bigip_guest_names': ['test-host-1']}
@@ -730,7 +730,7 @@ class TestF5Flows(base.TestCase):
                  # iControlREST does), we check it via startswith and a dot appended. But the hostname attribute of
                  # the BigIPRestClient instance always contains the domain, so it has to be contained here as well.
                  'bigip_guest_names': ['test-host-1.some.domain']}
-        remove_vcmp_l2_flow = f5flows.make_remove_vcmp_l2_flow()
+        remove_vcmp_l2_flow = f5flows.make_remove_l2_host_flow()
         engines.run(remove_vcmp_l2_flow, store=store)
 
         mock_vcmp.get.assert_called_with(path='/api/data/f5-tenants:tenants')

--- a/octavia_f5/tests/unit/controller/worker/tasks/test_f5_tasks.py
+++ b/octavia_f5/tests/unit/controller/worker/tasks/test_f5_tasks.py
@@ -24,7 +24,7 @@ import octavia.tests.unit.base as base
 from octavia.network import data_models as network_models
 # pylint: disable=unused-import
 from octavia_f5.common import config  # noqa
-from octavia_f5.controller.worker.tasks import f5_tasks_iseries
+from octavia_f5.controller.worker.tasks import f5_tasks_iseries, f5_tasks_rseries
 from octavia_f5.network import data_models as f5_network_models
 from octavia_f5.restclient import as3restclient
 from octavia_f5.tests.unit.controller.worker.flows import test_f5_flows
@@ -34,12 +34,258 @@ LOG = logging.getLogger(__name__)
 
 
 class TestF5Tasks(base.TestCase):
+
     def setUp(self):
         conf = self.useFixture(oslo_fixture.Config(cfg.CONF))
         conf.config(group="controller_worker",
                     network_driver='network_noop_driver_f5')
+        conf.config(group="networking", hardware_syncookie=False)
+        conf.config(group="networking", syn_flood_rate_limit=2000)
+        conf.config(group="networking", syncache_threshold=32000)
 
         super().setUp()
+
+
+    def test_EnsureVLAN_iSeries_existing_and_correct(self):
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_network = f5_network_models.Network(
+                id='test-network-id',
+                name='test-network-name',
+                mtu=9000,
+                segments=[{'provider:physical_network': 'physnet',
+                    'provider:segmentation_id': 1234}]
+                )
+
+        # existing VLAN which is correct
+        existing_vlan = {
+            'name': f'vlan-{mock_network.vlan_id}',
+            'tag': mock_network.vlan_id,
+            'mtu': mock_network.mtu,
+            'hardwareSyncookie': 'disabled',
+            'synFloodRateLimit': 2000,
+            'syncacheThreshold': 32000,
+        }
+
+        engines.run(f5_tasks_iseries.EnsureVLAN(), store={
+            'bigip': mock_bigip,
+            'network': mock_network,
+            'existing_vlan': existing_vlan
+            })
+        mock_bigip.post.assert_not_called()
+        mock_bigip.patch.assert_not_called()
+        mock_bigip.delete.assert_not_called()
+
+
+    def test_EnsureVLAN_iSeries_existing_and_needs_patching(self):
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_network = f5_network_models.Network(
+                id='test-network-id',
+                name='test-network-name',
+                mtu=9000,
+                segments=[{'provider:physical_network': 'physnet',
+                    'provider:segmentation_id': 1234}]
+                )
+
+        # existing VLAN with wrong MTU
+        existing_vlan = {
+            'name': f'vlan-{mock_network.vlan_id}',
+            'tag': mock_network.vlan_id,
+            'mtu': mock_network.mtu + 1,
+            'hardwareSyncookie': 'disabled',
+            'synFloodRateLimit': 2000,
+            'syncacheThreshold': 32000,
+        }
+
+        # expect VLAN with correct MTU
+        expected_vlan = existing_vlan | {'mtu': mock_network.mtu}
+
+        engines.run(f5_tasks_iseries.EnsureVLAN(), store={
+            'bigip': mock_bigip,
+            'network': mock_network,
+            'existing_vlan': existing_vlan
+            })
+        mock_bigip.post.assert_not_called()
+        # assert MTU has been corrected
+        mock_bigip.patch.assert_called_with(
+                path=f"/mgmt/tm/net/vlan/~Common~vlan-{mock_network.vlan_id}",
+                json=expected_vlan)
+        mock_bigip.delete.assert_not_called()
+
+
+    def test_EnsureVLAN_iSeries_new_vlan(self):
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_network = f5_network_models.Network(
+                id='test-network-id',
+                name='test-network-name',
+                mtu=9000,
+                segments=[{'provider:physical_network': 'physnet',
+                    'provider:segmentation_id': 1234}]
+                )
+
+        # no VLAN exists yet
+        existing_vlan = None
+        expected_vlan = {
+            'name': f'vlan-{mock_network.vlan_id}',
+            'tag': mock_network.vlan_id,
+            'mtu': mock_network.mtu,
+            'hardwareSyncookie': 'disabled',
+            'synFloodRateLimit': 2000,
+            'syncacheThreshold': 32000,
+        }
+
+        engines.run(f5_tasks_iseries.EnsureVLAN(), store={
+            'bigip': mock_bigip,
+            'network': mock_network,
+            'existing_vlan': existing_vlan
+            })
+        # assert VLAN has been created...
+        mock_bigip.post.assert_called_with(
+                path='/mgmt/tm/net/vlan',
+                json=expected_vlan)
+        # ...but no patching happened
+        mock_bigip.patch.assert_not_called()
+        mock_bigip.delete.assert_not_called()
+
+
+    def test_revert_EnsureVLAN_iSeries(self):
+        vlan_id = 1234
+        mock_network = f5_network_models.Network(
+                id='test-network-id',
+                name='test-network-name',
+                mtu=9000,
+                segments=[{'provider:physical_network': 'physnet',
+                    'provider:segmentation_id': vlan_id}]
+                )
+        class TestException(Exception):
+            pass
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip.post.side_effect = TestException(
+            "Test exception to trigger rollback of EnsureVLAN")
+
+        store = {
+                'bigip': mock_bigip,
+                'network': mock_network,
+                'existing_vlan': None,
+                }
+        self.assertRaises(TestException, engines.run,
+                f5_tasks_iseries.EnsureVLAN(), store=store)
+        mock_bigip.post.assert_called()
+        mock_bigip.delete.assert_called_with(
+                path=f"/mgmt/tm/net/vlan/~Common~vlan-{vlan_id}")
+
+
+    def test_revert_EnsureVLAN_iSeries_nop(self):
+        mock_network = f5_network_models.Network(
+                id='test-network-id',
+                name='test-network-name',
+                mtu=9000,
+                segments=[{'provider:physical_network': 'physnet',
+                    'provider:segmentation_id': 1234}]
+                )
+        class TestException(Exception):
+            pass
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        # since we pass something for existing_vlan, POST won't be called, but PATCH
+        mock_bigip.patch.side_effect = TestException(
+            "Test exception to trigger rollback of EnsureVLAN")
+
+        store = {
+                'bigip': mock_bigip,
+                'network': mock_network,
+                'existing_vlan': {'something':None},
+                }
+        self.assertRaises(TestException, engines.run,
+                f5_tasks_iseries.EnsureVLAN(), store=store)
+        mock_bigip.post.assert_not_called()
+        mock_bigip.patch.assert_called()
+        # since VLAN alread existed beforehand, revert must not delete it
+        mock_bigip.delete.assert_not_called()
+
+
+    def test_EnsureVLAN_rSeries_existing(self):
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_network = f5_network_models.Network(
+                id='test-network-id',
+                name='test-network-name',
+                mtu=9000,
+                segments=[{'provider:physical_network': 'physnet',
+                    'provider:segmentation_id': 1234}]
+                )
+
+        # existing VLAN (content doesn't matter)
+        existing_vlan = {'name': f'vlan-{mock_network.vlan_id}'}
+
+        engines.run(f5_tasks_rseries.EnsureVLAN(), store={
+            'bigip': mock_bigip,
+            'network': mock_network,
+            'existing_vlan': existing_vlan
+            })
+        mock_bigip.post.assert_not_called()
+        mock_bigip.patch.assert_not_called()
+        mock_bigip.delete.assert_not_called()
+
+
+    def test_EnsureVLAN_rSeries_new_vlan(self):
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        vlan_id = 1234
+        mock_network = f5_network_models.Network(
+                id='test-network-id',
+                name='test-network-name',
+                mtu=9000,
+                segments=[{'provider:physical_network': 'physnet',
+                    'provider:segmentation_id': vlan_id}],
+                )
+
+        # no VLAN exists yet
+        existing_vlan = None
+        expected_payload = {'openconfig-vlan:vlan': [{
+            'vlan-id': vlan_id,
+            'config': {
+                'vlan-id': vlan_id,
+                'name': f"vlan-{vlan_id}",
+                }
+            }]}
+
+        engines.run(f5_tasks_rseries.EnsureVLAN(), store={
+            'bigip': mock_bigip,
+            'network': mock_network,
+            'existing_vlan': existing_vlan
+            })
+        mock_bigip.post.assert_not_called()
+        mock_bigip.put.assert_called_with(
+                path=f"/api/data/openconfig-vlan:vlans/vlan={vlan_id}",
+                json=expected_payload)
+        mock_bigip.patch.assert_not_called()
+        mock_bigip.delete.assert_not_called()
+
+
+    def test_revert_EnsureVLAN_rSeries(self):
+        vlan_id = 1234
+        mock_network = f5_network_models.Network(
+                id='test-network-id',
+                name='test-network-name',
+                mtu=9000,
+                segments=[{'provider:physical_network': 'physnet',
+                    'provider:segmentation_id': vlan_id}]
+                )
+        class TestException(Exception):
+            pass
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip.put.side_effect = TestException(
+            "Test exception to trigger rollback of EnsureVLAN")
+
+        store = {
+                'bigip': mock_bigip,
+                'network': mock_network,
+                'existing_vlan': None,
+                }
+        self.assertRaises(TestException, engines.run,
+                f5_tasks_rseries.EnsureVLAN(), store=store)
+        mock_bigip.post.assert_not_called()
+        mock_bigip.put.assert_called()
+        mock_bigip.delete.assert_called_with(
+                path=f"/api/data/openconfig-vlan:vlans/vlan={vlan_id}")
+
 
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")
@@ -72,6 +318,7 @@ class TestF5Tasks(base.TestCase):
         mock_bigip.patch.assert_called_with(path='/mgmt/tm/net/route/~Common~vlan-1234',
                                             json={'gw': '2.3.4.5%1234', 'network': 'default%1234'})
         mock_bigip.post.assert_not_called()
+
 
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")
@@ -108,6 +355,7 @@ class TestF5Tasks(base.TestCase):
         mock_bigip.get.assert_has_calls(calls)
         mock_bigip.patch.assert_not_called()
         mock_bigip.post.assert_not_called()
+
 
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")
@@ -150,6 +398,7 @@ class TestF5Tasks(base.TestCase):
         mock_bigip.post.assert_called_with(json={
             'name': 'vlan-1234', 'gw': '8.8.8.8%1234', 'network': 'default%1234'},
             path='/mgmt/tm/net/route')
+
 
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")
@@ -217,6 +466,7 @@ class TestF5Tasks(base.TestCase):
                 'address': "1.2.3.2%1234/24",
             })
 
+
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")
     def test_EnsureSubnetRoute(self, mock_get_subnet):
@@ -274,6 +524,7 @@ class TestF5Tasks(base.TestCase):
                   'network': '2.3.4.0%1234/24'})
         mock_bigip.post.assert_not_called()
 
+
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")
     def test_revert_EnsureSelfIP(self, mock_get_subnet):
@@ -317,6 +568,7 @@ class TestF5Tasks(base.TestCase):
         mock_bigip.post.assert_not_called()
         mock_bigip.patch.assert_not_called()
 
+
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")
     def test_revert_EnsureSubnetRoute(self, mock_get_subnet):
@@ -354,6 +606,7 @@ class TestF5Tasks(base.TestCase):
         )
         mock_bigip.post.assert_not_called()
         mock_bigip.patch.assert_not_called()
+
 
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")
@@ -446,6 +699,7 @@ class TestF5Tasks(base.TestCase):
         mock_bigip.get.assert_called_with(path=f"/mgmt/tm/net/self/{selfip_port.id}")
         mock_bigip.post.assert_not_called()
         mock_bigip.patch.assert_not_called()
+
 
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")

--- a/octavia_f5/tests/unit/controller/worker/tasks/test_f5_tasks.py
+++ b/octavia_f5/tests/unit/controller/worker/tasks/test_f5_tasks.py
@@ -46,7 +46,7 @@ class TestF5Tasks(base.TestCase):
         super().setUp()
 
 
-    def test_EnsureVLAN_iSeries_existing_and_correct(self):
+    def test_EnsureHostVLAN_iSeries_existing(self):
         mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
         mock_network = f5_network_models.Network(
                 id='test-network-id',
@@ -60,13 +60,15 @@ class TestF5Tasks(base.TestCase):
         existing_vlan = {
             'name': f'vlan-{mock_network.vlan_id}',
             'tag': mock_network.vlan_id,
-            'mtu': mock_network.mtu,
+            # Make existing VLAN differ from wanted VLAN to make sure
+            # EnsureHostVLAN doesn't patch.
+            'mtu': mock_network.mtu + 1,
             'hardwareSyncookie': 'disabled',
             'synFloodRateLimit': 2000,
             'syncacheThreshold': 32000,
         }
 
-        engines.run(f5_tasks_iseries.EnsureVLAN(), store={
+        engines.run(f5_tasks_iseries.EnsureHostVLAN(), store={
             'bigip': mock_bigip,
             'network': mock_network,
             'existing_vlan': existing_vlan
@@ -76,43 +78,7 @@ class TestF5Tasks(base.TestCase):
         mock_bigip.delete.assert_not_called()
 
 
-    def test_EnsureVLAN_iSeries_existing_and_needs_patching(self):
-        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
-        mock_network = f5_network_models.Network(
-                id='test-network-id',
-                name='test-network-name',
-                mtu=9000,
-                segments=[{'provider:physical_network': 'physnet',
-                    'provider:segmentation_id': 1234}]
-                )
-
-        # existing VLAN with wrong MTU
-        existing_vlan = {
-            'name': f'vlan-{mock_network.vlan_id}',
-            'tag': mock_network.vlan_id,
-            'mtu': mock_network.mtu + 1,
-            'hardwareSyncookie': 'disabled',
-            'synFloodRateLimit': 2000,
-            'syncacheThreshold': 32000,
-        }
-
-        # expect VLAN with correct MTU
-        expected_vlan = existing_vlan | {'mtu': mock_network.mtu}
-
-        engines.run(f5_tasks_iseries.EnsureVLAN(), store={
-            'bigip': mock_bigip,
-            'network': mock_network,
-            'existing_vlan': existing_vlan
-            })
-        mock_bigip.post.assert_not_called()
-        # assert MTU has been corrected
-        mock_bigip.patch.assert_called_with(
-                path=f"/mgmt/tm/net/vlan/~Common~vlan-{mock_network.vlan_id}",
-                json=expected_vlan)
-        mock_bigip.delete.assert_not_called()
-
-
-    def test_EnsureVLAN_iSeries_new_vlan(self):
+    def test_EnsureHostVLAN_iSeries_new_vlan(self):
         mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
         mock_network = f5_network_models.Network(
                 id='test-network-id',
@@ -133,7 +99,7 @@ class TestF5Tasks(base.TestCase):
             'syncacheThreshold': 32000,
         }
 
-        engines.run(f5_tasks_iseries.EnsureVLAN(), store={
+        engines.run(f5_tasks_iseries.EnsureHostVLAN(), store={
             'bigip': mock_bigip,
             'network': mock_network,
             'existing_vlan': existing_vlan
@@ -147,7 +113,8 @@ class TestF5Tasks(base.TestCase):
         mock_bigip.delete.assert_not_called()
 
 
-    def test_revert_EnsureVLAN_iSeries(self):
+    def test_revert_EnsureHostVLAN_iSeries(self):
+        """VLAN didn't exist before and thus is deleted during revert"""
         vlan_id = 1234
         mock_network = f5_network_models.Network(
                 id='test-network-id',
@@ -160,7 +127,7 @@ class TestF5Tasks(base.TestCase):
             pass
         mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
         mock_bigip.post.side_effect = TestException(
-            "Test exception to trigger rollback of EnsureVLAN")
+            "Test exception to trigger rollback of EnsureHostVLAN")
 
         store = {
                 'bigip': mock_bigip,
@@ -168,41 +135,13 @@ class TestF5Tasks(base.TestCase):
                 'existing_vlan': None,
                 }
         self.assertRaises(TestException, engines.run,
-                f5_tasks_iseries.EnsureVLAN(), store=store)
+                f5_tasks_iseries.EnsureHostVLAN(), store=store)
         mock_bigip.post.assert_called()
         mock_bigip.delete.assert_called_with(
                 path=f"/mgmt/tm/net/vlan/~Common~vlan-{vlan_id}")
 
 
-    def test_revert_EnsureVLAN_iSeries_nop(self):
-        mock_network = f5_network_models.Network(
-                id='test-network-id',
-                name='test-network-name',
-                mtu=9000,
-                segments=[{'provider:physical_network': 'physnet',
-                    'provider:segmentation_id': 1234}]
-                )
-        class TestException(Exception):
-            pass
-        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
-        # since we pass something for existing_vlan, POST won't be called, but PATCH
-        mock_bigip.patch.side_effect = TestException(
-            "Test exception to trigger rollback of EnsureVLAN")
-
-        store = {
-                'bigip': mock_bigip,
-                'network': mock_network,
-                'existing_vlan': {'something':None},
-                }
-        self.assertRaises(TestException, engines.run,
-                f5_tasks_iseries.EnsureVLAN(), store=store)
-        mock_bigip.post.assert_not_called()
-        mock_bigip.patch.assert_called()
-        # since VLAN alread existed beforehand, revert must not delete it
-        mock_bigip.delete.assert_not_called()
-
-
-    def test_EnsureVLAN_rSeries_existing(self):
+    def test_EnsureHostVLAN_rSeries_existing(self):
         mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
         mock_network = f5_network_models.Network(
                 id='test-network-id',
@@ -212,10 +151,11 @@ class TestF5Tasks(base.TestCase):
                     'provider:segmentation_id': 1234}]
                 )
 
-        # existing VLAN (content doesn't matter)
+        # existing VLAN (with different content than is wanted, to make sure
+        # EnsureHostVLAN doesn't patch)
         existing_vlan = {'name': f'vlan-{mock_network.vlan_id}'}
 
-        engines.run(f5_tasks_rseries.EnsureVLAN(), store={
+        engines.run(f5_tasks_rseries.EnsureHostVLAN(), store={
             'bigip': mock_bigip,
             'network': mock_network,
             'existing_vlan': existing_vlan
@@ -225,7 +165,7 @@ class TestF5Tasks(base.TestCase):
         mock_bigip.delete.assert_not_called()
 
 
-    def test_EnsureVLAN_rSeries_new_vlan(self):
+    def test_EnsureHostVLAN_rSeries_new_vlan(self):
         mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
         vlan_id = 1234
         mock_network = f5_network_models.Network(
@@ -246,7 +186,7 @@ class TestF5Tasks(base.TestCase):
                 }
             }]}
 
-        engines.run(f5_tasks_rseries.EnsureVLAN(), store={
+        engines.run(f5_tasks_rseries.EnsureHostVLAN(), store={
             'bigip': mock_bigip,
             'network': mock_network,
             'existing_vlan': existing_vlan
@@ -259,7 +199,8 @@ class TestF5Tasks(base.TestCase):
         mock_bigip.delete.assert_not_called()
 
 
-    def test_revert_EnsureVLAN_rSeries(self):
+    def test_revert_EnsureHostVLAN_rSeries(self):
+        """VLAN existed before and thus is not deleted during revert"""
         vlan_id = 1234
         mock_network = f5_network_models.Network(
                 id='test-network-id',
@@ -272,7 +213,7 @@ class TestF5Tasks(base.TestCase):
             pass
         mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
         mock_bigip.put.side_effect = TestException(
-            "Test exception to trigger rollback of EnsureVLAN")
+            "Test exception to trigger rollback of EnsureHostVLAN")
 
         store = {
                 'bigip': mock_bigip,
@@ -280,11 +221,175 @@ class TestF5Tasks(base.TestCase):
                 'existing_vlan': None,
                 }
         self.assertRaises(TestException, engines.run,
-                f5_tasks_rseries.EnsureVLAN(), store=store)
+                f5_tasks_rseries.EnsureHostVLAN(), store=store)
         mock_bigip.post.assert_not_called()
         mock_bigip.put.assert_called()
         mock_bigip.delete.assert_called_with(
                 path=f"/api/data/openconfig-vlan:vlans/vlan={vlan_id}")
+
+
+    def test_EnsureGuestVLAN_iSeries_existing_and_correct(self):
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_network = f5_network_models.Network(
+                id='test-network-id',
+                name='test-network-name',
+                mtu=9000,
+                segments=[{'provider:physical_network': 'physnet',
+                    'provider:segmentation_id': 1234}]
+                )
+
+        # existing VLAN which is correct
+        existing_vlan = {
+            'name': f'vlan-{mock_network.vlan_id}',
+            'tag': mock_network.vlan_id,
+            'mtu': mock_network.mtu,
+            'hardwareSyncookie': 'disabled',
+            'synFloodRateLimit': 2000,
+            'syncacheThreshold': 32000,
+        }
+
+        engines.run(f5_tasks_iseries.EnsureGuestVLAN(), store={
+            'bigip': mock_bigip,
+            'network': mock_network,
+            'existing_vlan': existing_vlan
+            })
+        mock_bigip.post.assert_not_called()
+        mock_bigip.patch.assert_not_called()
+        mock_bigip.delete.assert_not_called()
+
+
+    def test_EnsureGuestVLAN_iSeries_existing_and_needs_patching(self):
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_network = f5_network_models.Network(
+                id='test-network-id',
+                name='test-network-name',
+                mtu=9000,
+                segments=[{'provider:physical_network': 'physnet',
+                    'provider:segmentation_id': 1234}]
+                )
+
+        # existing VLAN which is correct
+        existing_vlan = {
+            'name': f'vlan-{mock_network.vlan_id}',
+            'tag': mock_network.vlan_id,
+            # existing VLAN differs from wanted VLAN, thus needs patching
+            'mtu': mock_network.mtu + 1,
+            'hardwareSyncookie': 'disabled',
+            'synFloodRateLimit': 2000,
+            'syncacheThreshold': 32000,
+        }
+
+        engines.run(f5_tasks_iseries.EnsureGuestVLAN(), store={
+            'bigip': mock_bigip,
+            'network': mock_network,
+            'existing_vlan': existing_vlan
+            })
+        mock_bigip.post.assert_not_called()
+        mock_bigip.patch.assert_called_with(
+                path='/mgmt/tm/net/vlan',
+                json=expected_vlan)
+        mock_bigip.delete.assert_not_called()
+
+
+    def test_EnsureGuestVLAN_iSeries_new_vlan(self):
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_network = f5_network_models.Network(
+                id='test-network-id',
+                name='test-network-name',
+                mtu=9000,
+                segments=[{'provider:physical_network': 'physnet',
+                    'provider:segmentation_id': 1234}]
+                )
+
+        # no VLAN exists yet
+        existing_vlan = None
+        expected_vlan = {
+            'name': f'vlan-{mock_network.vlan_id}',
+            'tag': mock_network.vlan_id,
+            'mtu': mock_network.mtu,
+            'hardwareSyncookie': 'disabled',
+            'synFloodRateLimit': 2000,
+            'syncacheThreshold': 32000,
+        }
+
+        engines.run(f5_tasks_iseries.EnsureGuestVLAN(), store={
+            'bigip': mock_bigip,
+            'network': mock_network,
+            'existing_vlan': existing_vlan
+            })
+        # assert VLAN isn't being created on guest
+        mock_bigip.post.assert_not_called()
+        mock_bigip.patch.assert_not_called()
+        mock_bigip.delete.assert_not_called()
+
+
+    def test_revert_EnsureGuestVLAN_iSeries(self):
+        """VLAN was different before and thus is unpatched during revert"""
+        vlan_id = 1234
+        mock_network = f5_network_models.Network(
+                id='test-network-id',
+                name='test-network-name',
+                mtu=9000,
+                segments=[{'provider:physical_network': 'physnet',
+                    'provider:segmentation_id': vlan_id}]
+                )
+        class TestException(Exception):
+            pass
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip.post.side_effect = TestException(
+            "Test exception to trigger rollback of EnsureGuestVLAN")
+
+        # VLAN as it existed before execute()
+        existing_vlan = {'something':None}
+        store = {
+                'bigip': mock_bigip,
+                'network': mock_network,
+                'existing_vlan': existing_vlan,
+                }
+        self.assertRaises(TestException, engines.run,
+                f5_tasks_iseries.EnsureGuestVLAN(), store=store)
+        mock_bigip.post.assert_not_called()
+        mock_bigip.patch.assert_called_with(
+                path='/mgmt/tm/net/vlan',
+                json=existing_vlan)
+        mock_bigip.delete.assert_not_called()
+
+
+    def test_revert_EnsureGuestVLAN_iSeries_nop(self):
+        """VLAN was not different before and thus is untouched by revert"""
+        vlan_id = 1234
+        mock_network = f5_network_models.Network(
+                id='test-network-id',
+                name='test-network-name',
+                mtu=9000,
+                segments=[{'provider:physical_network': 'physnet',
+                    'provider:segmentation_id': vlan_id}]
+                )
+        class TestException(Exception):
+            pass
+        mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
+        mock_bigip.post.side_effect = TestException(
+            "Test exception to trigger rollback of EnsureGuestVLAN")
+
+        # VLAN as it (correctly) existed before execute()
+        existing_vlan = {
+            'name': f'vlan-{mock_network.vlan_id}',
+            'tag': mock_network.vlan_id,
+            'mtu': mock_network.mtu,
+            'hardwareSyncookie': 'disabled',
+            'synFloodRateLimit': 2000,
+            'syncacheThreshold': 32000,
+        }
+        store = {
+                'bigip': mock_bigip,
+                'network': mock_network,
+                'existing_vlan': existing_vlan,
+                }
+        self.assertRaises(TestException, engines.run,
+                f5_tasks_iseries.EnsureGuestVLAN(), store=store)
+        mock_bigip.post.assert_not_called()
+        mock_bigip.patch.assert_not_called()
+        mock_bigip.delete.assert_not_called()
 
 
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"

--- a/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
+++ b/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
@@ -642,3 +642,47 @@ class TestL2SyncManager(base.TestCase):
                       json={'name': 'vlan-1234', 'vlans': ['/Common/vlan-1234'], 'id': '1234'}),
         ]
         mock_bigip_2.post.assert_has_calls(bigip_2_post_calls, any_order=True)
+
+    @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
+                "L2SyncManager._do_ensure_l2_host_flow")
+    @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
+                "L2SyncManager._do_ensure_l2_guest_flow")
+    @mock.patch('octavia_f5.network.drivers.noop_driver_f5.driver.'
+                'NoopNetworkDriverF5.get_network')
+    def test_ensure_l2_flow_hosts_before_guests(self, mock_get_network,
+                                                mock_l2_guest_flow, mock_l2_host_flow):
+        """Ensure VCMP host flows finish before guest flows start."""
+        import time
+        host_times = []
+        guest_times = []
+
+        def host_side_effect(store):
+            # simulate some work
+            time.sleep(0.05)
+            host_times.append(time.time())
+
+        def guest_side_effect(data):
+            guest_times.append(time.time())
+
+        mock_l2_host_flow.side_effect = host_side_effect
+        mock_l2_guest_flow.side_effect = guest_side_effect
+
+        mocked_selfips = [
+            network_models.Port(
+                name=f"local-{MOCK_BIGIP_HOSTNAME}_0-{MOCK_FIXED_IP.subnet_id}",
+                fixed_ips=[MOCK_FIXED_IP]
+            ),
+            network_models.Port(
+                name=f"local-{MOCK_BIGIP_HOSTNAME}_1-{MOCK_FIXED_IP.subnet_id}",
+                fixed_ips=[MOCK_FIXED_IP]
+            ),
+        ]
+
+        self.manager.ensure_l2_flow(mocked_selfips, 'test-network-id')
+
+        # expect host flows called for both vcmps
+        self.assertEqual(mock_l2_host_flow.call_count, 2)
+        self.assertTrue(len(guest_times) >= 1)
+        self.assertTrue(len(host_times) >= 2)
+        # assert that the latest host completion time is before the guest start time
+        self.assertLess(max(host_times), min(guest_times))

--- a/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
+++ b/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
@@ -80,13 +80,13 @@ class TestL2SyncManager(base.TestCase):
         super().setUp()
 
     @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
-                "L2SyncManager._do_ensure_vcmp_l2_flow")
+                "L2SyncManager._do_ensure_l2_host_flow")
     @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
-                "L2SyncManager._do_ensure_l2_flow")
+                "L2SyncManager._do_ensure_l2_guest_flow")
     @mock.patch('octavia_f5.network.drivers.noop_driver_f5.driver.'
                 'NoopNetworkDriverF5.get_network')
     def test_ensure_l2_flow_all_available(self, mock_get_network,
-                                          mock_l2_flow, mock_vcmp_l2_flow):
+                                          mock_l2_guest_flow, mock_l2_host_flow):
         mocked_selfips = [
             network_models.Port(
                 name=f"local-{MOCK_BIGIP_HOSTNAME}_0-{MOCK_FIXED_IP.subnet_id}",
@@ -100,7 +100,7 @@ class TestL2SyncManager(base.TestCase):
                 name=f"local-OTHER_HOST-{uuidutils.generate_uuid()}")
         ]
         self.manager.ensure_l2_flow(mocked_selfips, 'test-network-id')
-        mock_l2_flow.assert_called_once_with(data=[
+        mock_l2_guest_flow.assert_called_once_with(data=[
             {
                 'selfips': [mocked_selfips[0]],
                 'store': {'bigip': self.manager._bigips[0],
@@ -113,23 +113,23 @@ class TestL2SyncManager(base.TestCase):
                           'network': mock_get_network.return_value,
                           'subnet_id': MOCK_FIXED_IP.subnet_id}
             }])
-        self.assertEqual(mock_vcmp_l2_flow.call_count, 2)
+        self.assertEqual(mock_l2_host_flow.call_count, 2)
         vcmp_l2_flow_calls = [
             mock.call(store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
                              'bigip_guest_names': [MOCK_BIGIP_HOSTNAME + "_0", MOCK_BIGIP_HOSTNAME + "_1"]}),
             mock.call(store={'bigip': self.manager._vcmps[1], 'network': mock_get_network.return_value,
                              'bigip_guest_names': [MOCK_BIGIP_HOSTNAME + "_0", MOCK_BIGIP_HOSTNAME + "_1"]})
         ]
-        mock_vcmp_l2_flow.assert_has_calls(vcmp_l2_flow_calls, any_order=True)
+        mock_l2_host_flow.assert_has_calls(vcmp_l2_flow_calls, any_order=True)
 
     @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
-                "L2SyncManager._do_ensure_vcmp_l2_flow")
+                "L2SyncManager._do_ensure_l2_host_flow")
     @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
-                "L2SyncManager._do_ensure_l2_flow")
+                "L2SyncManager._do_ensure_l2_guest_flow")
     @mock.patch('octavia_f5.network.drivers.noop_driver_f5.driver.'
                 'NoopNetworkDriverF5.get_network')
     def test_ensure_l2_flow_second_unavailable(self, mock_get_network,
-                                               mock_l2_flow, mock_vcmp_l2_flow):
+                                               mock_l2_guest_flow, mock_l2_host_flow):
         mocked_selfips = [
             network_models.Port(
                 name=f"local-{MOCK_BIGIP_HOSTNAME}_0-{MOCK_FIXED_IP.subnet_id}",
@@ -146,30 +146,30 @@ class TestL2SyncManager(base.TestCase):
         self.manager.ensure_l2_flow(mocked_selfips, 'test-network-id')
         self.manager._bigips[1].is_available.assert_called_once_with(timeout=5)
         # expect only one call for BigIP, only for available device
-        mock_l2_flow.assert_called_once_with(data=[
+        mock_l2_guest_flow.assert_called_once_with(data=[
             {
                 'selfips': [mocked_selfips[0]],
                 'store': {'bigip': self.manager._bigips[0],
                           'network': mock_get_network.return_value,
                           'subnet_id': MOCK_FIXED_IP.subnet_id}
             }])
-        self.assertEqual(mock_vcmp_l2_flow.call_count, 2)
+        self.assertEqual(mock_l2_host_flow.call_count, 2)
         vcmp_l2_flow_calls = [
             mock.call(store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
                              'bigip_guest_names': [MOCK_BIGIP_HOSTNAME + "_0", MOCK_BIGIP_HOSTNAME + "_1"]}),
             mock.call(store={'bigip': self.manager._vcmps[1], 'network': mock_get_network.return_value,
                              'bigip_guest_names': [MOCK_BIGIP_HOSTNAME + "_0", MOCK_BIGIP_HOSTNAME + "_1"]})
         ]
-        mock_vcmp_l2_flow.assert_has_calls(vcmp_l2_flow_calls, any_order=True)
+        mock_l2_host_flow.assert_has_calls(vcmp_l2_flow_calls, any_order=True)
 
     @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
-                "L2SyncManager._do_ensure_vcmp_l2_flow")
+                "L2SyncManager._do_ensure_l2_host_flow")
     @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
-                "L2SyncManager._do_ensure_l2_flow")
+                "L2SyncManager._do_ensure_l2_guest_flow")
     @mock.patch('octavia_f5.network.drivers.noop_driver_f5.driver.'
                 'NoopNetworkDriverF5.get_network')
     def test_ensure_l2_flow_override_host(self, mock_get_network,
-                                          mock_l2_flow, mock_vcmp_l2_flow):
+                                          mock_l2_guest_flow, mock_l2_host_flow):
         conf = self.useFixture(oslo_fixture.Config(cfg.CONF))
         conf.config(group='networking',
                     override_vcmp_guest_names=['test-host-2'])
@@ -186,7 +186,7 @@ class TestL2SyncManager(base.TestCase):
                 name=f"local-OTHER_HOST-{uuidutils.generate_uuid()}")
         ]
         self.manager.ensure_l2_flow(mocked_selfips, 'test-network-id')
-        mock_l2_flow.assert_called_once_with(data=[
+        mock_l2_guest_flow.assert_called_once_with(data=[
             {
                 'selfips': [mocked_selfips[0]],
                 'store': {'bigip': self.manager._bigips[0],
@@ -199,23 +199,23 @@ class TestL2SyncManager(base.TestCase):
                           'network': mock_get_network.return_value,
                           'subnet_id': MOCK_FIXED_IP.subnet_id}
             }])
-        self.assertEqual(mock_vcmp_l2_flow.call_count, 2)
+        self.assertEqual(mock_l2_host_flow.call_count, 2)
         vcmp_l2_flow_calls = [
             mock.call(store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
                              'bigip_guest_names': ['test-host-2']}),
             mock.call(store={'bigip': self.manager._vcmps[1], 'network': mock_get_network.return_value,
                              'bigip_guest_names': ['test-host-2']})
         ]
-        mock_vcmp_l2_flow.assert_has_calls(vcmp_l2_flow_calls, any_order=True)
+        mock_l2_host_flow.assert_has_calls(vcmp_l2_flow_calls, any_order=True)
 
     @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
-                "L2SyncManager._do_ensure_vcmp_l2_flow", side_effect=Exception('Boom!'))
+                "L2SyncManager._do_ensure_l2_host_flow", side_effect=Exception('Boom!'))
     @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
-                "L2SyncManager._do_ensure_l2_flow")
+                "L2SyncManager._do_ensure_l2_guest_flow")
     @mock.patch('octavia_f5.network.drivers.noop_driver_f5.driver.'
                 'NoopNetworkDriverF5.get_network')
     def test_ensure_l2_flow_exception(self, mock_get_network,
-                                      mock_l2_flow, mock_vcmp_l2_flow):
+                                      mock_l2_guest_flow, mock_l2_host_flow):
         mocked_selfips = [
             network_models.Port(
                 name=f"local-{MOCK_BIGIP_HOSTNAME}_0-{MOCK_FIXED_IP.subnet_id}",
@@ -232,7 +232,7 @@ class TestL2SyncManager(base.TestCase):
             self.assertEqual("Failed ensure_l2_flow for all vcmp devices of network_id=test-network-id",
                              e.args[0])
 
-        mock_l2_flow.assert_called_once_with(data=[
+        mock_l2_guest_flow.assert_called_once_with(data=[
             {
                 'selfips': [mocked_selfips[0]],
                 'store': {'bigip': self.manager._bigips[0],
@@ -245,18 +245,18 @@ class TestL2SyncManager(base.TestCase):
                           'network': mock_get_network.return_value,
                           'subnet_id': MOCK_FIXED_IP.subnet_id}
             }])
-        self.assertEqual(mock_vcmp_l2_flow.call_count, 2)
+        self.assertEqual(mock_l2_host_flow.call_count, 2)
         vcmp_l2_flow_calls = [
             mock.call(store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
                              'bigip_guest_names': [MOCK_BIGIP_HOSTNAME + "_0", MOCK_BIGIP_HOSTNAME + "_1"]}),
             mock.call(store={'bigip': self.manager._vcmps[1], 'network': mock_get_network.return_value,
                              'bigip_guest_names': [MOCK_BIGIP_HOSTNAME + "_0", MOCK_BIGIP_HOSTNAME + "_1"]})
         ]
-        mock_vcmp_l2_flow.assert_has_calls(vcmp_l2_flow_calls, any_order=True)
+        mock_l2_host_flow.assert_has_calls(vcmp_l2_flow_calls, any_order=True)
 
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")
-    def test__do_ensure_l2_flow_nothing_exist_no_errors(self, mock_get_subnet):
+    def test__do_ensure_l2_guest_flow_nothing_exist_no_errors(self, mock_get_subnet):
         mock_get_subnet.return_value = network_models.Subnet(
             id='test-subnet-id-1', gateway_ip='1.2.3.1',
             cidr='1.2.3.0/24', network_id='test-network-id')
@@ -298,7 +298,7 @@ class TestL2SyncManager(base.TestCase):
                 }
             }
         ]
-        self.manager._do_ensure_l2_flow(data=data)
+        self.manager._do_ensure_l2_guest_flow(data=data)
         # check that both devices were called and REVERT tasks were not called
         self.assertEqual(mock_bigips[0].get.call_count, 9)
         self.assertEqual(mock_bigips[1].get.call_count, 9)
@@ -328,7 +328,7 @@ class TestL2SyncManager(base.TestCase):
 
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")
-    def test__do_ensure_l2_flow_nothing_exist_route_domain_failed_on_second_device(
+    def test__do_ensure_l2_guest_flow_nothing_exist_route_domain_failed_on_second_device(
             self, mock_get_subnet):
         mock_get_subnet.return_value = network_models.Subnet(
             id='test-subnet-id', gateway_ip='1.2.3.1',
@@ -388,7 +388,7 @@ class TestL2SyncManager(base.TestCase):
                 }
             }
         ]
-        self.assertRaises(Exception, self.manager._do_ensure_l2_flow, data=data)
+        self.assertRaises(Exception, self.manager._do_ensure_l2_guest_flow, data=data)
         # check that both devices were called and REVERT tasks were also called
         self.assertEqual(mock_bigip_1.get.call_count, 10)
         self.assertEqual(mock_bigip_2.get.call_count, 7)
@@ -414,15 +414,16 @@ class TestL2SyncManager(base.TestCase):
         mock_bigip_2.delete.assert_has_calls(bigip_2_delete_calls, any_order=True)
 
     @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
-                "L2SyncManager._do_remove_vcmp_l2_flow")
+                "L2SyncManager._do_remove_l2_host_flow")
     @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
                 "L2SyncManager._do_remove_l2_flow")
     @mock.patch('octavia_f5.network.drivers.noop_driver_f5.driver.'
                 'NoopNetworkDriverF5.get_network')
     def test_remove_l2_flow_all_available(self, mock_get_network,
-                                          mock_l2_flow, mock_vcmp_l2_flow):
+                                                mock_remove_l2_flow,
+                                                mock_remove_l2_host_flow):
         self.manager.remove_l2_flow('test-network-id')
-        mock_l2_flow.assert_called_once_with(data=[
+        mock_remove_l2_flow.assert_called_once_with(data=[
             {
                 'store': {'bigip': self.manager._bigips[0],
                           'network': mock_get_network.return_value}
@@ -431,40 +432,41 @@ class TestL2SyncManager(base.TestCase):
                 'store': {'bigip': self.manager._bigips[1],
                           'network': mock_get_network.return_value}
             }])
-        self.assertEqual(mock_vcmp_l2_flow.call_count, 2)
+        self.assertEqual(mock_remove_l2_host_flow.call_count, 2)
         vcmp_l2_flow_calls = [
             mock.call(store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
                       'bigip_guest_names': [MOCK_BIGIP_HOSTNAME + "_0", MOCK_BIGIP_HOSTNAME + "_1"]}),
             mock.call(store={'bigip': self.manager._vcmps[1], 'network': mock_get_network.return_value,
                       'bigip_guest_names': [MOCK_BIGIP_HOSTNAME + "_0", MOCK_BIGIP_HOSTNAME + "_1"]})
         ]
-        mock_vcmp_l2_flow.assert_has_calls(vcmp_l2_flow_calls, any_order=True)
+        mock_remove_l2_host_flow.assert_has_calls(vcmp_l2_flow_calls, any_order=True)
 
     @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
-                "L2SyncManager._do_remove_vcmp_l2_flow")
+                "L2SyncManager._do_remove_l2_host_flow")
     @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
                 "L2SyncManager._do_remove_l2_flow")
     @mock.patch('octavia_f5.network.drivers.noop_driver_f5.driver.'
                 'NoopNetworkDriverF5.get_network')
     def test_remove_l2_flow_second_unavailable(self, mock_get_network,
-                                               mock_l2_flow, mock_vcmp_l2_flow):
+                                                     mock_remove_l2_flow,
+                                                     mock_remove_l2_host_flow):
         self.manager._bigips[1].is_available.side_effect = [False]
         self.manager.remove_l2_flow('test-network-id')
         self.manager._bigips[1].is_available.assert_called_once_with(timeout=5)
         # expect only one call for BigIP, only for available device
-        mock_l2_flow.assert_called_once_with(data=[
+        mock_remove_l2_flow.assert_called_once_with(data=[
             {
                 'store': {'bigip': self.manager._bigips[0],
                           'network': mock_get_network.return_value}
             }])
-        self.assertEqual(mock_vcmp_l2_flow.call_count, 2)
+        self.assertEqual(mock_remove_l2_host_flow.call_count, 2)
         vcmp_l2_flow_calls = [
             mock.call(store={'bigip': self.manager._vcmps[0], 'network': mock_get_network.return_value,
                       'bigip_guest_names': [MOCK_BIGIP_HOSTNAME + "_0", MOCK_BIGIP_HOSTNAME + "_1"]}),
             mock.call(store={'bigip': self.manager._vcmps[1], 'network': mock_get_network.return_value,
                       'bigip_guest_names': [MOCK_BIGIP_HOSTNAME + "_0", MOCK_BIGIP_HOSTNAME + "_1"]})
         ]
-        mock_vcmp_l2_flow.assert_has_calls(vcmp_l2_flow_calls, any_order=True)
+        mock_remove_l2_host_flow.assert_has_calls(vcmp_l2_flow_calls, any_order=True)
 
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")


### PR DESCRIPTION
**THIS PR HAS BEEN SUPERSEEDED BY #343** 

- [x] Run host flows before guest flows
      This is to ensure VLAN is created on host before it's patched on the guest.
- [ ] Do not create VLAN on guest (only patch it to add the extra properties)
      VLANs on guest are auto-created by the host. VLAN creation on the guest should be completely removed, instead, on the guest we need to check if the VLAN already exists and if not, we need to wait for the host to create it, then we PATCH it with the custom settings
- [ ] Do not patch VLAN on host (relevant to iSeries hosts only)
      VLANs on iSeries host do not need patching with the extra properties, these settings are guest-only, ignored by the host