### PR TITLE
Fix the ERROR status for the listener if certificate retrieval failed.

### DIFF
--- a/octavia_f5/restclient/as3objects/service.py
+++ b/octavia_f5/restclient/as3objects/service.py
@@ -17,7 +17,6 @@ from octavia_lib.common import constants as lib_consts
 from oslo_config import cfg
 from oslo_log import log as logging
 
-from octavia.common import exceptions
 from octavia_f5.common import constants as f5_const
 from octavia_f5.restclient import as3classes as as3, as3types
 from octavia_f5.restclient.as3objects import application as m_app
@@ -178,11 +177,8 @@ def get_service(listener, cert_manager, esd_repository, sg_rules):
 
         # Client Side Certificates
         if listener.client_ca_tls_certificate_id and listener.client_authentication != 'NONE':
-            try:
-                auth_name, secret = cert_manager.load_secret(project_id, listener.client_ca_tls_certificate_id)
-                entities.append((auth_name, m_cert.get_ca_bundle(secret, auth_name, auth_name)))
-            except exceptions.CertificateRetrievalException as e:
-                LOG.error("Error fetching certificate: %s", e)
+            auth_name, secret = cert_manager.load_secret(project_id, listener.client_ca_tls_certificate_id)
+            entities.append((auth_name, m_cert.get_ca_bundle(secret, auth_name, auth_name)))
 
         # TLS renegotiation has to be turned off for HTTP2, in order to be compliant.
         allow_renegotiation = not is_http2(listener)

--- a/octavia_f5/restclient/as3objects/tenant.py
+++ b/octavia_f5/restclient/as3objects/tenant.py
@@ -74,11 +74,14 @@ def get_tenant(segmentation_id, loadbalancers, self_ips, status_manager, cert_ma
                         # Error connecting to keystore, skip tenant update
                         raise e
 
-                    LOG.error("Could not retrieve certificate, assuming it is deleted, skipping "
+                    LOG.error("Could not retrieve certificate, assuming it is deleted, set ERROR status for "
                               "listener '%s': %s", listener.id, e)
                     if status_manager:
                         # Key / Container not found in keystore
                         status_manager.set_error(listener)
+                    else:
+                        LOG.debug(f"Status manager not set, impossible to set ERROR "
+                                  f"status for Listener '{listener.id}'")
 
         # Attach pools
         for pool in loadbalancer.pools:

--- a/octavia_f5/utils/cert_manager.py
+++ b/octavia_f5/utils/cert_manager.py
@@ -44,7 +44,8 @@ class CertManagerWrapper(object):
             octavia_exc.CertificateRetrievalException),
         wait=tenacity.wait_incrementing(
             RETRY_INITIAL_DELAY, RETRY_BACKOFF, RETRY_MAX),
-        stop=tenacity.stop_after_attempt(RETRY_ATTEMPTS))
+        stop=tenacity.stop_after_attempt(RETRY_ATTEMPTS),
+        reraise=True)
     def get_certificates(self, obj, context=None):
         """Fetches certificates and creates dict out of octavia objects
 
@@ -85,7 +86,8 @@ class CertManagerWrapper(object):
             octavia_exc.CertificateRetrievalException),
         wait=tenacity.wait_incrementing(
             RETRY_INITIAL_DELAY, RETRY_BACKOFF, RETRY_MAX),
-        stop=tenacity.stop_after_attempt(RETRY_ATTEMPTS))
+        stop=tenacity.stop_after_attempt(RETRY_ATTEMPTS),
+        reraise=True)
     def load_secret(self, project_id, secret_ref):
         """Loads secrets from secret store
 


### PR DESCRIPTION
This PR fixes the ERROR status update for Listeners when the Certificate is removed from Barbican or cannot be retrieved.