### PR TITLE
Remove Subnet and Default Routes only on active F5 device.

### DIFF
--- a/octavia_f5/controller/worker/flows/f5_flows_iseries.py
+++ b/octavia_f5/controller/worker/flows/f5_flows_iseries.py
@@ -156,10 +156,12 @@ class F5Flows(object):
             inject=store)
 
         remove_l2_flow = linear_flow.Flow(f'remove-l2-flow-{bigip_hostname}')
-        remove_l2_flow.add(remove_subnet_routes_subflow,
-                           remove_default_route_task,
-                           # SelfIPs must be deleted after routes, otherwise a route would be unreachable
-                           remove_selfips_subflow,
+        # SubnetRoute and DefaultRoute have to be removed only from active device.
+        if store["bigip"].is_active:
+            remove_l2_flow.add(remove_subnet_routes_subflow,
+                               remove_default_route_task)
+        # SelfIPs must be deleted after routes, otherwise a route would be unreachable
+        remove_l2_flow.add(remove_selfips_subflow,
                            get_existing_route_domain,
                            remove_route_domain_task,
                            get_existing_vlan,
@@ -231,8 +233,9 @@ class F5Flows(object):
 
         # make and return flow
         remove_selfips_and_subnet_routes_flow = linear_flow.Flow('remove-selfips-and-subnet-routes-flow')
-        remove_selfips_and_subnet_routes_flow.add(remove_subnet_routes_subflow,
-                                                  remove_selfips_subflow)
+        if store['bigip'].is_active:
+            remove_selfips_and_subnet_routes_flow.add(remove_subnet_routes_subflow)
+        remove_selfips_and_subnet_routes_flow.add(remove_selfips_subflow)
         return remove_selfips_and_subnet_routes_flow
 
     def make_ensure_selfips_and_subnet_routes_flow(self, needed_selfips, subnets_that_need_routes,

--- a/octavia_f5/controller/worker/l2_sync_manager.py
+++ b/octavia_f5/controller/worker/l2_sync_manager.py
@@ -21,7 +21,7 @@ import requests
 from oslo_config import cfg
 from oslo_log import log as logging
 from taskflow.listeners import logging as tf_logging
-from taskflow.patterns import unordered_flow
+from taskflow.patterns import unordered_flow, linear_flow
 
 from octavia.common import data_models as octavia_models
 from octavia.common.base_taskflow import BaseTaskFlowEngine
@@ -121,7 +121,11 @@ class L2SyncManager(BaseTaskFlowEngine):
             e.run()
 
     def _do_remove_l2_flow(self, data: list):
-        remove_l2_flow = unordered_flow.Flow('remove-l2-flow-from-all-devices')
+        # We have to use Linear Flow here because SubnetRoutes and DefaultRoute have to be removed first from the active
+        # device and after that SelfIPs can be removed from both devices, so we need the exact order one-by-one.
+        # This order is guaranteed by the order of data where we put the active device first every time.
+        remove_l2_flow = linear_flow.Flow('remove-l2-flow-from-all-devices')
+        data.sort(key=lambda e: e['store']['bigip'].is_active, reverse=True)
         for flow_data in data:
             # get existing SelfIPs and subnet routes
             e = self.taskflow_load(self._f5flows_guest.make_get_existing_selfips_and_subnet_routes_flow(),

--- a/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
+++ b/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
@@ -481,6 +481,10 @@ class TestL2SyncManager(base.TestCase):
         for i in range(0, 2):
             mock_bigip = mock.Mock(spec=as3restclient.AS3RestClient)
             mock_bigip.hostname = f'hostname-{i}'
+            if i == 0:
+                mock_bigip.is_active = True
+            else:
+                mock_bigip.is_active = False
             mock_bigip.get.side_effect = [
                 MockResponse({}, 404) for _ in range(9)]
             mock_bigips.append(mock_bigip)
@@ -504,7 +508,7 @@ class TestL2SyncManager(base.TestCase):
         self.manager._do_remove_l2_flow(data=data)
         # check that both devices were called and REVERT tasks were not called
         self.assertEqual(mock_bigips[0].get.call_count, 7)
-        self.assertEqual(mock_bigips[1].get.call_count, 7)
+        self.assertEqual(mock_bigips[1].get.call_count, 5)
         self.assertEqual(mock_bigips[0].post.call_count, 0)
         self.assertEqual(mock_bigips[1].post.call_count, 0)
         self.assertEqual(mock_bigips[0].delete.call_count, 0)
@@ -563,9 +567,8 @@ class TestL2SyncManager(base.TestCase):
         ]
         mock_bigip_2 = mock.Mock(spec=as3restclient.AS3RestClient)
         mock_bigip_2.hostname = 'hostname-2'
+        mock_bigip_2.is_active = False
         mock_bigip_2.get.side_effect = [
-            MockResponse({}, 404),
-            MockResponse({}, 404),
             # DefaultRoute
             MockResponse({}, 200),
             # RouteDomain
@@ -592,37 +595,35 @@ class TestL2SyncManager(base.TestCase):
             )
         ]
         mock_bigip_2.delete.side_effect = [
-            # DefaultRoute delete
-            MockResponse({}, 200),
             # RouteDomain delete
-            MockResponse({}, 200),
-            # VLAN delete
             MockResponse({}, 502, "something happened")
         ]
         data = [
             {
                 'store': {
                     'network': mock_network,
-                    'bigip': mock_bigip_1,
+                    'bigip': mock_bigip_2,
                     'subnet_id': 'test-subnet-id',
                 }
             },
             {
                 'store': {
                     'network': mock_network,
-                    'bigip': mock_bigip_2,
+                    'bigip': mock_bigip_1,
                     'subnet_id': 'test-subnet-id',
                 }
             }
         ]
         self.assertRaises(Exception, self.manager._do_remove_l2_flow, data=data)
+        print(mock_bigip_1.mock_calls)
+        print(mock_bigip_2.mock_calls)
         # check that both devices were called and REVERT tasks were not called
         self.assertEqual(mock_bigip_1.get.call_count, 5)
-        self.assertEqual(mock_bigip_2.get.call_count, 5)
+        self.assertEqual(mock_bigip_2.get.call_count, 3)
         self.assertEqual(mock_bigip_1.post.call_count, 2)
-        self.assertEqual(mock_bigip_2.post.call_count, 1)
+        self.assertEqual(mock_bigip_2.post.call_count, 0)
         self.assertEqual(mock_bigip_1.delete.call_count, 3)
-        self.assertEqual(mock_bigip_2.delete.call_count, 3)
+        self.assertEqual(mock_bigip_2.delete.call_count, 0)
         bigip_1_post_calls = [
             # check that VLAN reverted
             mock.call(path='/mgmt/tm/net/vlan',
@@ -634,9 +635,3 @@ class TestL2SyncManager(base.TestCase):
                       json={'name': 'vlan-1234', 'vlans': ['/Common/vlan-1234'], 'id': '1234'}),
         ]
         mock_bigip_1.post.assert_has_calls(bigip_1_post_calls, any_order=True)
-        bigip_2_post_calls = [
-            # check that RouteDomain reverted
-            mock.call(path='/mgmt/tm/net/route-domain',
-                      json={'name': 'vlan-1234', 'vlans': ['/Common/vlan-1234'], 'id': '1234'}),
-        ]
-        mock_bigip_2.post.assert_has_calls(bigip_2_post_calls, any_order=True)


### PR DESCRIPTION
This PR fixes the incorrect removal of SubnetRoute and DefaultRoute, which should be removed only from active F5 devices, not before any SelfIPs.

Flow before:
<img width="2690" height="1318" alt="image" src="https://github.com/user-attachments/assets/0e20d8b4-8189-4bdb-af14-186f6e646263" />

Flow after:
<img width="1314" height="1962" alt="image" src="https://github.com/user-attachments/assets/fcc427f5-297b-4ca7-9c0c-d78fed0f83aa" />
