### PR TITLE
Fix vlan creation RC

### DIFF
--- a/octavia_f5/controller/worker/flows/f5_flows_iseries.py
+++ b/octavia_f5/controller/worker/flows/f5_flows_iseries.py
@@ -81,16 +81,12 @@ class F5Flows(object):
         ensure_default_route = self.tasks.EnsureDefaultRoute(
             name=f'ensure-default-route-{bigip_hostname}',
             inject=store)
-        get_existing_vlan = self.tasks.GetExistingVLAN(
-            name=f'get-existing-vlan-{bigip_hostname}',
-            inject=store)
-        ensure_vlan = self.tasks.EnsureVLAN(
-            name=f'ensure-vlan-{bigip_hostname}',
+        ensure_vlan = self.tasks.EnsureVLANGuest(
+            name=f'ensure-vlan-guest-{bigip_hostname}',
             inject=store)
 
         ensure_l2_flow = linear_flow.Flow(f'ensure-l2-flow-{bigip_hostname}')
-        ensure_l2_flow.add(get_existing_vlan,
-                           ensure_vlan,
+        ensure_l2_flow.add(ensure_vlan,
                            get_existing_route_domain,
                            ensure_route_domain,
                            # SelfIPs must be present for routes to work
@@ -303,7 +299,7 @@ class F5Flows(object):
 
     def make_ensure_vcmp_l2_flow(self) -> flow.Flow:
         get_existing_vlan = self.tasks.GetExistingVLAN()
-        ensure_vlan = self.tasks.EnsureVLAN()
+        ensure_vlan = self.tasks.EnsureVLANHost()
         ensure_vlan_interface = self.tasks.EnsureVLANInterface()
         ensure_vlan_guest_assignment = self.tasks.EnsureVLANGuestAssignment()
 

--- a/octavia_f5/controller/worker/l2_sync_manager.py
+++ b/octavia_f5/controller/worker/l2_sync_manager.py
@@ -188,7 +188,7 @@ class L2SyncManager(BaseTaskFlowEngine):
             e.run()
 
     def ensure_l2_flow(self, selfips: List[network_models.Port], network_id: str, device=None):
-        """ Runs the taskflows for ensuring correct l2 configuration on all bigip devices in parallel
+        """Runs the taskflows for ensuring correct l2 configuration on the hosts, then on the guests.
 
         :param selfips: Neutron SelfIP ports
         :param network_id: Neutron Network ID
@@ -203,60 +203,76 @@ class L2SyncManager(BaseTaskFlowEngine):
             raise exceptions.ProviderDriverException(
                 f"Failed ensure_l2_flow for network_id={network_id}: No segment bound")
 
-        # run l2 flow for all devices in parallel
-        fs = {}
-        ensure_l2_flow_data = []
-        for bigip in self._bigips:
-            if device and bigip.hostname != device:
-                continue
-
-            # skip unavailable devices
-            if not bigip.is_available(timeout=CONF.status_manager.failover_timeout):
-                LOG.warning(f"ensure_l2_flow: Skipping unavailable device {bigip.hostname}")
-                continue
-
-            selfips_for_host = [selfip for selfip in selfips if bigip.hostname in selfip.name]
-            subnet_ids = set(sip.fixed_ips[0].subnet_id for sip in selfips_for_host)
-            ensure_l2_flow_data.append({
-                'store': {'bigip': bigip, 'network': network, 'subnet_id': subnet_ids.pop()},
-                'selfips': selfips_for_host,
-            })
-        fs[self.executor.submit(
-            self._do_ensure_l2_flow,
-            data=ensure_l2_flow_data)] = self._bigips
-
         # run VCMP l2 flow for all VCMP hosts in parallel
-        for vcmp in self._vcmps:
-            store = {'bigip': vcmp, 'network': network}
+        host_fs = {}
+        for host in self._vcmps:
+            store = {'bigip': host, 'network': network}
             if CONF.networking.override_vcmp_guest_names:
                 store['bigip_guest_names'] = CONF.networking.override_vcmp_guest_names
             else:
                 store['bigip_guest_names'] = [bigip.hostname for bigip in self._bigips]
-            fs[self.executor.submit(self._do_ensure_vcmp_l2_flow, store=store)] = [vcmp]
+            host_fs[self.executor.submit(self._do_ensure_vcmp_l2_flow, store=store)] = host
 
-        # wait for all flows to finish
-        failed_bigips = []
-        done, not_done = futures.wait(fs, timeout=CONF.networking.l2_timeout)
+        # wait for host flows to finish
+        failed_vcmps = []
+        done, not_done = futures.wait(host_fs, timeout=CONF.networking.l2_timeout)
         for f in done | not_done:
-            bigips = fs[f]
+            vcmp = host_fs[f]
+            try:
+                f.result(0)
+            except Exception as e:
+                hostname = vcmp.hostname
+                self._metric_failed_futures.labels(hostname, 'ensure_l2_flow').inc()
+                failed_vcmps.append(hostname)
+                LOG.error(f"Failed running ensure_l2_flow for host {hostname}: {e}")
+
+        # raise error only if flows failed for both hosts
+        if self._vcmps and all(host in failed_vcmps for host in self._vcmps):
+            raise exceptions.ProviderDriverException(
+                f"Failed ensure_l2_flow for all hosts of network_id={network_id}")
+
+        # run l2 flow for all guests in parallel
+        guest_fs = {}
+        ensure_l2_flow_data = []
+        for guest in self._bigips:
+            if device and guest.hostname != device:
+                continue
+
+            # skip unavailable devices
+            if not guest.is_available(timeout=CONF.status_manager.failover_timeout):
+                LOG.warning(f"ensure_l2_flow: Skipping unavailable device {guest.hostname}")
+                continue
+
+            selfips_for_host = [selfip for selfip in selfips if guest.hostname in selfip.name]
+            subnet_ids = set(sip.fixed_ips[0].subnet_id for sip in selfips_for_host)
+            ensure_l2_flow_data.append({
+                'store': {'bigip': guest, 'network': network, 'subnet_id': subnet_ids.pop()},
+                'selfips': selfips_for_host,
+            })
+        guest_fs[self.executor.submit(
+            self._do_ensure_l2_flow,
+            data=ensure_l2_flow_data)] = self._bigips
+
+        # wait for all guest flows to finish
+        failed_bigips = []
+        done, not_done = futures.wait(guest_fs, timeout=CONF.networking.l2_timeout)
+        for f in done | not_done:
+            bigips = guest_fs[f]
             try:
                 f.result(0)
             except Exception as e:
                 hostnames = [bigip.hostname for bigip in bigips]
                 for hostname in hostnames:
-                    # consider both device flows as failed, since we don't know
-                    # which one the error originated in.
                     self._metric_failed_futures.labels(hostname, 'ensure_l2_flow').inc()
                     failed_bigips.append(hostname)
+                # consider both device flows as failed, since we don't know
+                # which one the error originated in.
                 LOG.error(f"Failed running ensure_l2_flow for hosts {', '.join(hostnames)}: {e}")
 
-        # raise error only if all pairs failed
-        if self._bigips and all(bigip in failed_bigips for bigip in self._bigips):
+        # raise error only if flows failed for both guests
+        if self._bigips and all(guest in failed_bigips for guest in self._bigips):
             raise exceptions.ProviderDriverException(
-                f"Failed ensure_l2_flow for all bigip devices of network_id={network_id}")
-        if self._vcmps and all(vcmp in failed_bigips for vcmp in self._vcmps):
-            raise exceptions.ProviderDriverException(
-                f"Failed ensure_l2_flow for all vcmp devices of network_id={network_id}")
+                f"Failed ensure_l2_flow for all guests of network_id={network_id}")
 
     def remove_l2_flow(self, network_id: str, device=None):
         """ Runs the taskflows for cleanup of l2 configuration on all bigip devices in parallel

--- a/octavia_f5/controller/worker/tasks/f5_tasks_iseries.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks_iseries.py
@@ -30,10 +30,10 @@ LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
 
 
-class EnsureVLAN(task.Task):
+class EnsureVLANHost(task.Task):
     default_provides = 'device_vlan'
 
-    """ Task to create or update VLAN if needed """
+    """ Task to create VLAN on the host, if needed """
 
     @decorators.RaisesIControlRestError()
     @tenacity.retry(
@@ -54,35 +54,68 @@ class EnsureVLAN(task.Task):
             'syncacheThreshold': CONF.networking.syncache_threshold
         }
 
-        # Create vlan if not existing
-        if existing_vlan is None:
-            res = bigip.post(path='/mgmt/tm/net/vlan', json=vlan)
-            res.raise_for_status()
-            return res.json()
+        # check whether VLAN already exists
+        if existing_vlan is not None:
+            return existing_vlan
 
-        # patch VLAN if it differs (<= is a subset operator here)
-        if not vlan.items() <= existing_vlan.items():
-            res = bigip.patch(path=f"/mgmt/tm/net/vlan/~Common~{vlan['name']}",
-                              json=vlan)
-            res.raise_for_status()
-            return res.json()
-
-        # No Changes needed
-        return existing_vlan
+        # create vlan
+        res = bigip.post(path='/mgmt/tm/net/vlan', json=vlan)
+        res.raise_for_status()
+        return res.json()
 
     @decorators.RaisesIControlRestError()
     def revert(self, network: f5_network_models.Network,
                bigip: bigip_restclient.BigIPRestClient,
                existing_vlan, *args, **kwargs):
         if existing_vlan is not None:
-            LOG.warning(f"Reverting EnsureVLAN: Not deleting VLAN, since it existed before "
+            LOG.warning(f"Reverting EnsureVLANHost: Not deleting VLAN, since it existed before "
                         f"the task was run: {existing_vlan}")
             return
         res = bigip.delete(path=f"/mgmt/tm/net/vlan/~Common~vlan-{network.vlan_id}")
         if not res.ok:
-            LOG.warning("Reverting EnsureVLAN: Failed removing VLAN on the device %s for "
+            LOG.warning("Reverting EnsureVLANHost: Failed removing VLAN on the device %s for "
                         "vlan_id=%s: %s", bigip.hostname, network.vlan_id, res.content)
             res.raise_for_status()
+
+
+class EnsureVLANGuest(task.Task):
+    default_provides = 'device_vlan'
+
+    """ Task to patch the VLAN on the guest, if needed """
+
+    @decorators.RaisesIControlRestError()
+    @tenacity.retry(
+        retry=tenacity.retry_if_exception_type(requests.HTTPError),
+        wait=tenacity.wait_fixed(2),
+        stop=tenacity.stop_after_attempt(3)
+    )
+    def execute(self,
+                bigip: bigip_restclient.BigIPRestClient,
+                network: f5_network_models.Network):
+        vlan = {
+            'name': f'vlan-{network.vlan_id}',
+            'tag': network.vlan_id,
+            'mtu': network.mtu,
+            'hardwareSyncookie': 'enabled' if CONF.networking.hardware_syncookie else 'disabled',
+            'synFloodRateLimit': CONF.networking.syn_flood_rate_limit,
+            'syncacheThreshold': CONF.networking.syncache_threshold
+        }
+
+        # check that VLAN has been auto-created by host
+        path = f"/mgmt/tm/net/vlan/~Common~{vlan['name']}?expandSubcollections=true"
+        device_response = bigip.get(path=path)
+        device_response.raise_for_status()
+        device_vlan = device_response.json()
+
+        # check whether VLAN is already complete ('<=' is a subset operator here)
+        if vlan.items() <= device_vlan.items():
+            return device_vlan
+
+        res = bigip.patch(path=f"/mgmt/tm/net/vlan/~Common~{vlan['name']}", json=vlan)
+        return res.json()
+
+    def revert(self, *args, **kwargs):
+        LOG.warning("Reverting EnsureVLANHost: Not unpatching VLAN")
 
 
 class EnsureVLANInterface(task.Task):
@@ -260,7 +293,8 @@ class GetExistingVLAN(task.Task):
 
     def execute(self, bigip: bigip_restclient.BigIPRestClient,
                 network: f5_network_models.Network):
-        device_response = bigip.get(path=f"/mgmt/tm/net/vlan/~Common~vlan-{network.vlan_id}?expandSubcollections=true")
+        vlan_name = f"vlan-{network.vlan_id}"
+        device_response = bigip.get(path=f"/mgmt/tm/net/vlan/~Common~{vlan_name}?expandSubcollections=true")
         if device_response.status_code == 404:
             return None
         return device_response.json()
@@ -567,7 +601,7 @@ class RemoveVLAN(task.Task):
     def execute(self, network: f5_network_models.Network,
                 bigip: bigip_restclient.BigIPRestClient,
                 existing_vlan: dict):
-        """ Task to delete VLAN """
+        """ Task to delete VLAN, if it exists """
         if existing_vlan is None:
             return
         res = bigip.delete(path=f"/mgmt/tm/net/vlan/~Common~vlan-{network.vlan_id}")

--- a/octavia_f5/controller/worker/tasks/f5_tasks_rseries.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks_rseries.py
@@ -77,15 +77,6 @@ class EnsureVLANHost(task.Task):
         res.raise_for_status()
 
 
-class EnsureVLANGuest(task.Task):
-    pass
-    # contrary to the EnsureVLANGuest task for iSeries devices, we don't need
-    # to patch the VLAN in this task, because it only contains the VLAN ID. In
-    # fact, comparing the existing_vlan dictionary with the payload would be
-    # misleading, since existing_vlan may also include the "members" key, which
-    # can change pretty much arbitrarily.
-
-
 class GetExistingVLAN(task.Task):
     default_provides = 'existing_vlan'
 

--- a/octavia_f5/controller/worker/tasks/f5_tasks_rseries.py
+++ b/octavia_f5/controller/worker/tasks/f5_tasks_rseries.py
@@ -29,7 +29,7 @@ LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
 
 
-class EnsureVLAN(task.Task):
+class EnsureVLANHost(task.Task):
 
     """ Task to create or update VLAN if needed """
 
@@ -57,11 +57,6 @@ class EnsureVLAN(task.Task):
         if existing_vlan:
             return existing_vlan
 
-        # contrary to the EnsureVLAN task for iSeries devices, we don't need to patch the VLAN in this task,
-        # because it only contains the VLAN ID. In fact, comparing the existing_vlan dictionary with the payload
-        # would be misleading, since existing_vlan may also include the "members" key, which can change pretty
-        # much arbitrarily.
-
         # create missing VLAN
         res = bigip.put(path=f"/api/data/openconfig-vlan:vlans/vlan={vlan_id}", json=payload)
         res.raise_for_status()
@@ -72,14 +67,23 @@ class EnsureVLAN(task.Task):
                existing_vlan, *args, **kwargs):
         vlan_id = network.vlan_id
         if existing_vlan is not None:
-            LOG.warning(f"EnsureVLAN revert: Not deleting VLAN {vlan_id}, since it existed before "
-                        f"the task was run: {existing_vlan}")
+            LOG.warning(f"EnsureVLANHost revert: Not deleting VLAN {vlan_id}, "
+                        f"since it existed before the task was run: {existing_vlan}")
             return
         res = bigip.delete(path=f"/api/data/openconfig-vlan:vlans/vlan={vlan_id}")
         if not res.ok:
-            LOG.warning("EnsureVLAN revert: Failed removing VLAN on the device %s for "
+            LOG.warning("EnsureVLANHost revert: Failed removing VLAN on the device %s for "
                         "vlan_id=%s: %s", bigip.hostname, vlan_id, res.content)
         res.raise_for_status()
+
+
+class EnsureVLANGuest(task.Task):
+    pass
+    # contrary to the EnsureVLANGuest task for iSeries devices, we don't need
+    # to patch the VLAN in this task, because it only contains the VLAN ID. In
+    # fact, comparing the existing_vlan dictionary with the payload would be
+    # misleading, since existing_vlan may also include the "members" key, which
+    # can change pretty much arbitrarily.
 
 
 class GetExistingVLAN(task.Task):

--- a/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
+++ b/octavia_f5/tests/unit/controller/worker/flows/test_f5_flows.py
@@ -101,11 +101,13 @@ class TestF5Flows(base.TestCase):
         engines.run(ensure_l2_flow, store=store)
 
         # check that VLAN, RD, SelfIP, and default route have been created
-        calls = [
+        patch_calls = [
             mock.call(json={'name': 'vlan-1234', 'tag': 1234,
                             'mtu': 9000, 'hardwareSyncookie': 'enabled',
                             'synFloodRateLimit': 2000, 'syncacheThreshold': 32000},
-                      path='/mgmt/tm/net/vlan'),
+                      path='/mgmt/tm/net/vlan/~Common~vlan-1234')
+        ]
+        post_calls = [
             mock.call(json={'name': 'vlan-1234', 'id': 1234,
                             'vlans': ['/Common/vlan-1234']},
                       path='/mgmt/tm/net/route-domain'),
@@ -118,9 +120,10 @@ class TestF5Flows(base.TestCase):
                             'network': 'default%1234'},
                       path='/mgmt/tm/net/route')
         ]
-        mock_bigip.post.assert_has_calls(calls, any_order=True)
+        mock_bigip.patch.assert_has_calls(patch_calls)
+        # any_order to ignore the calls to raise_for_status() and json()
+        mock_bigip.post.assert_has_calls(post_calls, any_order=True)
         mock_bigip.get.assert_called()
-        mock_bigip.patch.assert_not_called()
 
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")

--- a/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
+++ b/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
@@ -635,3 +635,47 @@ class TestL2SyncManager(base.TestCase):
                       json={'name': 'vlan-1234', 'vlans': ['/Common/vlan-1234'], 'id': '1234'}),
         ]
         mock_bigip_1.post.assert_has_calls(bigip_1_post_calls, any_order=True)
+
+    @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
+                "L2SyncManager._do_ensure_vcmp_l2_flow")
+    @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
+                "L2SyncManager._do_ensure_l2_flow")
+    @mock.patch('octavia_f5.network.drivers.noop_driver_f5.driver.'
+                'NoopNetworkDriverF5.get_network')
+    def test_ensure_l2_flow_hosts_before_guests(self, mock_get_network,
+                                                mock_l2_guest_flow, mock_l2_host_flow):
+        """Ensure VCMP host flows finish before guest flows start."""
+        import time
+        host_times = []
+        guest_times = []
+
+        def host_side_effect(store):
+            # simulate some work
+            time.sleep(0.05)
+            host_times.append(time.time())
+
+        def guest_side_effect(data):
+            guest_times.append(time.time())
+
+        mock_l2_host_flow.side_effect = host_side_effect
+        mock_l2_guest_flow.side_effect = guest_side_effect
+
+        mocked_selfips = [
+            network_models.Port(
+                name=f"local-{MOCK_BIGIP_HOSTNAME}_0-{MOCK_FIXED_IP.subnet_id}",
+                fixed_ips=[MOCK_FIXED_IP]
+            ),
+            network_models.Port(
+                name=f"local-{MOCK_BIGIP_HOSTNAME}_1-{MOCK_FIXED_IP.subnet_id}",
+                fixed_ips=[MOCK_FIXED_IP]
+            ),
+        ]
+
+        self.manager.ensure_l2_flow(mocked_selfips, 'test-network-id')
+
+        # expect host flows called for both vcmps
+        self.assertEqual(mock_l2_host_flow.call_count, 2)
+        self.assertTrue(len(guest_times) >= 1)
+        self.assertTrue(len(host_times) >= 2)
+        # assert that the latest host completion time is before the guest start time
+        self.assertLess(max(host_times), min(guest_times))

--- a/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
+++ b/octavia_f5/tests/unit/controller/worker/test_l2_sync_manager.py
@@ -18,6 +18,7 @@ from oslo_config import cfg
 from oslo_config import fixture as oslo_fixture
 from oslo_log import log as logging
 from oslo_utils import uuidutils
+from taskflow.patterns import unordered_flow
 
 from octavia.tests.unit import base
 from octavia.network import data_models as network_models
@@ -254,6 +255,14 @@ class TestL2SyncManager(base.TestCase):
         ]
         mock_vcmp_l2_flow.assert_has_calls(vcmp_l2_flow_calls, any_order=True)
 
+    @mock.patch("octavia_f5.controller.worker.l2_sync_manager.L2SyncManager.taskflow_load")
+    def test__do_ensure_l2_flow__guest_flows_parallel(self, mock_taskflow_load):
+        """Check that both guest devices are provisioned in parallel."""
+        data = []  # no data needed, the flow can be empty
+        self.manager._do_ensure_l2_flow(data=data)
+        flow = mock_taskflow_load.call_args.args[0]
+        assert isinstance(flow, unordered_flow.Flow)
+
     @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
                 ".get_subnet")
     def test__do_ensure_l2_flow_nothing_exist_no_errors(self, mock_get_subnet):
@@ -302,8 +311,8 @@ class TestL2SyncManager(base.TestCase):
         # check that both devices were called and REVERT tasks were not called
         self.assertEqual(mock_bigips[0].get.call_count, 9)
         self.assertEqual(mock_bigips[1].get.call_count, 9)
-        self.assertEqual(mock_bigips[0].post.call_count, 5)
-        self.assertEqual(mock_bigips[1].post.call_count, 5)
+        self.assertEqual(mock_bigips[0].post.call_count, 4)
+        self.assertEqual(mock_bigips[1].post.call_count, 4)
         self.assertEqual(mock_bigips[0].delete.call_count, 0)
         self.assertEqual(mock_bigips[1].delete.call_count, 0)
         for i in range(0, 2):
@@ -325,93 +334,6 @@ class TestL2SyncManager(base.TestCase):
                 path='/mgmt/tm/net/route',
                 json={'name': 'net_test-network-id_sub_test-subnet-id-1',
                       'tmInterface': '/Common/vlan-1234', 'network': '1.2.3.0%1234/24'})
-
-    @mock.patch("octavia.network.drivers.noop_driver.driver.NoopManager"
-                ".get_subnet")
-    def test__do_ensure_l2_flow_nothing_exist_route_domain_failed_on_second_device(
-            self, mock_get_subnet):
-        mock_get_subnet.return_value = network_models.Subnet(
-            id='test-subnet-id', gateway_ip='1.2.3.1',
-            cidr='1.2.3.0/24', network_id='test-network-id')
-        mock_network = f5_network_models.Network(
-            mtu=8950, id='test-network-id', subnets=['test-subnet-id'],
-            segments=[{'provider:physical_network': 'physnet',
-                       'provider:segmentation_id': 1234}]
-        )
-        selfip_fixed_ip = network_models.FixedIP(
-            ip_address='1.2.3.2', subnet_id='test-subnet-id-2')
-        selfip_port = network_models.Port(
-            id='test-selfip-port-id', fixed_ips=[selfip_fixed_ip],
-        )
-        mock_bigip_1 = mock.Mock(spec=as3restclient.AS3RestClient)
-        mock_bigip_1.hostname = 'hostname-1'
-        mock_bigip_1.is_active = True
-        mock_bigip_1.get.side_effect = [
-            MockResponse({}, 404),
-            MockResponse({}, 404),
-            MockResponse({}, 404),
-            MockResponse({}, 404),
-            MockResponse({}, 404),
-            MockResponse({}, 404),
-            MockResponse({}, 404),
-            MockResponse({}, 404),
-            MockResponse({}, 404),
-            MockResponse({}, 200),
-        ]
-        mock_bigip_2 = mock.Mock(spec=as3restclient.AS3RestClient)
-        mock_bigip_2.hostname = 'hostname-2'
-        mock_bigip_2.get.side_effect = [
-            MockResponse({}, 404) for _ in range(8)]
-        mock_bigip_2.post.side_effect = [
-            # VLAN creation
-            MockResponse({}, 202),
-            # Route Domain creation
-            MockResponse({}, 502)
-        ]
-        data = [
-            {
-                'selfips': [selfip_port],
-                'store': {
-                    'network': mock_network,
-                    'bigip': mock_bigip_1,
-                    'subnet_id': 'test-subnet-id',
-                    'existing_selfips': []
-                }
-            },
-            {
-                'selfips': [selfip_port],
-                'store': {
-                    'network': mock_network,
-                    'bigip': mock_bigip_2,
-                    'subnet_id': 'test-subnet-id',
-                    'existing_selfips': []
-                }
-            }
-        ]
-        self.assertRaises(Exception, self.manager._do_ensure_l2_flow, data=data)
-        # check that both devices were called and REVERT tasks were also called
-        self.assertEqual(mock_bigip_1.get.call_count, 10)
-        self.assertEqual(mock_bigip_2.get.call_count, 7)
-        self.assertEqual(mock_bigip_1.post.call_count, 5)
-        self.assertEqual(mock_bigip_2.post.call_count, 2)
-        self.assertEqual(mock_bigip_1.delete.call_count, 4)
-        self.assertEqual(mock_bigip_2.delete.call_count, 1)
-        bigip_1_delete_calls = [
-            # check that VLAN reverted
-            mock.call(path='/mgmt/tm/net/vlan/~Common~vlan-1234'),
-            # check that Route Domain was reverted
-            mock.call(path='/mgmt/tm/net/route-domain/vlan-1234'),
-            # check that Self IP was reverted
-            mock.call(path='/mgmt/tm/net/self/port-test-selfip-port-id'),
-            # check that Subnet Route was reverted
-            mock.call(path='/mgmt/tm/net/route/~Common~net_test-network-id_sub_test-subnet-id')
-        ]
-        mock_bigip_1.delete.assert_has_calls(bigip_1_delete_calls, any_order=True)
-        bigip_2_delete_calls = [
-            # check that VLAN reverted
-            mock.call(path='/mgmt/tm/net/vlan/~Common~vlan-1234'),
-        ]
-        mock_bigip_2.delete.assert_has_calls(bigip_2_delete_calls, any_order=True)
 
     @mock.patch("octavia_f5.controller.worker.l2_sync_manager."
                 "L2SyncManager._do_remove_vcmp_l2_flow")


### PR DESCRIPTION
Supersedes #337 (since that PR was before #338).

- [x] Run host flows before guest flows
      This is to ensure VLAN is created on host before it's patched on the guest.
- [x] Do not create VLAN on guest (only patch it to add the extra properties)
      VLANs on guest are auto-created by the host. VLAN creation on the guest should be completely removed, instead, on the guest we need to check if the VLAN already exists and if not, we need to wait for the host to create it, then we PATCH it with the custom settings
- [x] Do not patch VLAN on host (relevant to iSeries hosts only)
      VLANs on iSeries host do not need patching with the extra properties, these settings are guest-only, ignored by the host

So all in all it looks like this: Creation only on the hosts, patching only on the guests.
| | iSeries host | rSeries host |
|-|-|-|
| 1) host | create | create |
| 2) guest (always iSeries) | patch | patch |

Also removes a test, replacing it with a much simpler one. See 67903b4664b228de55320acb319443711febae6c for details.